### PR TITLE
feat(mcp): full MCP 2026-07-28 support — stateless core, MRTR, Tasks, subscriptions/listen

### DIFF
--- a/changelog/entries/2026-07-28-mcp-2026-07-28-protocol.json
+++ b/changelog/entries/2026-07-28-mcp-2026-07-28-protocol.json
@@ -4,7 +4,9 @@
   "date": "2026-07-28",
   "category": "feat",
   "title": "MCP 2026-07-28 protocol support",
-  "summary": "The vcad MCP server now speaks the stateless 2026-07-28 revision — server/discover, per-request protocol metadata, no initialize handshake — alongside every earlier revision.",
-  "features": ["mcp"],
+  "summary": "The vcad MCP server now fully speaks the stateless 2026-07-28 revision \u2014 server/discover, MRTR, the Tasks extension, subscriptions/listen, and streamed progress \u2014 alongside every earlier revision.",
+  "features": [
+    "mcp"
+  ],
   "mcpTools": []
 }

--- a/changelog/entries/2026-07-28-mcp-2026-07-28-protocol.json
+++ b/changelog/entries/2026-07-28-mcp-2026-07-28-protocol.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-28-mcp-2026-07-28-protocol",
+  "version": "0.9.4",
+  "date": "2026-07-28",
+  "category": "feat",
+  "title": "MCP 2026-07-28 protocol support",
+  "summary": "The vcad MCP server now speaks the stateless 2026-07-28 revision — server/discover, per-request protocol metadata, no initialize handshake — alongside every earlier revision.",
+  "features": ["mcp"],
+  "mcpTools": []
+}

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -21,23 +21,39 @@ every `initialize`-handshake revision back to `2024-11-05`, on the same
 endpoint and the same stdio process. Clients need no configuration change.
 
 Modern (`2026-07-28`) requests are recognized by the per-request metadata they
-carry (`_meta['io.modelcontextprotocol/protocolVersion']`) or by asking for
-`server/discover`; everything else stays on the SDK's legacy path. Supported
-modern surface: `server/discover`, `tools/list`, `tools/call`,
-`resources/list`, `resources/templates/list`, `resources/read`, `prompts/*`,
-`completion/complete`, plus `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name`
-header validation and `ttlMs` / `cacheScope` cache hints on list results.
+carry (`_meta['io.modelcontextprotocol/protocolVersion']`) or by using a
+modern-only method (`server/discover`, `subscriptions/listen`, `tasks/*`);
+everything else stays on the SDK's legacy path. The modern surface:
+
+- `server/discover`, `tools/list`, `tools/call`, `resources/*`, `prompts/*`,
+  `completion/complete`, with `resultType` on every result, `serverInfo` in
+  result `_meta`, and `ttlMs` / `cacheScope` cache hints on list results.
+- `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name` header–body validation
+  (`HeaderMismatch` −32020, base64 sentinel decoding included).
+- **MRTR** — a URL-mode elicitation raised mid-call (e.g. `authorize_spend`
+  spend approval) terminates the request with an `input_required` result;
+  retry the same call with `inputResponses: { input_1: {...} }` to complete.
+- **Tasks extension** (`io.modelcontextprotocol/tasks`) — clients that declare
+  it get a `resultType: "task"` handle from known long-running tools
+  (`route_nets`, `topology_optimize`, `simulate_*`, `export_video`, …) and
+  poll `tasks/get` / feed elicitations via `tasks/update` / cancel with
+  `tasks/cancel`. Tasks live in process memory with a 30-minute TTL — the
+  same durability as the instance serving them.
+- **`subscriptions/listen`** — a long-lived SSE stream (HTTP) or channel
+  subscription (stdio) honoring `toolsListChanged` (fires when
+  `set_tool_packs` re-shapes the surface) and Tasks `taskIds`. Prompt and
+  resource lists are static, so those types are omitted from the
+  acknowledgment rather than faked.
+- Request-scoped `notifications/progress` / `notifications/message` stream on
+  the request's SSE response (a `tools/call` reply upgrades from JSON to SSE
+  the moment the first notification arrives); `notifications/message` is
+  gated on the request's `_meta['io.modelcontextprotocol/logLevel']`, as the
+  revision requires.
 
 vcad needed no architectural change to go stateless: cross-call state has
 always ridden on a server-minted `document_id` passed as an ordinary tool
 argument — the exact pattern the revision prescribes — and the HTTP transport
-was already session-free.
-
-Not implemented yet, and reported honestly rather than silently accepted:
-SSE response streams for in-flight `notifications/progress`,
-`subscriptions/listen` (nothing stateful to subscribe to), MRTR
-`InputRequiredResult` (URL-mode elicitation degrades to a dismissed prompt),
-and the Tasks extension. See `src/protocol-2026.ts`.
+was already session-free. See `src/protocol-2026.ts`.
 
 ## Tool packs
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -14,6 +14,31 @@ Or add to your MCP configuration directly:
 claude mcp add vcad --command "npx @vcad/mcp"
 ```
 
+## Protocol revisions
+
+The server is **dual-era**: it speaks the stateless `2026-07-28` revision and
+every `initialize`-handshake revision back to `2024-11-05`, on the same
+endpoint and the same stdio process. Clients need no configuration change.
+
+Modern (`2026-07-28`) requests are recognized by the per-request metadata they
+carry (`_meta['io.modelcontextprotocol/protocolVersion']`) or by asking for
+`server/discover`; everything else stays on the SDK's legacy path. Supported
+modern surface: `server/discover`, `tools/list`, `tools/call`,
+`resources/list`, `resources/templates/list`, `resources/read`, `prompts/*`,
+`completion/complete`, plus `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name`
+header validation and `ttlMs` / `cacheScope` cache hints on list results.
+
+vcad needed no architectural change to go stateless: cross-call state has
+always ridden on a server-minted `document_id` passed as an ordinary tool
+argument — the exact pattern the revision prescribes — and the HTTP transport
+was already session-free.
+
+Not implemented yet, and reported honestly rather than silently accepted:
+SSE response streams for in-flight `notifications/progress`,
+`subscriptions/listen` (nothing stateful to subscribe to), MRTR
+`InputRequiredResult` (URL-mode elicitation degrades to a dismissed prompt),
+and the Tasks extension. See `src/protocol-2026.ts`.
+
 ## Tool packs
 
 The surface is a small always-on core — the make → see → measure → verify →

--- a/packages/mcp/src/__tests__/protocol-2026.test.ts
+++ b/packages/mcp/src/__tests__/protocol-2026.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Engine } from "@vcad/engine";
 import { createServer } from "../server.js";
+import { InMemoryFabricateStore } from "../fabricate/store.js";
+import type { Order } from "../fabricate/types.js";
 import {
   PROTOCOL_2026,
+  TASKS_EXTENSION,
+  handleModernListen,
+  resetTasksForTest,
   SUPPORTED_PROTOCOL_VERSIONS,
   META_PROTOCOL_VERSION,
   META_CLIENT_INFO,
@@ -284,16 +289,6 @@ describe("removed and unimplemented methods", () => {
     expect(body.error!.message).toContain("2025-11-25");
   });
 
-  it("reports subscriptions/listen as unimplemented rather than silently accepting", async () => {
-    const { status, body } = await call(
-      request(1, "subscriptions/listen"),
-      headersFor("subscriptions/listen"),
-    );
-    expect(status).toBe(404);
-    expect(body.error!.code).toBe(-32601);
-    expect(body.error!.message).toMatch(/stateless/);
-  });
-
   it("acknowledges a notification with 202 and no body", async () => {
     const res = await handleModernRequest(
       { jsonrpc: "2.0", method: "notifications/whatever", params: { _meta: META } },
@@ -308,6 +303,282 @@ describe("removed and unimplemented methods", () => {
       createServer: makeServer,
     });
     expect(res.status).toBe(400);
+  });
+});
+
+describe("MRTR (multi round-trip requests)", () => {
+  // `authorize_spend` raises a URL-mode elicitation when the client declares
+  // `elicitation.url` — the one server-initiated request vcad makes. Under
+  // MRTR the first call must terminate with `input_required` carrying the
+  // ElicitRequest, and the retry (same params + inputResponses) completes.
+  async function seedOrder(orderId: string): Promise<void> {
+    const now = new Date().toISOString();
+    const order: Order = {
+      order_id: orderId,
+      document_id: "doc_mrtr",
+      quote_id: `q_${orderId}`,
+      state: "QUOTED",
+      fab: "digitalmetal",
+      fab_order_ref: null,
+      amount_total_minor: 5000,
+      currency: "USD",
+      ship_to: null,
+      events: [{ state: "QUOTED", at: now, note: "quote" }],
+      created_at: now,
+      updated_at: now,
+    };
+    await new InMemoryFabricateStore().saveOrder(order, 4000, "local");
+  }
+
+  function elicitingRequest(
+    id: number,
+    orderId: string,
+    inputResponses?: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+      name: "authorize_spend",
+      arguments: { order_id: orderId },
+      _meta: {
+        ...META,
+        [META_CLIENT_CAPABILITIES]: { elicitation: { url: {} } },
+      },
+    };
+    if (inputResponses) params.inputResponses = inputResponses;
+    return { jsonrpc: "2.0", id, method: "tools/call", params };
+  }
+
+  it("returns input_required with the elicitation, then completes on retry", async () => {
+    process.env.VCAD_FABRICATE_ORDERING = "1";
+    try {
+      await seedOrder("ord_mrtr_1");
+      const first = await call(
+        elicitingRequest(1, "ord_mrtr_1"),
+        headersFor("tools/call", "authorize_spend"),
+      );
+      expect(first.status).toBe(200);
+      const r1 = first.body.result!;
+      expect(r1.resultType).toBe("input_required");
+      const reqs = r1.inputRequests as Record<
+        string,
+        { method: string; params: { mode?: string; url?: string } }
+      >;
+      expect(Object.keys(reqs)).toEqual(["input_1"]);
+      expect(reqs.input_1.method).toBe("elicitation/create");
+      expect(reqs.input_1.params.mode).toBe("url");
+      expect(reqs.input_1.params.url).toMatch(/vcad\.io\/authorize\//);
+
+      // Retry: a NEW request id, original params, plus the gathered responses.
+      const retry = await call(
+        elicitingRequest(2, "ord_mrtr_1", { input_1: { action: "decline" } }),
+        headersFor("tools/call", "authorize_spend"),
+      );
+      expect(retry.status).toBe(200);
+      const r2 = retry.body.result!;
+      expect(r2.resultType).toBe("complete");
+      const out = JSON.parse((r2.content as { text: string }[])[0].text);
+      expect(out.status).toBe("revoked"); // decline revokes — the input landed
+    } finally {
+      delete process.env.VCAD_FABRICATE_ORDERING;
+    }
+  });
+
+  it("never raises input_required for a client without the elicitation capability", async () => {
+    process.env.VCAD_FABRICATE_ORDERING = "1";
+    try {
+      await seedOrder("ord_mrtr_2");
+      const msg = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "authorize_spend",
+          arguments: { order_id: "ord_mrtr_2" },
+          _meta: META, // no elicitation capability declared
+        },
+      };
+      const { body } = await call(msg, headersFor("tools/call", "authorize_spend"));
+      // The tool falls back to its out-of-band approval note.
+      expect(body.result!.resultType).toBe("complete");
+    } finally {
+      delete process.env.VCAD_FABRICATE_ORDERING;
+    }
+  });
+});
+
+describe("tasks extension", () => {
+  const TASK_META = {
+    ...META,
+    [META_CLIENT_CAPABILITIES]: { extensions: { [TASKS_EXTENSION]: {} } },
+  };
+
+  it("is advertised in server/discover capabilities", async () => {
+    const { body } = await call(
+      request("d", "server/discover"),
+      headersFor("server/discover"),
+    );
+    const caps = body.result!.capabilities as {
+      extensions: Record<string, unknown>;
+    };
+    expect(caps.extensions[TASKS_EXTENSION]).toEqual({});
+  });
+
+  it("returns a task handle for a long-running tool when the client opts in, pollable to terminal", async () => {
+    resetTasksForTest();
+    // route_nets against a nonexistent document finishes fast but still
+    // exercises the full task lifecycle: handle now, result via tasks/get.
+    const created = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: TASK_META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    expect(created.status).toBe(200);
+    const handle = created.body.result!;
+    expect(handle.resultType).toBe("task");
+    const taskId = handle.taskId as string;
+    expect(taskId).toMatch(/^task_/);
+    expect(handle.status).toBe("working");
+    expect(handle.pollIntervalMs).toBeGreaterThan(0);
+
+    // Poll to terminal.
+    let status = "working";
+    let final: Record<string, unknown> | undefined;
+    for (let i = 0; i < 100 && (status === "working" || status === "input_required"); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      const got = await call(
+        request(10 + i, "tasks/get", { taskId }),
+        headersFor("tasks/get"),
+      );
+      expect(got.status).toBe(200);
+      final = got.body.result!;
+      status = final.status as string;
+    }
+    // Tool-level errors are still a COMPLETED task whose result carries
+    // isError — same as a synchronous call; `failed` is for JSON-RPC faults.
+    expect(status).toBe("completed");
+    expect((final!.result as { isError?: boolean }).isError).toBe(true);
+  });
+
+  it("never returns a task to a client that did not declare the extension", async () => {
+    const { body } = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    expect(body.result!.resultType).toBe("complete");
+  });
+
+  it("reports an unknown taskId as invalid params", async () => {
+    const { body } = await call(
+      request(1, "tasks/get", { taskId: "task_nope" }),
+      headersFor("tasks/get"),
+    );
+    expect(body.error!.code).toBe(-32602);
+  });
+
+  it("acknowledges tasks/cancel and marks the task cancelled", async () => {
+    resetTasksForTest();
+    const created = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: TASK_META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    const taskId = created.body.result!.taskId as string;
+    const cancelled = await call(
+      request(2, "tasks/cancel", { taskId }),
+      headersFor("tasks/cancel"),
+    );
+    expect(cancelled.body.result!.resultType).toBe("complete");
+    const got = await call(
+      request(3, "tasks/get", { taskId }),
+      headersFor("tasks/get"),
+    );
+    // Cooperative: either the cancel landed first or the (fast) tool already
+    // finished — both are terminal, neither is `failed`.
+    expect(["cancelled", "completed"]).toContain(got.body.result!.status);
+  });
+});
+
+describe("subscriptions/listen", () => {
+  it("acknowledges only honored types, then delivers toolsListChanged on a pack flip", async () => {
+    const seen: Record<string, unknown>[] = [];
+    const handle = handleModernListen(
+      {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "subscriptions/listen",
+        params: {
+          _meta: META,
+          notifications: {
+            toolsListChanged: true,
+            promptsListChanged: true, // unsupported — must be dropped from ack
+            resourceSubscriptions: ["file:///x"],
+          },
+        },
+      },
+      { send: (m) => seen.push(m as Record<string, unknown>) },
+    );
+
+    // Acknowledgment first, honoring only what can actually fire.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].method).toBe("notifications/subscriptions/acknowledged");
+    const ackParams = seen[0].params as {
+      _meta: Record<string, unknown>;
+      notifications: Record<string, unknown>;
+    };
+    expect(ackParams._meta["io.modelcontextprotocol/subscriptionId"]).toBe(7);
+    expect(ackParams.notifications).toEqual({ toolsListChanged: true });
+
+    // A pack flip through the modern path fires the notification.
+    await call(
+      request(1, "tools/call", {
+        name: "set_tool_packs",
+        arguments: { enable: ["dfm"] },
+      }),
+      headersFor("tools/call", "set_tool_packs"),
+    );
+    expect(
+      seen.some((m) => m.method === "notifications/tools/list_changed"),
+    ).toBe(true);
+    const note = seen.find(
+      (m) => m.method === "notifications/tools/list_changed",
+    )!.params as { _meta: Record<string, unknown> };
+    expect(note._meta["io.modelcontextprotocol/subscriptionId"]).toBe(7);
+
+    // After close, further flips are silent.
+    handle.close();
+    const count = seen.length;
+    await call(
+      request(2, "tools/call", {
+        name: "set_tool_packs",
+        arguments: { enable: ["dfm"] },
+      }),
+      headersFor("tools/call", "set_tool_packs"),
+    );
+    expect(seen.length).toBe(count);
   });
 });
 

--- a/packages/mcp/src/__tests__/protocol-2026.test.ts
+++ b/packages/mcp/src/__tests__/protocol-2026.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { Engine } from "@vcad/engine";
+import { createServer } from "../server.js";
+import {
+  PROTOCOL_2026,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  META_PROTOCOL_VERSION,
+  META_CLIENT_INFO,
+  META_CLIENT_CAPABILITIES,
+  META_SERVER_INFO,
+  ERR_HEADER_MISMATCH,
+  ERR_UNSUPPORTED_PROTOCOL_VERSION,
+  isModernMessage,
+  handleModernRequest,
+} from "../protocol-2026.js";
+
+/**
+ * MCP 2026-07-28 conformance for the dual-era front end.
+ *
+ * These drive `handleModernRequest` exactly as the HTTP entry does — raw
+ * JSON-RPC in, `{status, body}` out — so they cover the wire contract a real
+ * modern client sees: no `initialize`, no session header, `server/discover`
+ * for negotiation, `resultType` on every result, and header/body agreement.
+ */
+
+let engine: Engine;
+
+beforeAll(async () => {
+  engine = await Engine.init();
+}, 60_000);
+
+const makeServer = () => createServer(engine, { user: null, assumeUiClient: true });
+
+const META = {
+  [META_PROTOCOL_VERSION]: PROTOCOL_2026,
+  [META_CLIENT_INFO]: { name: "conformance-test", version: "1.0.0" },
+  [META_CLIENT_CAPABILITIES]: {},
+};
+
+/** Build the headers a conforming client mirrors onto the POST. */
+function headersFor(method: string, name?: string): Record<string, string> {
+  const h: Record<string, string> = {
+    "mcp-protocol-version": PROTOCOL_2026,
+    "mcp-method": method,
+  };
+  if (name !== undefined) h["mcp-name"] = name;
+  return h;
+}
+
+function request(
+  id: number | string,
+  method: string,
+  params: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return { jsonrpc: "2.0", id, method, params: { ...params, _meta: META } };
+}
+
+interface JsonRpcResult {
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+async function call(
+  msg: Record<string, unknown>,
+  headers?: Record<string, string>,
+): Promise<{ status: number; body: JsonRpcResult }> {
+  const res = await handleModernRequest(msg, {
+    createServer: makeServer,
+    headers,
+  });
+  return { status: res.status, body: res.body as JsonRpcResult };
+}
+
+describe("era detection", () => {
+  it("routes a body that declares a protocol version to the modern handler", () => {
+    expect(isModernMessage(request(1, "tools/list"))).toBe(true);
+  });
+
+  it("routes server/discover to the modern handler even without _meta", () => {
+    expect(
+      isModernMessage({ jsonrpc: "2.0", id: 1, method: "server/discover" }),
+    ).toBe(true);
+  });
+
+  it("leaves a legacy initialize handshake on the SDK path", () => {
+    // A 2025-11-25 client sends MCP-Protocol-Version too — the header alone
+    // must never be read as a modern signal, or every legacy client breaks.
+    expect(
+      isModernMessage(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2025-11-25", capabilities: {} },
+        },
+        { "mcp-protocol-version": "2025-11-25" },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("server/discover", () => {
+  it("reports supported versions, capabilities, and identity", async () => {
+    const { status, body } = await call(
+      request("d1", "server/discover"),
+      headersFor("server/discover"),
+    );
+    expect(status).toBe(200);
+    const result = body.result!;
+    expect(result.resultType).toBe("complete");
+    expect(result.supportedVersions).toEqual(SUPPORTED_PROTOCOL_VERSIONS);
+    expect(SUPPORTED_PROTOCOL_VERSIONS[0]).toBe(PROTOCOL_2026);
+    expect(result.capabilities).toMatchObject({ tools: { listChanged: true } });
+    const meta = result._meta as Record<string, { name?: string }>;
+    expect(meta[META_SERVER_INFO].name).toBe("vcad");
+    expect(typeof result.instructions).toBe("string");
+    // CacheableResult: a discovery response is cacheable, and private because
+    // the tool surface varies with the caller's auth and enabled packs.
+    expect(result.ttlMs).toBeGreaterThan(0);
+    expect(result.cacheScope).toBe("private");
+  });
+
+  it("answers a probe that has not yet chosen a version", async () => {
+    const { status, body } = await call(
+      { jsonrpc: "2.0", id: "d2", method: "server/discover" },
+      headersFor("server/discover"),
+    );
+    expect(status).toBe(200);
+    expect(body.result!.supportedVersions).toEqual(SUPPORTED_PROTOCOL_VERSIONS);
+  });
+});
+
+describe("tools", () => {
+  it("lists tools without any initialize handshake", async () => {
+    const { status, body } = await call(
+      request(1, "tools/list"),
+      headersFor("tools/list"),
+    );
+    expect(status).toBe(200);
+    const tools = body.result!.tools as { name: string }[];
+    expect(tools.length).toBeGreaterThan(10);
+    expect(tools.some((t) => t.name === "open_document")).toBe(true);
+    expect(body.result!.resultType).toBe("complete");
+    expect(body.result!.ttlMs).toBeGreaterThan(0);
+  });
+
+  it("returns tools in a deterministic order across calls", async () => {
+    // SHOULD in 2026-07-28: stable order lets clients cache the catalog and
+    // keeps the LLM prompt prefix cacheable.
+    const [a, b] = await Promise.all([
+      call(request(1, "tools/list"), headersFor("tools/list")),
+      call(request(2, "tools/list"), headersFor("tools/list")),
+    ]);
+    const names = (r: typeof a) =>
+      (r.body.result!.tools as { name: string }[]).map((t) => t.name);
+    expect(names(a)).toEqual(names(b));
+  });
+
+  it("calls a tool and carries state on a server-minted handle, not a session", async () => {
+    const opened = await call(
+      request(1, "tools/call", { name: "open_document", arguments: {} }),
+      headersFor("tools/call", "open_document"),
+    );
+    expect(opened.status).toBe(200);
+    expect(opened.body.result!.resultType).toBe("complete");
+    const text = (opened.body.result!.content as { text: string }[])[0].text;
+    const documentId = JSON.parse(text).document_id as string;
+    expect(documentId).toBeTruthy();
+
+    // A completely independent request — served by a different Server
+    // instance, with no session id anywhere on the wire — resolves the same
+    // document through the handle passed as an ordinary tool argument. This is
+    // the state model 2026-07-28 prescribes now that protocol sessions are gone.
+    const read = await call(
+      request(2, "tools/call", {
+        name: "read",
+        arguments: { document_id: documentId },
+      }),
+      headersFor("tools/call", "read"),
+    );
+    expect(read.status).toBe(200);
+    expect(read.body.result!.isError).toBeFalsy();
+    expect((read.body.result!.content as { text: string }[])[0].text).not.toMatch(
+      /Unknown document_id/,
+    );
+  });
+
+  it("stamps serverInfo into every result's _meta", async () => {
+    const { body } = await call(
+      request(1, "tools/list"),
+      headersFor("tools/list"),
+    );
+    const meta = body.result!._meta as Record<string, { name?: string }>;
+    expect(meta[META_SERVER_INFO].name).toBe("vcad");
+  });
+});
+
+describe("version negotiation", () => {
+  it("rejects an unsupported version with the supported list", async () => {
+    const msg = request(1, "tools/list");
+    (msg.params as Record<string, Record<string, unknown>>)._meta = {
+      ...META,
+      [META_PROTOCOL_VERSION]: "1900-01-01",
+    };
+    const { status, body } = await call(msg, {
+      ...headersFor("tools/list"),
+      "mcp-protocol-version": "1900-01-01",
+    });
+    expect(status).toBe(400);
+    expect(body.error!.code).toBe(ERR_UNSUPPORTED_PROTOCOL_VERSION);
+    expect(body.error!.data).toEqual({
+      supported: SUPPORTED_PROTOCOL_VERSIONS,
+      requested: "1900-01-01",
+    });
+  });
+});
+
+describe("header validation", () => {
+  it("rejects a Mcp-Method header that disagrees with the body", async () => {
+    const { status, body } = await call(
+      request(1, "tools/list"),
+      headersFor("resources/list"),
+    );
+    expect(status).toBe(400);
+    expect(body.error!.code).toBe(ERR_HEADER_MISMATCH);
+  });
+
+  it("rejects a missing Mcp-Name on tools/call", async () => {
+    const { status, body } = await call(
+      request(1, "tools/call", { name: "open_document", arguments: {} }),
+      headersFor("tools/call"),
+    );
+    expect(status).toBe(400);
+    expect(body.error!.code).toBe(ERR_HEADER_MISMATCH);
+  });
+
+  it("rejects a MCP-Protocol-Version header that disagrees with the body", async () => {
+    const { status, body } = await call(request(1, "tools/list"), {
+      ...headersFor("tools/list"),
+      "mcp-protocol-version": "2025-11-25",
+    });
+    expect(status).toBe(400);
+    expect(body.error!.code).toBe(ERR_HEADER_MISMATCH);
+  });
+
+  it("accepts a base64-sentinel Mcp-Name", async () => {
+    const encoded = `=?base64?${Buffer.from("open_document", "utf-8").toString("base64")}?=`;
+    const { status } = await call(
+      request(1, "tools/call", { name: "open_document", arguments: {} }),
+      { ...headersFor("tools/call"), "mcp-name": encoded },
+    );
+    expect(status).toBe(200);
+  });
+
+  it("skips header checks on a transport that has none (stdio)", async () => {
+    const { status } = await call(request(1, "tools/list"));
+    expect(status).toBe(200);
+  });
+});
+
+describe("removed and unimplemented methods", () => {
+  it.each(["ping", "logging/setLevel", "resources/subscribe", "tasks/list"])(
+    "reports %s — removed in this revision — as method-not-found with 404",
+    async (method) => {
+      const { status, body } = await call(
+        request(1, method),
+        headersFor(method),
+      );
+      expect(status).toBe(404);
+      expect(body.error!.code).toBe(-32601);
+    },
+  );
+
+  it("names its supported versions when a legacy handshake reaches the modern path", async () => {
+    // A legacy client has no fall-forward mechanism, so this error may be the
+    // only diagnostic its user ever sees.
+    const { status, body } = await call(
+      request(1, "initialize"),
+      headersFor("initialize"),
+    );
+    expect(status).toBe(404);
+    expect(body.error!.code).toBe(-32601);
+    expect(body.error!.message).toContain(PROTOCOL_2026);
+    expect(body.error!.message).toContain("2025-11-25");
+  });
+
+  it("reports subscriptions/listen as unimplemented rather than silently accepting", async () => {
+    const { status, body } = await call(
+      request(1, "subscriptions/listen"),
+      headersFor("subscriptions/listen"),
+    );
+    expect(status).toBe(404);
+    expect(body.error!.code).toBe(-32601);
+    expect(body.error!.message).toMatch(/stateless/);
+  });
+
+  it("acknowledges a notification with 202 and no body", async () => {
+    const res = await handleModernRequest(
+      { jsonrpc: "2.0", method: "notifications/whatever", params: { _meta: META } },
+      { createServer: makeServer },
+    );
+    expect(res.status).toBe(202);
+    expect(res.body).toBeNull();
+  });
+
+  it("rejects a JSON-RPC batch", async () => {
+    const res = await handleModernRequest([request(1, "tools/list")], {
+      createServer: makeServer,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("resources", () => {
+  it("renumbers resource-not-found to Invalid Params (-32602)", async () => {
+    const { body } = await call(
+      request(1, "resources/read", { uri: "ui://vcad/does-not-exist" }),
+      headersFor("resources/read", "ui://vcad/does-not-exist"),
+    );
+    expect(body.error!.code).toBe(-32602);
+  });
+});

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -27,6 +27,7 @@ import { flushTelemetry } from "./telemetry.js";
 import { handleLiveRequest } from "./live-route.js";
 import { handleArtifactRequest } from "./artifact-route.js";
 import { sessionStoreInfo } from "./session-store.js";
+import { isModernMessage, handleModernRequest } from "./protocol-2026.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
 
@@ -108,7 +109,58 @@ async function handleMcpRequest(
   // assumeUiClient: this stateless path builds a fresh Server per request,
   // so the UI-extension capability from `initialize` is never visible here —
   // attach the inline `_meta` preview unconditionally (see ServerContext).
-  const server = await createServer(eng, { user, assumeUiClient: true });
+  const makeServer = () => createServer(eng, { user, assumeUiClient: true });
+
+  // Dual-era: a request that declares its own protocol version (or asks for
+  // `server/discover`) speaks MCP 2026-07-28 and is served by the modern
+  // handler; `initialize`-based traffic falls through to the SDK transport.
+  if (req.method === "POST") {
+    const body = await readBody(req);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: "Parse error" },
+        }),
+      );
+      return;
+    }
+
+    if (isModernMessage(parsed, req.headers)) {
+      const { status, body: out } = await handleModernRequest(parsed, {
+        createServer: makeServer,
+        headers: req.headers,
+      });
+      if (out === null) {
+        res.writeHead(status);
+        res.end();
+        return;
+      }
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(out));
+      return;
+    }
+
+    await handleLegacyMcpRequest(req, res, makeServer, parsed);
+    return;
+  }
+
+  await handleLegacyMcpRequest(req, res, makeServer);
+}
+
+/** The pre-2026 (`initialize`-handshake) path, on the SDK's own transport. */
+async function handleLegacyMcpRequest(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  makeServer: () => Promise<Awaited<ReturnType<typeof createServer>>>,
+  parsed?: unknown,
+): Promise<void> {
+  const server = await makeServer();
 
   const transport = new StreamableHTTPServerTransport({
     // Stateless: no session tracking
@@ -118,10 +170,7 @@ async function handleMcpRequest(
   await server.connect(transport);
 
   try {
-    // Parse body for POST requests
-    if (req.method === "POST") {
-      const body = await readBody(req);
-      const parsed = JSON.parse(body);
+    if (parsed !== undefined) {
       await transport.handleRequest(req, res, parsed);
     } else {
       await transport.handleRequest(req, res);

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -27,7 +27,11 @@ import { flushTelemetry } from "./telemetry.js";
 import { handleLiveRequest } from "./live-route.js";
 import { handleArtifactRequest } from "./artifact-route.js";
 import { sessionStoreInfo } from "./session-store.js";
-import { isModernMessage, handleModernRequest } from "./protocol-2026.js";
+import {
+  isModernMessage,
+  handleModernRequest,
+  handleModernListen,
+} from "./protocol-2026.js";
 
 const PORT = parseInt(process.env.PORT || "8080", 10);
 
@@ -132,17 +136,7 @@ async function handleMcpRequest(
     }
 
     if (isModernMessage(parsed, req.headers)) {
-      const { status, body: out } = await handleModernRequest(parsed, {
-        createServer: makeServer,
-        headers: req.headers,
-      });
-      if (out === null) {
-        res.writeHead(status);
-        res.end();
-        return;
-      }
-      res.writeHead(status, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(out));
+      await handleModernHttp(req, res, parsed, makeServer);
       return;
     }
 
@@ -151,6 +145,98 @@ async function handleMcpRequest(
   }
 
   await handleLegacyMcpRequest(req, res, makeServer);
+}
+
+/** Write one JSON-RPC message as an SSE event. */
+function sseWrite(
+  res: import("node:http").ServerResponse,
+  message: unknown,
+): void {
+  res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+}
+
+/** Open an SSE response stream (headers only; events follow). */
+function sseOpen(res: import("node:http").ServerResponse): void {
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+    // Tell reverse proxies (nginx) not to buffer, or events arrive in bursts.
+    "X-Accel-Buffering": "no",
+  });
+}
+
+/**
+ * Serve one modern (MCP 2026-07-28) request over HTTP.
+ *
+ * Response shape by method:
+ *  - `subscriptions/listen` → a long-lived SSE stream: acknowledgment first,
+ *    then opted-in change notifications, kept alive with SSE comments until
+ *    the client closes the stream (which is the cancellation signal).
+ *  - `tools/call` → a single JSON object, upgraded to an SSE response stream
+ *    the moment the tool emits a request-scoped notification
+ *    (`notifications/progress`, `notifications/message`) — the notification(s)
+ *    then precede the final response on the stream.
+ *  - everything else → a single `application/json` object.
+ */
+async function handleModernHttp(
+  req: import("node:http").IncomingMessage,
+  res: import("node:http").ServerResponse,
+  parsed: unknown,
+  makeServer: () => Promise<Awaited<ReturnType<typeof createServer>>>,
+): Promise<void> {
+  const method = (parsed as { method?: string } | null)?.method;
+
+  if (method === "subscriptions/listen") {
+    sseOpen(res);
+    const handle = handleModernListen(parsed, {
+      send: (m) => sseWrite(res, m),
+    });
+    // SSE comment keep-alive so intermediaries don't reap the quiet stream.
+    const keepAlive = setInterval(() => res.write(":\n\n"), 25_000);
+    keepAlive.unref();
+    req.on("close", () => {
+      clearInterval(keepAlive);
+      handle.close();
+      res.end();
+    });
+    return;
+  }
+
+  // The stream is opened lazily, on the first request-scoped notification:
+  // that keeps validation failures (400 with a JSON-RPC error body, as the
+  // spec requires) on the plain-JSON path, while a tool that emits progress
+  // gets a real SSE response stream. Both response shapes are ones the client
+  // MUST support.
+  let streamOpen = false;
+  const { status, body: out } = await handleModernRequest(parsed, {
+    createServer: makeServer,
+    headers: req.headers,
+    onNotification:
+      method === "tools/call"
+        ? (n) => {
+            if (!streamOpen) {
+              sseOpen(res);
+              streamOpen = true;
+            }
+            sseWrite(res, n);
+          }
+        : undefined,
+  });
+
+  if (streamOpen) {
+    if (out !== null) sseWrite(res, out);
+    res.end();
+    return;
+  }
+
+  if (out === null) {
+    res.writeHead(status);
+    res.end();
+    return;
+  }
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(out));
 }
 
 /** The pre-2026 (`initialize`-handshake) path, on the SDK's own transport. */

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -302,7 +302,7 @@ function setCors(
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
     res.setHeader(
       "Access-Control-Allow-Headers",
-      "Authorization, Content-Type, mcp-session-id, Last-Event-ID, mcp-protocol-version",
+      "Authorization, Content-Type, mcp-session-id, Last-Event-ID, mcp-protocol-version, mcp-method, mcp-name",
     );
     res.setHeader(
       "Access-Control-Expose-Headers",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,7 +12,9 @@ const _origLog = console.log;
 console.log = (...args: unknown[]) => console.error(...args);
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { createServer } from "./server.js";
+import { isModernMessage, handleModernRequest } from "./protocol-2026.js";
 
 async function main() {
   // stdio is a single trusted local process — no HTTP request, no auth — so
@@ -21,6 +23,34 @@ async function main() {
   const server = await createServer(undefined, { user: null });
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  // Dual-era stdio. `connect` installed the SDK's legacy (`initialize`-based)
+  // message handler; wrap it so a client speaking MCP 2026-07-28 — which sends
+  // `server/discover` as its opening probe and never sends `initialize` — is
+  // served by the modern handler instead of getting a
+  // "received request before initialization" error and falling back.
+  //
+  // The modern path builds a short-lived server per request, which is safe
+  // here for the same reason stateless HTTP already is: the session cache
+  // (`fallbackDocuments` in tools/session-core.ts) is process-global, and an
+  // anonymous stdio caller resolves to it rather than to a per-connection
+  // scope. `document_id` handles therefore survive across modern requests —
+  // which is exactly the pattern 2026-07-28 prescribes now that the protocol
+  // itself carries no session.
+  const legacyOnMessage = transport.onmessage?.bind(transport);
+  transport.onmessage = (msg: JSONRPCMessage) => {
+    if (!isModernMessage(msg)) {
+      legacyOnMessage?.(msg);
+      return;
+    }
+    void handleModernRequest(msg, {
+      createServer: () => createServer(undefined, { user: null }),
+    }).then(({ body }) => {
+      if (body !== null) {
+        void transport.send(body as JSONRPCMessage);
+      }
+    });
+  };
 }
 
 main().catch((err) => {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,7 +14,12 @@ console.log = (...args: unknown[]) => console.error(...args);
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import { createServer } from "./server.js";
-import { isModernMessage, handleModernRequest } from "./protocol-2026.js";
+import {
+  isModernMessage,
+  handleModernRequest,
+  handleModernListen,
+  type ListenHandle,
+} from "./protocol-2026.js";
 
 async function main() {
   // stdio is a single trusted local process — no HTTP request, no auth — so
@@ -38,13 +43,49 @@ async function main() {
   // which is exactly the pattern 2026-07-28 prescribes now that the protocol
   // itself carries no session.
   const legacyOnMessage = transport.onmessage?.bind(transport);
+  const listens = new Map<string | number, ListenHandle>();
   transport.onmessage = (msg: JSONRPCMessage) => {
     if (!isModernMessage(msg)) {
+      // A modern client cancels a stdio subscription by referencing the
+      // listen request's id in notifications/cancelled — intercept that
+      // before the legacy path (which knows nothing about it).
+      const m = msg as unknown as {
+        method?: string;
+        params?: { requestId?: string | number };
+      };
+      const cancelId = m.params?.requestId;
+      if (
+        m.method === "notifications/cancelled" &&
+        cancelId !== undefined &&
+        listens.has(cancelId)
+      ) {
+        listens.get(cancelId)!.close();
+        listens.delete(cancelId);
+        return;
+      }
       legacyOnMessage?.(msg);
       return;
     }
+
+    const method = (msg as unknown as { method?: string }).method;
+    if (method === "subscriptions/listen") {
+      // Long-lived subscription on the shared channel: acknowledgment first,
+      // then opted-in notifications, each tagged with the subscription id so
+      // the client can demultiplex. Ends on notifications/cancelled (above)
+      // or process exit.
+      const id = (msg as unknown as { id?: string | number }).id;
+      const handle = handleModernListen(msg, {
+        send: (m) => void transport.send(m as JSONRPCMessage),
+      });
+      if (id !== undefined) listens.set(id, handle);
+      return;
+    }
+
     void handleModernRequest(msg, {
       createServer: () => createServer(undefined, { user: null }),
+      // Request-scoped notifications share the stdio channel; the SDK
+      // client correlates progress via its progressToken.
+      onNotification: (n) => void transport.send(n as JSONRPCMessage),
     }).then(({ body }) => {
       if (body !== null) {
         void transport.send(body as JSONRPCMessage);

--- a/packages/mcp/src/protocol-2026.ts
+++ b/packages/mcp/src/protocol-2026.ts
@@ -1,0 +1,619 @@
+/**
+ * MCP `2026-07-28` ("modern") protocol support.
+ *
+ * The 2026-07-28 revision removes the `initialize` handshake, protocol-level
+ * sessions, and the standalone GET stream: every request is self-describing
+ * (protocol version, client identity, and client capabilities ride in
+ * `params._meta`), and `server/discover` replaces `initialize` as the way a
+ * client learns what a server speaks.
+ *
+ * The TypeScript SDK does not implement this revision yet (1.30.0's
+ * `LATEST_PROTOCOL_VERSION` is still `2025-11-25`), so this module is a
+ * *dual-era* front end: it answers modern requests itself and leaves legacy
+ * (`initialize`-based) traffic on the SDK's transport untouched. The spec
+ * explicitly sanctions this shape — "A dual-era server MAY serve both eras
+ * concurrently on the same endpoint or process."
+ *
+ * How modern requests are served: rather than duplicating the ~2k lines of
+ * tool dispatch in `server.ts`, a modern request is bridged onto a real SDK
+ * `Server` over an in-process `InMemoryTransport` pair. The bridge performs
+ * the legacy handshake on the client side of the pair, forwards the request,
+ * then re-shapes the reply into a modern result (`resultType`, cache hints,
+ * `_meta['io.modelcontextprotocol/serverInfo']`). vcad's HTTP entry already
+ * builds a fresh `Server` per request, so the bridge adds no server
+ * construction that wasn't happening anyway.
+ *
+ * Known gaps, stated rather than papered over:
+ *   - Responses are always `application/json`. Notifications emitted by a tool
+ *     (`notifications/progress`, `notifications/message`) are dropped instead
+ *     of being streamed on the request's SSE response stream.
+ *   - `subscriptions/listen` is not implemented; this server is stateless and
+ *     has no per-connection subscription state to feed it. Reported honestly
+ *     as method-not-found rather than acknowledged and left silent.
+ *   - MRTR (`InputRequiredResult`) is not implemented. A server-initiated
+ *     request raised inside the bridge (URL-mode elicitation) is refused, and
+ *     `server.ts` already degrades that to `{action:"cancel"}`.
+ *   - The Tasks extension (`io.modelcontextprotocol/tasks`) is not advertised.
+ */
+
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+/** The protocol revision this module implements. */
+export const PROTOCOL_2026 = "2026-07-28";
+
+/**
+ * Version spoken on the in-process bridge to the SDK `Server`. Internal
+ * plumbing only — never advertised to a client.
+ */
+const BRIDGE_VERSION = "2025-11-25";
+
+/**
+ * Every revision this server can serve: the modern one via this module, the
+ * legacy ones via the SDK's own `initialize` path. Ordered newest-first, which
+ * is the order a client should prefer when picking from `supported`.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+  PROTOCOL_2026,
+  "2025-11-25",
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+];
+
+// ── `_meta` keys defined by the revision ──────────────────────────
+
+export const META_PROTOCOL_VERSION = "io.modelcontextprotocol/protocolVersion";
+export const META_CLIENT_CAPABILITIES =
+  "io.modelcontextprotocol/clientCapabilities";
+export const META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo";
+export const META_SERVER_INFO = "io.modelcontextprotocol/serverInfo";
+
+// ── Error codes ──────────────────────────────────────────────────
+// -32020..-32099 is the range the spec reserves for itself; -32000..-32019
+// stays implementation-defined (existing SDK usage is grandfathered).
+
+/** Headers disagree with the body, or a required header is missing. */
+export const ERR_HEADER_MISMATCH = -32020;
+/** A capability the request requires was not declared by the client. */
+export const ERR_MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+/** The requested protocol version is not one this server serves. */
+export const ERR_UNSUPPORTED_PROTOCOL_VERSION = -32022;
+const ERR_METHOD_NOT_FOUND = -32601;
+const ERR_INVALID_PARAMS = -32602;
+const ERR_INTERNAL = -32603;
+/** Pre-2026 code for "resource not found"; renumbered to Invalid Params. */
+const LEGACY_RESOURCE_NOT_FOUND = -32002;
+
+/**
+ * Freshness hint for list-shaped results, in ms. Deliberately short: the tool
+ * surface is mutable at runtime (`set_tool_packs` re-advertises it), so a long
+ * TTL would let a client serve a stale catalog for minutes after a pack flip.
+ */
+const LIST_TTL_MS = 60_000;
+/** `server/discover` changes only on deploy; safe to cache longer. */
+const DISCOVER_TTL_MS = 300_000;
+/**
+ * Always `private`: results vary with the caller's bearer token (tool packs,
+ * document scope, Fabricate state), so a shared intermediary must not reuse
+ * one caller's response for another.
+ */
+const CACHE_SCOPE = "private" as const;
+
+/** Methods whose results carry `ttlMs` / `cacheScope` per `CacheableResult`. */
+const CACHEABLE_METHODS = new Map<string, number>([
+  ["server/discover", DISCOVER_TTL_MS],
+  ["tools/list", LIST_TTL_MS],
+  ["prompts/list", LIST_TTL_MS],
+  ["resources/list", LIST_TTL_MS],
+  ["resources/templates/list", LIST_TTL_MS],
+  ["resources/read", LIST_TTL_MS],
+]);
+
+/** Methods forwarded verbatim to the bridged SDK server. */
+const FORWARDED_METHODS = new Set<string>([
+  "tools/list",
+  "tools/call",
+  "resources/list",
+  "resources/templates/list",
+  "resources/read",
+  "prompts/list",
+  "prompts/get",
+  "completion/complete",
+]);
+
+/** `Mcp-Name` mirrors `params.name` for these; `params.uri` for resources. */
+const NAME_HEADER_METHODS = new Set(["tools/call", "prompts/get"]);
+
+// ── Types ────────────────────────────────────────────────────────
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id?: string | number | null;
+  method?: string;
+  params?: Record<string, unknown>;
+}
+
+/** Case-insensitive header bag. Absent for stdio, where there are no headers. */
+export type HeaderBag = Record<string, string | string[] | undefined>;
+
+export interface ModernResponse {
+  /** HTTP status the caller should use. `null` body means "no body" (202). */
+  status: number;
+  body: unknown | null;
+}
+
+export interface ModernOptions {
+  /** Builds the SDK server the request is bridged onto. */
+  createServer: () => Promise<Server>;
+  /** Request headers, when the transport has them (HTTP). Omit for stdio. */
+  headers?: HeaderBag;
+}
+
+// ── Detection ────────────────────────────────────────────────────
+
+function header(headers: HeaderBag | undefined, name: string): string | undefined {
+  if (!headers) return undefined;
+  const lower = name.toLowerCase();
+  for (const [k, v] of Object.entries(headers)) {
+    if (k.toLowerCase() !== lower) continue;
+    return Array.isArray(v) ? v[0] : v;
+  }
+  return undefined;
+}
+
+function metaOf(msg: unknown): Record<string, unknown> | undefined {
+  const params = (msg as JsonRpcRequest | undefined)?.params;
+  const meta = params?._meta;
+  return meta && typeof meta === "object"
+    ? (meta as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * True when a message should be served by this module rather than the SDK.
+ *
+ * Two independent signals, either of which is conclusive: the body declares a
+ * protocol version in `_meta` (only modern clients do this), or the method is
+ * `server/discover` (which exists only in the modern revision — a legacy
+ * client has no reason to send it). The `MCP-Protocol-Version` header alone is
+ * NOT a signal: `2025-06-18` and later legacy clients send it too.
+ */
+export function isModernMessage(
+  msg: unknown,
+  headers?: HeaderBag,
+): boolean {
+  const first = Array.isArray(msg) ? msg[0] : msg;
+  if (!first || typeof first !== "object") return false;
+  const method = (first as JsonRpcRequest).method;
+  if (method === "server/discover") return true;
+  const declared = metaOf(first)?.[META_PROTOCOL_VERSION];
+  if (typeof declared === "string") return true;
+  // A `Mcp-Method` header is required on modern POSTs and defined nowhere
+  // else, so treat it as a fallback signal for a body we couldn't read.
+  return header(headers, "mcp-method") !== undefined;
+}
+
+// ── Header value encoding ────────────────────────────────────────
+
+const BASE64_SENTINEL_PREFIX = "=?base64?";
+const BASE64_SENTINEL_SUFFIX = "?=";
+
+/** Decode the `=?base64?...?=` sentinel form used for non-ASCII header values. */
+function decodeHeaderValue(value: string): string {
+  if (
+    !value.startsWith(BASE64_SENTINEL_PREFIX) ||
+    !value.endsWith(BASE64_SENTINEL_SUFFIX) ||
+    value.length < BASE64_SENTINEL_PREFIX.length + BASE64_SENTINEL_SUFFIX.length
+  ) {
+    return value;
+  }
+  const encoded = value.slice(
+    BASE64_SENTINEL_PREFIX.length,
+    value.length - BASE64_SENTINEL_SUFFIX.length,
+  );
+  try {
+    return Buffer.from(encoded, "base64").toString("utf-8");
+  } catch {
+    return value;
+  }
+}
+
+// ── Response helpers ─────────────────────────────────────────────
+
+function errorResponse(
+  id: string | number | null | undefined,
+  code: number,
+  message: string,
+  data?: unknown,
+): unknown {
+  return {
+    jsonrpc: "2.0",
+    id: id ?? null,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}
+
+function unsupportedVersion(
+  id: string | number | null | undefined,
+  requested: string,
+): ModernResponse {
+  return {
+    status: 400,
+    body: errorResponse(
+      id,
+      ERR_UNSUPPORTED_PROTOCOL_VERSION,
+      "Unsupported protocol version",
+      { supported: SUPPORTED_PROTOCOL_VERSIONS, requested },
+    ),
+  };
+}
+
+function headerMismatch(
+  id: string | number | null | undefined,
+  message: string,
+): ModernResponse {
+  return {
+    status: 400,
+    body: errorResponse(id, ERR_HEADER_MISMATCH, `Header mismatch: ${message}`),
+  };
+}
+
+// ── The in-process bridge ────────────────────────────────────────
+
+interface BridgeReply {
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface Bridge {
+  /** Send a JSON-RPC request and await its response message. */
+  rpc(method: string, params?: Record<string, unknown>): Promise<BridgeReply>;
+  /** The bridged server's own `initialize` result — capabilities, identity,
+   *  and instructions, which `server/discover` reshapes and every modern
+   *  result stamps into `_meta`. */
+  handshake: {
+    capabilities?: unknown;
+    serverInfo?: { name?: string; version?: string };
+    instructions?: string;
+  };
+  close(): Promise<void>;
+}
+
+/**
+ * Stand up an SDK `Server` on one end of an in-memory transport pair and drive
+ * it from the other end with raw JSON-RPC. The legacy `initialize` handshake
+ * happens here, invisible to the modern client.
+ */
+async function openBridge(
+  createServer: () => Promise<Server>,
+  clientInfo: { name: string; version: string },
+  clientCapabilities: Record<string, unknown>,
+): Promise<Bridge> {
+  const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
+
+  let nextId = 1;
+  const pending = new Map<
+    string | number,
+    (msg: Record<string, unknown>) => void
+  >();
+
+  clientSide.onmessage = (msg: JSONRPCMessage) => {
+    const m = msg as unknown as Record<string, unknown>;
+    const id = m.id as string | number | undefined;
+    if (id !== undefined && ("result" in m || "error" in m)) {
+      pending.get(id)?.(m);
+      pending.delete(id);
+      return;
+    }
+    if (id !== undefined && typeof m.method === "string") {
+      // A server-initiated request (URL-mode elicitation). Under 2026-07-28
+      // these become MRTR input requests, which this shim does not implement —
+      // refuse so the caller's `catch` degrades it to a dismissed prompt
+      // rather than hanging the request.
+      void clientSide.send({
+        jsonrpc: "2.0",
+        id,
+        error: {
+          code: ERR_METHOD_NOT_FOUND,
+          message:
+            "Server-initiated requests are not available under protocol 2026-07-28 (MRTR not implemented)",
+        },
+      } as unknown as JSONRPCMessage);
+    }
+    // Notifications (progress, logging) are dropped: this shim answers with a
+    // single JSON object, not an SSE response stream.
+  };
+
+  await clientSide.start();
+  const server = await createServer();
+  await server.connect(serverSide);
+
+  const rpc: Bridge["rpc"] = (method, params) => {
+    const id = nextId++;
+    return new Promise((resolve) => {
+      pending.set(id, (m) =>
+        resolve(
+          m as {
+            result?: Record<string, unknown>;
+            error?: { code: number; message: string; data?: unknown };
+          },
+        ),
+      );
+      void clientSide.send({
+        jsonrpc: "2.0",
+        id,
+        method,
+        params: params ?? {},
+      } as unknown as JSONRPCMessage);
+    });
+  };
+
+  // Legacy handshake on the bridge. The modern client never sees it.
+  const init = await rpc("initialize", {
+    protocolVersion: BRIDGE_VERSION,
+    capabilities: clientCapabilities,
+    clientInfo,
+  });
+  await clientSide.send({
+    jsonrpc: "2.0",
+    method: "notifications/initialized",
+  } as unknown as JSONRPCMessage);
+
+  return {
+    rpc,
+    handshake: (init.result ?? {}) as Bridge["handshake"],
+    close: async () => {
+      pending.clear();
+      await server.close().catch(() => {});
+      await clientSide.close().catch(() => {});
+    },
+  };
+}
+
+// ── Entry point ──────────────────────────────────────────────────
+
+/**
+ * Serve one modern JSON-RPC message. Returns the HTTP status and body the
+ * caller should write; `body: null` means "write no body" (a notification
+ * acknowledged with 202).
+ */
+export async function handleModernRequest(
+  msg: unknown,
+  opts: ModernOptions,
+): Promise<ModernResponse> {
+  if (Array.isArray(msg)) {
+    return {
+      status: 400,
+      body: errorResponse(
+        null,
+        ERR_INVALID_PARAMS,
+        "Batched requests are not supported; send one JSON-RPC message per POST",
+      ),
+    };
+  }
+  if (!msg || typeof msg !== "object") {
+    return {
+      status: 400,
+      body: errorResponse(null, ERR_INVALID_PARAMS, "Malformed JSON-RPC message"),
+    };
+  }
+
+  const req = msg as JsonRpcRequest;
+  const id = req.id;
+  const method = req.method;
+  const params = (req.params ?? {}) as Record<string, unknown>;
+  const meta = metaOf(req) ?? {};
+
+  // A notification carries no id: acknowledge and do nothing. This revision
+  // defines no client-to-server notifications over Streamable HTTP.
+  if (id === undefined || id === null) return { status: 202, body: null };
+
+  if (typeof method !== "string") {
+    return {
+      status: 400,
+      body: errorResponse(id, ERR_INVALID_PARAMS, "Missing JSON-RPC method"),
+    };
+  }
+
+  // ── Version check ───────────────────────────────────────────────
+  const bodyVersion = meta[META_PROTOCOL_VERSION];
+  const headerVersion = header(opts.headers, "mcp-protocol-version");
+  if (
+    typeof bodyVersion === "string" &&
+    headerVersion !== undefined &&
+    headerVersion !== bodyVersion
+  ) {
+    return headerMismatch(
+      id,
+      `MCP-Protocol-Version header value '${headerVersion}' does not match body value '${bodyVersion}'`,
+    );
+  }
+  const version =
+    typeof bodyVersion === "string" ? bodyVersion : headerVersion;
+  // `server/discover` is the version-negotiation probe itself, so a client may
+  // send it without having picked a version yet — but a version it *does* name
+  // still has to be one we serve. Every other method must name one.
+  if (version === undefined) {
+    if (method !== "server/discover") {
+      return unsupportedVersion(id, "(unspecified)");
+    }
+  } else if (version !== PROTOCOL_2026) {
+    return unsupportedVersion(id, version);
+  }
+
+  // ── Header/body agreement ───────────────────────────────────────
+  // Only enforced on transports that actually carry headers. A load balancer
+  // routing on `Mcp-Method` while the server dispatches on the body is exactly
+  // the split-brain this check exists to prevent.
+  if (opts.headers) {
+    const methodHeader = header(opts.headers, "mcp-method");
+    if (methodHeader === undefined) {
+      return headerMismatch(id, "required header Mcp-Method is missing");
+    }
+    if (methodHeader !== method) {
+      return headerMismatch(
+        id,
+        `Mcp-Method header value '${methodHeader}' does not match body value '${method}'`,
+      );
+    }
+
+    const expectedName = NAME_HEADER_METHODS.has(method)
+      ? params.name
+      : method === "resources/read"
+        ? params.uri
+        : undefined;
+    if (typeof expectedName === "string") {
+      const nameHeader = header(opts.headers, "mcp-name");
+      if (nameHeader === undefined) {
+        return headerMismatch(id, "required header Mcp-Name is missing");
+      }
+      if (decodeHeaderValue(nameHeader) !== expectedName) {
+        return headerMismatch(
+          id,
+          `Mcp-Name header value does not match body value '${expectedName}'`,
+        );
+      }
+    }
+  }
+
+  // ── Methods this revision removed or that we do not implement ───
+  // `initialize` gets a bespoke message: a legacy client has no fall-forward
+  // mechanism, so per the spec this error may be the only diagnostic a user
+  // ever sees — it must name the versions this server does serve. (Reaching
+  // here at all means the client sent modern `_meta` alongside a legacy
+  // handshake; a plain legacy `initialize` is routed to the SDK, not here.)
+  if (method === "initialize") {
+    return {
+      status: 404,
+      body: errorResponse(
+        id,
+        ERR_METHOD_NOT_FOUND,
+        `'initialize' was removed in protocol ${PROTOCOL_2026}; use 'server/discover'. This server supports: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}`,
+      ),
+    };
+  }
+  if (method === "subscriptions/listen") {
+    return {
+      status: 404,
+      body: errorResponse(
+        id,
+        ERR_METHOD_NOT_FOUND,
+        "subscriptions/listen is not implemented: this server is stateless and holds no per-connection subscription state",
+      ),
+    };
+  }
+  if (method !== "server/discover" && !FORWARDED_METHODS.has(method)) {
+    return {
+      status: 404,
+      body: errorResponse(id, ERR_METHOD_NOT_FOUND, `Unknown method '${method}'`),
+    };
+  }
+
+  // ── Bridge to the SDK server ────────────────────────────────────
+  const rawClientInfo = meta[META_CLIENT_INFO];
+  const clientInfo =
+    rawClientInfo && typeof rawClientInfo === "object"
+      ? (rawClientInfo as { name?: string; version?: string })
+      : {};
+  const rawCaps = meta[META_CLIENT_CAPABILITIES];
+  const clientCapabilities =
+    rawCaps && typeof rawCaps === "object"
+      ? (rawCaps as Record<string, unknown>)
+      : {};
+
+  let bridge: Bridge | undefined;
+  try {
+    bridge = await openBridge(
+      opts.createServer,
+      {
+        name: typeof clientInfo.name === "string" ? clientInfo.name : "unknown",
+        version:
+          typeof clientInfo.version === "string" ? clientInfo.version : "0.0.0",
+      },
+      clientCapabilities,
+    );
+
+    if (method === "server/discover") {
+      const info = bridge.handshake;
+      const result: Record<string, unknown> = {
+        resultType: "complete",
+        supportedVersions: SUPPORTED_PROTOCOL_VERSIONS,
+        capabilities: info.capabilities ?? {},
+        _meta: { [META_SERVER_INFO]: info.serverInfo ?? {} },
+      };
+      if (info.instructions) result.instructions = info.instructions;
+      decorateCache(result, "server/discover");
+      return { status: 200, body: { jsonrpc: "2.0", id, result } };
+    }
+
+    // Forward with the modern-only `_meta` keys stripped: the SDK server has
+    // no use for them and passing an unknown `_meta` through tool arguments
+    // is noise in the dispatch layer.
+    const forwarded = stripModernMeta(params);
+    const reply = await bridge.rpc(method, forwarded);
+
+    if (reply.error) {
+      const code =
+        reply.error.code === LEGACY_RESOURCE_NOT_FOUND
+          ? ERR_INVALID_PARAMS
+          : reply.error.code;
+      return {
+        status: code === ERR_METHOD_NOT_FOUND ? 404 : 200,
+        body: errorResponse(id, code, reply.error.message, reply.error.data),
+      };
+    }
+
+    const result = { ...(reply.result ?? {}) } as Record<string, unknown>;
+    result.resultType = "complete";
+    const resultMeta =
+      result._meta && typeof result._meta === "object"
+        ? { ...(result._meta as Record<string, unknown>) }
+        : {};
+    resultMeta[META_SERVER_INFO] = bridge.handshake.serverInfo ?? {
+      name: "vcad",
+      version: "0.0.0",
+    };
+    result._meta = resultMeta;
+    decorateCache(result, method);
+
+    return { status: 200, body: { jsonrpc: "2.0", id, result } };
+  } catch (err) {
+    return {
+      status: 500,
+      body: errorResponse(
+        id,
+        ERR_INTERNAL,
+        err instanceof Error ? err.message : String(err),
+      ),
+    };
+  } finally {
+    await bridge?.close();
+  }
+}
+
+/** Attach `ttlMs` / `cacheScope` to results the spec makes cacheable. */
+function decorateCache(result: Record<string, unknown>, method: string): void {
+  const ttl = CACHEABLE_METHODS.get(method);
+  if (ttl === undefined) return;
+  result.ttlMs = ttl;
+  result.cacheScope = CACHE_SCOPE;
+}
+
+/** Drop the per-request modern `_meta` keys before forwarding to the SDK. */
+function stripModernMeta(
+  params: Record<string, unknown>,
+): Record<string, unknown> {
+  const meta = params._meta;
+  if (!meta || typeof meta !== "object") return params;
+  const rest = { ...(meta as Record<string, unknown>) };
+  delete rest[META_PROTOCOL_VERSION];
+  delete rest[META_CLIENT_CAPABILITIES];
+  delete rest[META_CLIENT_INFO];
+  const out = { ...params };
+  if (Object.keys(rest).length === 0) delete out._meta;
+  else out._meta = rest;
+  return out;
+}
+

--- a/packages/mcp/src/protocol-2026.ts
+++ b/packages/mcp/src/protocol-2026.ts
@@ -23,19 +23,29 @@
  * builds a fresh `Server` per request, so the bridge adds no server
  * construction that wasn't happening anyway.
  *
- * Known gaps, stated rather than papered over:
- *   - Responses are always `application/json`. Notifications emitted by a tool
- *     (`notifications/progress`, `notifications/message`) are dropped instead
- *     of being streamed on the request's SSE response stream.
- *   - `subscriptions/listen` is not implemented; this server is stateless and
- *     has no per-connection subscription state to feed it. Reported honestly
- *     as method-not-found rather than acknowledged and left silent.
- *   - MRTR (`InputRequiredResult`) is not implemented. A server-initiated
- *     request raised inside the bridge (URL-mode elicitation) is refused, and
- *     `server.ts` already degrades that to `{action:"cancel"}`.
- *   - The Tasks extension (`io.modelcontextprotocol/tasks`) is not advertised.
+ * Beyond plain request/response, this module implements:
+ *   - MRTR (SEP-2322): a server-initiated request raised mid-call (URL-mode
+ *     elicitation) becomes an `InputRequiredResult`; the client retries the
+ *     original call with `inputResponses` and the bridge answers the re-raised
+ *     request from them. Deterministic `input_N` keys make the retry line up
+ *     without any `requestState`.
+ *   - The Tasks extension (`io.modelcontextprotocol/tasks`, SEP-2663): when a
+ *     client declares it, calls to known long-running tools return a
+ *     `CreateTaskResult` immediately and finish in the background; clients
+ *     poll `tasks/get`, feed elicitations via `tasks/update`, and cancel
+ *     cooperatively via `tasks/cancel`. Tasks live in process memory with a
+ *     TTL — durable for the life of the stdio process or warm HTTP instance,
+ *     which is exactly the durability vcad sessions already have.
+ *   - `subscriptions/listen`: a long-lived notification stream serving
+ *     `toolsListChanged` (fired when `set_tool_packs` re-shapes the surface)
+ *     and `notifications/tasks` for subscribed task ids.
+ *   - Request-scoped notification forwarding: `notifications/progress` (and
+ *     `notifications/message`, gated on the request's `logLevel` `_meta` key
+ *     as the revision requires) are handed to the transport for SSE delivery.
  */
 
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
@@ -69,6 +79,11 @@ export const META_CLIENT_CAPABILITIES =
   "io.modelcontextprotocol/clientCapabilities";
 export const META_CLIENT_INFO = "io.modelcontextprotocol/clientInfo";
 export const META_SERVER_INFO = "io.modelcontextprotocol/serverInfo";
+export const META_LOG_LEVEL = "io.modelcontextprotocol/logLevel";
+export const META_SUBSCRIPTION_ID = "io.modelcontextprotocol/subscriptionId";
+
+/** Extension identifier for the MCP Tasks extension. */
+export const TASKS_EXTENSION = "io.modelcontextprotocol/tasks";
 
 // ── Error codes ──────────────────────────────────────────────────
 // -32020..-32099 is the range the spec reserves for itself; -32000..-32019
@@ -126,6 +141,44 @@ const FORWARDED_METHODS = new Set<string>([
 /** `Mcp-Name` mirrors `params.name` for these; `params.uri` for resources. */
 const NAME_HEADER_METHODS = new Set(["tools/call", "prompts/get"]);
 
+/** MRTR is allowed only on these client requests (spec §Supported Requests). */
+const MRTR_METHODS = new Set(["tools/call", "prompts/get", "resources/read"]);
+
+/**
+ * Tools eligible to return a Tasks-extension handle when the client declares
+ * `io.modelcontextprotocol/tasks`. These are the calls that routinely run for
+ * tens of seconds to minutes — routing, field solvers, optimization, video —
+ * where a durable handle beats holding an HTTP response open. Everything else
+ * stays synchronous even for task-capable clients: a sub-second `inspect_cad`
+ * gains nothing from a poll loop.
+ */
+const LONG_RUNNING_TOOLS = new Set<string>([
+  "route_nets",
+  "route_diff_pair",
+  "length_match_traces",
+  "fab_prep",
+  "fix_drc",
+  "topology_optimize",
+  "optimize_electrodes",
+  "export_video",
+  "render_sequence",
+  "simulate_flow",
+  "simulate_em",
+  "simulate_photonics",
+  "simulate_charged_particles",
+  "simulate_neutron_shield",
+  "simulate_lattice_gauge",
+  "md_run",
+  "minimize_energy",
+  "homogenize_material",
+  "design_material",
+]);
+
+/** How long a finished (or abandoned) task is retrievable, per the Task TTL. */
+const TASK_TTL_MS = 30 * 60_000;
+/** Suggested poll cadence for `tasks/get`. */
+const TASK_POLL_INTERVAL_MS = 1_000;
+
 // ── Types ────────────────────────────────────────────────────────
 
 interface JsonRpcRequest {
@@ -149,6 +202,14 @@ export interface ModernOptions {
   createServer: () => Promise<Server>;
   /** Request headers, when the transport has them (HTTP). Omit for stdio. */
   headers?: HeaderBag;
+  /**
+   * Receives request-scoped notifications (`notifications/progress`,
+   * `notifications/message`) as they flow from the bridged server, for
+   * delivery on the request's SSE response stream (HTTP) or the shared
+   * channel (stdio). When omitted, notifications are dropped and the reply
+   * is still complete — streaming is an enhancement, not a dependency.
+   */
+  onNotification?: (notification: Record<string, unknown>) => void;
 }
 
 // ── Detection ────────────────────────────────────────────────────
@@ -171,14 +232,24 @@ function metaOf(msg: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+/** Modern-only methods this module answers without a body version signal. */
+const MODERN_ONLY_METHODS = new Set([
+  "server/discover",
+  "subscriptions/listen",
+  "tasks/get",
+  "tasks/update",
+  "tasks/cancel",
+]);
+
 /**
  * True when a message should be served by this module rather than the SDK.
  *
  * Two independent signals, either of which is conclusive: the body declares a
- * protocol version in `_meta` (only modern clients do this), or the method is
- * `server/discover` (which exists only in the modern revision — a legacy
- * client has no reason to send it). The `MCP-Protocol-Version` header alone is
- * NOT a signal: `2025-06-18` and later legacy clients send it too.
+ * protocol version in `_meta` (only modern clients do this), or the method
+ * exists only in the modern revision (`server/discover`, `subscriptions/
+ * listen`, `tasks/*` — a legacy client has no reason to send any of them).
+ * The `MCP-Protocol-Version` header alone is NOT a signal: `2025-06-18` and
+ * later legacy clients send it too.
  */
 export function isModernMessage(
   msg: unknown,
@@ -187,7 +258,7 @@ export function isModernMessage(
   const first = Array.isArray(msg) ? msg[0] : msg;
   if (!first || typeof first !== "object") return false;
   const method = (first as JsonRpcRequest).method;
-  if (method === "server/discover") return true;
+  if (typeof method === "string" && MODERN_ONLY_METHODS.has(method)) return true;
   const declared = metaOf(first)?.[META_PROTOCOL_VERSION];
   if (typeof declared === "string") return true;
   // A `Mcp-Method` header is required on modern POSTs and defined nowhere
@@ -260,11 +331,99 @@ function headerMismatch(
   };
 }
 
+// ── Process-level event bus ──────────────────────────────────────
+// Feeds `subscriptions/listen` streams. Process-scoped on purpose: the tool
+// surface (pack flips) and the task store are both process state, so their
+// change events are too.
+
+const bus = new EventEmitter();
+bus.setMaxListeners(100);
+const EVT_TOOLS_CHANGED = "tools_list_changed";
+const EVT_TASK = "task";
+
+// ── Task store (Tasks extension) ─────────────────────────────────
+
+type TaskStatus =
+  | "working"
+  | "input_required"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+interface TaskRecord {
+  taskId: string;
+  status: TaskStatus;
+  statusMessage?: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  expiresAt: number;
+  toolName: string;
+  /** Outstanding MRTR-style requests while `input_required`. */
+  inputRequests: Record<string, Record<string, unknown>>;
+  /** Resolvers for elicitations awaiting a `tasks/update`. */
+  pendingInputs: Map<string, (response: Record<string, unknown>) => void>;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+  /** Cooperative-cancel flag read by the elicitation path. */
+  cancelRequested: boolean;
+  /** Tears down the background bridge on cancel/expiry. */
+  dispose?: () => void;
+}
+
+const tasks = new Map<string, TaskRecord>();
+
+function pruneTasks(): void {
+  const now = Date.now();
+  for (const [id, t] of tasks) {
+    if (t.expiresAt <= now) {
+      t.dispose?.();
+      tasks.delete(id);
+    }
+  }
+}
+
+function touchTask(t: TaskRecord, status?: TaskStatus, message?: string): void {
+  if (status) t.status = status;
+  if (message !== undefined) t.statusMessage = message;
+  t.lastUpdatedAt = new Date().toISOString();
+  bus.emit(EVT_TASK, detailedTask(t));
+}
+
+/** The wire shape of a task: base fields plus status-specific ones inlined. */
+function detailedTask(t: TaskRecord): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    taskId: t.taskId,
+    status: t.status,
+    createdAt: t.createdAt,
+    lastUpdatedAt: t.lastUpdatedAt,
+    ttlMs: TASK_TTL_MS,
+    pollIntervalMs: TASK_POLL_INTERVAL_MS,
+  };
+  if (t.statusMessage !== undefined) base.statusMessage = t.statusMessage;
+  if (t.status === "input_required") base.inputRequests = t.inputRequests;
+  if (t.status === "completed") base.result = t.result ?? {};
+  if (t.status === "failed") base.error = t.error ?? { code: ERR_INTERNAL, message: "unknown" };
+  return base;
+}
+
 // ── The in-process bridge ────────────────────────────────────────
 
 interface BridgeReply {
   result?: Record<string, unknown>;
   error?: { code: number; message: string; data?: unknown };
+}
+
+interface BridgeHooks {
+  /** Request-scoped notifications from the bridged server. */
+  onNotification?: (notification: Record<string, unknown>) => void;
+  /**
+   * A server-initiated request (elicitation) raised mid-call. Return the
+   * result to answer it with; the bridge sends it back to the server.
+   */
+  onServerRequest: (
+    method: string,
+    params: Record<string, unknown>,
+  ) => Promise<Record<string, unknown>>;
 }
 
 interface Bridge {
@@ -274,7 +433,7 @@ interface Bridge {
    *  and instructions, which `server/discover` reshapes and every modern
    *  result stamps into `_meta`. */
   handshake: {
-    capabilities?: unknown;
+    capabilities?: Record<string, unknown>;
     serverInfo?: { name?: string; version?: string };
     instructions?: string;
   };
@@ -290,6 +449,7 @@ async function openBridge(
   createServer: () => Promise<Server>,
   clientInfo: { name: string; version: string },
   clientCapabilities: Record<string, unknown>,
+  hooks: BridgeHooks,
 ): Promise<Bridge> {
   const [clientSide, serverSide] = InMemoryTransport.createLinkedPair();
 
@@ -308,22 +468,29 @@ async function openBridge(
       return;
     }
     if (id !== undefined && typeof m.method === "string") {
-      // A server-initiated request (URL-mode elicitation). Under 2026-07-28
-      // these become MRTR input requests, which this shim does not implement —
-      // refuse so the caller's `catch` degrades it to a dismissed prompt
-      // rather than hanging the request.
-      void clientSide.send({
-        jsonrpc: "2.0",
-        id,
-        error: {
-          code: ERR_METHOD_NOT_FOUND,
-          message:
-            "Server-initiated requests are not available under protocol 2026-07-28 (MRTR not implemented)",
-        },
-      } as unknown as JSONRPCMessage);
+      // Server-initiated request (URL-mode elicitation). Route through the
+      // hook: MRTR answers it from the retry's inputResponses (or captures it
+      // and cancels), a task parks it as `input_required`.
+      void hooks
+        .onServerRequest(
+          m.method,
+          (m.params ?? {}) as Record<string, unknown>,
+        )
+        .then((result) =>
+          clientSide.send({ jsonrpc: "2.0", id, result } as unknown as JSONRPCMessage),
+        )
+        .catch(() =>
+          clientSide.send({
+            jsonrpc: "2.0",
+            id,
+            error: { code: ERR_INTERNAL, message: "input bridge failed" },
+          } as unknown as JSONRPCMessage),
+        );
+      return;
     }
-    // Notifications (progress, logging) are dropped: this shim answers with a
-    // single JSON object, not an SSE response stream.
+    if (typeof m.method === "string" && id === undefined) {
+      hooks.onNotification?.(m);
+    }
   };
 
   await clientSide.start();
@@ -333,14 +500,7 @@ async function openBridge(
   const rpc: Bridge["rpc"] = (method, params) => {
     const id = nextId++;
     return new Promise((resolve) => {
-      pending.set(id, (m) =>
-        resolve(
-          m as {
-            result?: Record<string, unknown>;
-            error?: { code: number; message: string; data?: unknown };
-          },
-        ),
-      );
+      pending.set(id, (m) => resolve(m as BridgeReply));
       void clientSide.send({
         jsonrpc: "2.0",
         id,
@@ -478,6 +638,11 @@ export async function handleModernRequest(
     }
   }
 
+  // ── Task polling / input / cancel ───────────────────────────────
+  if (method === "tasks/get" || method === "tasks/update" || method === "tasks/cancel") {
+    return handleTaskMethod(id, method, params);
+  }
+
   // ── Methods this revision removed or that we do not implement ───
   // `initialize` gets a bespoke message: a legacy client has no fall-forward
   // mechanism, so per the spec this error may be the only diagnostic a user
@@ -494,16 +659,6 @@ export async function handleModernRequest(
       ),
     };
   }
-  if (method === "subscriptions/listen") {
-    return {
-      status: 404,
-      body: errorResponse(
-        id,
-        ERR_METHOD_NOT_FOUND,
-        "subscriptions/listen is not implemented: this server is stateless and holds no per-connection subscription state",
-      ),
-    };
-  }
   if (method !== "server/discover" && !FORWARDED_METHODS.has(method)) {
     return {
       status: 404,
@@ -511,36 +666,104 @@ export async function handleModernRequest(
     };
   }
 
-  // ── Bridge to the SDK server ────────────────────────────────────
+  // ── Client identity, capabilities, and MRTR retry payload ───────
   const rawClientInfo = meta[META_CLIENT_INFO];
-  const clientInfo =
+  const infoObj =
     rawClientInfo && typeof rawClientInfo === "object"
       ? (rawClientInfo as { name?: string; version?: string })
       : {};
+  const clientInfo = {
+    name: typeof infoObj.name === "string" ? infoObj.name : "unknown",
+    version: typeof infoObj.version === "string" ? infoObj.version : "0.0.0",
+  };
   const rawCaps = meta[META_CLIENT_CAPABILITIES];
   const clientCapabilities =
     rawCaps && typeof rawCaps === "object"
       ? (rawCaps as Record<string, unknown>)
       : {};
+  const wantsLogs = typeof meta[META_LOG_LEVEL] === "string";
+
+  const inputResponses =
+    params.inputResponses && typeof params.inputResponses === "object"
+      ? (params.inputResponses as Record<string, Record<string, unknown>>)
+      : {};
+
+  // Tasks: client declared the extension AND the tool is one that earns a
+  // durable handle. The server decides per request; never return a task to a
+  // client that did not opt in.
+  const extCaps = (clientCapabilities.extensions ?? {}) as Record<string, unknown>;
+  const asTask =
+    method === "tools/call" &&
+    TASKS_EXTENSION in extCaps &&
+    typeof params.name === "string" &&
+    LONG_RUNNING_TOOLS.has(params.name);
+
+  // ── MRTR bookkeeping ────────────────────────────────────────────
+  // Elicitations are keyed `input_1`, `input_2`, … in the order the tool
+  // raises them. Re-running the tool on retry replays the same sequence, so
+  // the keys line up without any server-side state or `requestState` blob.
+  let inputSeq = 0;
+  const capturedInputRequests: Record<string, Record<string, unknown>> = {};
+
+  const onServerRequest: BridgeHooks["onServerRequest"] = async (
+    reqMethod,
+    reqParams,
+  ) => {
+    if (reqMethod !== "elicitation/create") {
+      // Roots and sampling are deprecated features vcad never initiates.
+      throw new Error(`unsupported server-initiated request ${reqMethod}`);
+    }
+    // Once the bridge is owned by a background task, elicitations park the
+    // task as `input_required` instead of terminating the request (MRTR).
+    if (bridgeRef) {
+      const parked = taskElicitation(bridgeRef, reqParams);
+      if (parked) return parked;
+    }
+    const key = `input_${++inputSeq}`;
+    const provided = inputResponses[key];
+    if (provided) return provided;
+    if (!MRTR_METHODS.has(method)) return { action: "cancel" };
+    // First sight of this elicitation: capture it for the InputRequiredResult
+    // and answer the in-flight tool with a cancel so it winds down; its result
+    // is discarded in favor of the input_required reply below. The spec's
+    // basic workflow — the initial request terminates once input is needed.
+    const { elicitationId: _drop, ...cleanParams } = reqParams;
+    capturedInputRequests[key] = {
+      method: "elicitation/create",
+      params: cleanParams,
+    };
+    return { action: "cancel" };
+  };
 
   let bridge: Bridge | undefined;
+  // Stable reference to the opened bridge for the elicitation hook — survives
+  // the ownership handoff (`bridge = undefined`) when a task takes over.
+  let bridgeRef: Bridge | undefined;
   try {
-    bridge = await openBridge(
-      opts.createServer,
-      {
-        name: typeof clientInfo.name === "string" ? clientInfo.name : "unknown",
-        version:
-          typeof clientInfo.version === "string" ? clientInfo.version : "0.0.0",
+    bridge = bridgeRef = await openBridge(opts.createServer, clientInfo, clientCapabilities, {
+      onNotification: (n) => {
+        const nm = n.method as string;
+        // The revision removed the log-level RPC: notifications/message flows
+        // only when this request carried a logLevel in `_meta`.
+        if (nm === "notifications/message" && !wantsLogs) return;
+        opts.onNotification?.(n);
       },
-      clientCapabilities,
-    );
+      onServerRequest,
+    });
 
     if (method === "server/discover") {
       const info = bridge.handshake;
+      const capabilities = { ...(info.capabilities ?? {}) } as Record<string, unknown>;
+      // Advertise the Tasks extension alongside whatever the bridged server
+      // declared (the MCP Apps UI extension rides in from server.ts).
+      capabilities.extensions = {
+        ...((capabilities.extensions ?? {}) as Record<string, unknown>),
+        [TASKS_EXTENSION]: {},
+      };
       const result: Record<string, unknown> = {
         resultType: "complete",
         supportedVersions: SUPPORTED_PROTOCOL_VERSIONS,
-        capabilities: info.capabilities ?? {},
+        capabilities,
         _meta: { [META_SERVER_INFO]: info.serverInfo ?? {} },
       };
       if (info.instructions) result.instructions = info.instructions;
@@ -548,11 +771,39 @@ export async function handleModernRequest(
       return { status: 200, body: { jsonrpc: "2.0", id, result } };
     }
 
-    // Forward with the modern-only `_meta` keys stripped: the SDK server has
-    // no use for them and passing an unknown `_meta` through tool arguments
-    // is noise in the dispatch layer.
-    const forwarded = stripModernMeta(params);
+    const serverInfo = bridge.handshake.serverInfo ?? {
+      name: "vcad",
+      version: "0.0.0",
+    };
+    const forwarded = stripModernFields(params);
+
+    // ── Tasks path: return the handle now, finish in the background ──
+    if (asTask) {
+      pruneTasks();
+      const record = createTaskRecord(params.name as string);
+      const owned = bridge; // background closure owns the bridge from here
+      bridge = undefined;
+      runTaskInBackground(record, owned, method, forwarded, inputResponses);
+      const result: Record<string, unknown> = {
+        resultType: "task",
+        ...detailedTask(record),
+        _meta: { [META_SERVER_INFO]: serverInfo },
+      };
+      return { status: 200, body: { jsonrpc: "2.0", id, result } };
+    }
+
+    // ── Synchronous path ────────────────────────────────────────────
     const reply = await bridge.rpc(method, forwarded);
+
+    // MRTR: the call raised input needs the retry must satisfy.
+    if (Object.keys(capturedInputRequests).length > 0) {
+      const result: Record<string, unknown> = {
+        resultType: "input_required",
+        inputRequests: capturedInputRequests,
+        _meta: { [META_SERVER_INFO]: serverInfo },
+      };
+      return { status: 200, body: { jsonrpc: "2.0", id, result } };
+    }
 
     if (reply.error) {
       const code =
@@ -571,12 +822,16 @@ export async function handleModernRequest(
       result._meta && typeof result._meta === "object"
         ? { ...(result._meta as Record<string, unknown>) }
         : {};
-    resultMeta[META_SERVER_INFO] = bridge.handshake.serverInfo ?? {
-      name: "vcad",
-      version: "0.0.0",
-    };
+    resultMeta[META_SERVER_INFO] = serverInfo;
     result._meta = resultMeta;
     decorateCache(result, method);
+
+    // The one mutation that re-shapes the tool surface at runtime. Legacy
+    // connections learn via the SDK's own list_changed notification; modern
+    // listeners learn through the process bus feeding subscriptions/listen.
+    if (method === "tools/call" && params.name === "set_tool_packs") {
+      bus.emit(EVT_TOOLS_CHANGED);
+    }
 
     return { status: 200, body: { jsonrpc: "2.0", id, result } };
   } catch (err) {
@@ -601,19 +856,307 @@ function decorateCache(result: Record<string, unknown>, method: string): void {
   result.cacheScope = CACHE_SCOPE;
 }
 
-/** Drop the per-request modern `_meta` keys before forwarding to the SDK. */
-function stripModernMeta(
+/**
+ * Drop the per-request modern `_meta` keys and MRTR retry fields before
+ * forwarding to the SDK: the bridged server has no use for them, and
+ * `inputResponses` is consumed by the bridge's elicitation hook, not the tool.
+ */
+function stripModernFields(
   params: Record<string, unknown>,
 ): Record<string, unknown> {
-  const meta = params._meta;
-  if (!meta || typeof meta !== "object") return params;
-  const rest = { ...(meta as Record<string, unknown>) };
-  delete rest[META_PROTOCOL_VERSION];
-  delete rest[META_CLIENT_CAPABILITIES];
-  delete rest[META_CLIENT_INFO];
   const out = { ...params };
-  if (Object.keys(rest).length === 0) delete out._meta;
-  else out._meta = rest;
+  delete out.inputResponses;
+  delete out.requestState;
+  const meta = out._meta;
+  if (meta && typeof meta === "object") {
+    const rest = { ...(meta as Record<string, unknown>) };
+    delete rest[META_PROTOCOL_VERSION];
+    delete rest[META_CLIENT_CAPABILITIES];
+    delete rest[META_CLIENT_INFO];
+    delete rest[META_LOG_LEVEL];
+    if (Object.keys(rest).length === 0) delete out._meta;
+    else out._meta = rest;
+  }
   return out;
 }
 
+// ── Tasks execution ──────────────────────────────────────────────
+
+function createTaskRecord(toolName: string): TaskRecord {
+  const now = new Date().toISOString();
+  const record: TaskRecord = {
+    taskId: `task_${randomUUID().slice(0, 13)}`,
+    status: "working",
+    statusMessage: `running ${toolName}`,
+    createdAt: now,
+    lastUpdatedAt: now,
+    expiresAt: Date.now() + TASK_TTL_MS,
+    toolName,
+    inputRequests: {},
+    pendingInputs: new Map(),
+    cancelRequested: false,
+  };
+  tasks.set(record.taskId, record);
+  return record;
+}
+
+/**
+ * Drive the bridged call to completion in the background. Unlike the MRTR
+ * path, the bridge stays alive across `input_required`: an elicitation parks
+ * the task and *waits* for `tasks/update`, so the tool resumes exactly where
+ * it stopped instead of being re-run.
+ */
+function runTaskInBackground(
+  record: TaskRecord,
+  bridge: Bridge,
+  method: string,
+  forwarded: Record<string, unknown>,
+  presetResponses: Record<string, Record<string, unknown>>,
+): void {
+  record.dispose = () => {
+    void bridge.close();
+  };
+
+  // Rewire the elicitation path for task semantics. The hook installed at
+  // openBridge time closes over these via the shared maps on the record.
+  taskInputHooks.set(bridge, { record, presetResponses, seq: 0 });
+
+  void bridge
+    .rpc(method, forwarded)
+    .then((reply) => {
+      if (record.status === "cancelled") return;
+      if (reply.error) {
+        record.error = reply.error;
+        touchTask(record, "failed", reply.error.message);
+      } else {
+        const result = { ...(reply.result ?? {}) } as Record<string, unknown>;
+        result.resultType = "complete";
+        record.result = result;
+        touchTask(record, "completed", `${record.toolName} finished`);
+      }
+    })
+    .catch((err) => {
+      record.error = {
+        code: ERR_INTERNAL,
+        message: err instanceof Error ? err.message : String(err),
+      };
+      touchTask(record, "failed");
+    })
+    .finally(() => {
+      taskInputHooks.delete(bridge);
+      void bridge.close();
+      record.dispose = undefined;
+    });
+}
+
+/** Per-bridge task context so the elicitation hook can find its record. */
+const taskInputHooks = new WeakMap<
+  Bridge,
+  {
+    record: TaskRecord;
+    presetResponses: Record<string, Record<string, unknown>>;
+    seq: number;
+  }
+>();
+
+/**
+ * Elicitation raised inside a running task: park the task as `input_required`
+ * and hold the tool until `tasks/update` supplies the answer (or the task is
+ * cancelled). Exposed for the bridge hook installed in `handleModernRequest`.
+ */
+export function taskElicitation(
+  bridge: object,
+  reqParams: Record<string, unknown>,
+): Promise<Record<string, unknown>> | undefined {
+  const ctx = taskInputHooks.get(bridge as Bridge);
+  if (!ctx) return undefined;
+  const { record, presetResponses } = ctx;
+  const key = `input_${++ctx.seq}`;
+  const preset = presetResponses[key];
+  if (preset) return Promise.resolve(preset);
+  if (record.cancelRequested) return Promise.resolve({ action: "cancel" });
+  const { elicitationId: _drop, ...cleanParams } = reqParams;
+  record.inputRequests[key] = {
+    method: "elicitation/create",
+    params: cleanParams,
+  };
+  return new Promise((resolve) => {
+    record.pendingInputs.set(key, resolve);
+    touchTask(record, "input_required", "waiting for client input");
+  });
+}
+
+function handleTaskMethod(
+  id: string | number,
+  method: string,
+  params: Record<string, unknown>,
+): ModernResponse {
+  pruneTasks();
+  const taskId = typeof params.taskId === "string" ? params.taskId : "";
+  const record = tasks.get(taskId);
+  if (!record) {
+    return {
+      status: 200,
+      body: errorResponse(
+        id,
+        ERR_INVALID_PARAMS,
+        `Unknown taskId '${taskId}' — expired, cancelled long ago, or from a previous server instance`,
+      ),
+    };
+  }
+
+  if (method === "tasks/get") {
+    const result = { resultType: "complete", ...detailedTask(record) };
+    return { status: 200, body: { jsonrpc: "2.0", id, result } };
+  }
+
+  if (method === "tasks/update") {
+    const responses =
+      params.inputResponses && typeof params.inputResponses === "object"
+        ? (params.inputResponses as Record<string, Record<string, unknown>>)
+        : {};
+    for (const [key, response] of Object.entries(responses)) {
+      const resolve = record.pendingInputs.get(key);
+      if (!resolve) continue; // unknown or already-satisfied key: ignore per spec
+      record.pendingInputs.delete(key);
+      delete record.inputRequests[key];
+      resolve(response);
+    }
+    if (
+      record.status === "input_required" &&
+      Object.keys(record.inputRequests).length === 0
+    ) {
+      touchTask(record, "working", `running ${record.toolName}`);
+    }
+    return {
+      status: 200,
+      body: { jsonrpc: "2.0", id, result: { resultType: "complete" } },
+    };
+  }
+
+  // tasks/cancel — cooperative: unblock any parked elicitation with a cancel,
+  // flag the record, and acknowledge. The background rpc may still land a
+  // result; the terminal `cancelled` status wins (checked before overwrite).
+  record.cancelRequested = true;
+  if (record.status === "working" || record.status === "input_required") {
+    for (const [key, resolve] of record.pendingInputs) {
+      record.pendingInputs.delete(key);
+      delete record.inputRequests[key];
+      resolve({ action: "cancel" });
+    }
+    touchTask(record, "cancelled", "cancelled by client");
+  }
+  return {
+    status: 200,
+    body: { jsonrpc: "2.0", id, result: { resultType: "complete" } },
+  };
+}
+
+// ── subscriptions/listen ─────────────────────────────────────────
+
+export interface ListenSink {
+  /** Write one JSON-RPC message to the stream. */
+  send(message: unknown): void;
+}
+
+export interface ListenHandle {
+  /** Detach listeners. Call when the stream closes for any reason. */
+  close(): void;
+}
+
+/**
+ * Serve a `subscriptions/listen` request: acknowledge the honored filter and
+ * feed opted-in notifications to `sink` until `close()` is called. The caller
+ * owns the transport (SSE stream on HTTP, the shared channel on stdio) and its
+ * lifecycle; this function only routes events.
+ *
+ * Honored types: `toolsListChanged` (pack flips re-shape the surface) and the
+ * Tasks extension's `taskIds`. `promptsListChanged` / `resourcesListChanged` /
+ * `resourceSubscriptions` are omitted from the acknowledgment — this server's
+ * prompt and resource surfaces are static, so those events can never fire, and
+ * the spec says unhonored types are dropped from the ack rather than faked.
+ */
+export function handleModernListen(
+  msg: unknown,
+  sink: ListenSink,
+): ListenHandle {
+  const req = msg as JsonRpcRequest;
+  const subscriptionId = req.id ?? null;
+  const filter =
+    req.params?.notifications && typeof req.params.notifications === "object"
+      ? (req.params.notifications as Record<string, unknown>)
+      : {};
+
+  const honored: Record<string, unknown> = {};
+  const listeners: Array<() => void> = [];
+
+  if (filter.toolsListChanged === true) {
+    honored.toolsListChanged = true;
+    const onChange = () =>
+      sink.send({
+        jsonrpc: "2.0",
+        method: "notifications/tools/list_changed",
+        params: { _meta: { [META_SUBSCRIPTION_ID]: subscriptionId } },
+      });
+    bus.on(EVT_TOOLS_CHANGED, onChange);
+    listeners.push(() => bus.off(EVT_TOOLS_CHANGED, onChange));
+  }
+
+  const taskIds = Array.isArray(filter.taskIds)
+    ? (filter.taskIds as string[]).filter((t) => typeof t === "string")
+    : [];
+  if (taskIds.length > 0) {
+    honored.taskIds = taskIds;
+    const wanted = new Set(taskIds);
+    const onTask = (task: Record<string, unknown>) => {
+      if (!wanted.has(task.taskId as string)) return;
+      sink.send({
+        jsonrpc: "2.0",
+        method: "notifications/tasks",
+        params: { _meta: { [META_SUBSCRIPTION_ID]: subscriptionId }, ...task },
+      });
+    };
+    bus.on(EVT_TASK, onTask);
+    listeners.push(() => bus.off(EVT_TASK, onTask));
+  }
+
+  // Acknowledgment MUST precede every notification on this subscription.
+  sink.send({
+    jsonrpc: "2.0",
+    method: "notifications/subscriptions/acknowledged",
+    params: {
+      _meta: { [META_SUBSCRIPTION_ID]: subscriptionId },
+      notifications: honored,
+    },
+  });
+
+  return {
+    close: () => {
+      for (const off of listeners) off();
+      listeners.length = 0;
+    },
+  };
+}
+
+/**
+ * The graceful-closure response for a listen stream the *server* is ending
+ * (shutdown). Sent as the JSON-RPC response to the original request, then the
+ * stream closes.
+ */
+export function listenClosureResponse(msg: unknown): unknown {
+  const id = (msg as JsonRpcRequest).id ?? null;
+  return {
+    jsonrpc: "2.0",
+    id,
+    result: {
+      resultType: "complete",
+      _meta: { [META_SUBSCRIPTION_ID]: id },
+    },
+  };
+}
+
+/** Exposed for tests: clear all task state. */
+export function resetTasksForTest(): void {
+  for (const t of tasks.values()) t.dispose?.();
+  tasks.clear();
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -16,6 +16,8 @@ import {
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  McpError,
+  ErrorCode,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Engine, getKernelWasm, resetKernelWasm } from "@vcad/engine";
 import { commandRegistry, getPcbNodeIds } from "@vcad/core";
@@ -1281,7 +1283,11 @@ export async function createServer(
       };
     }
 
-    throw new Error(`Unknown resource: ${uri}`);
+    // InvalidParams, not a bare Error: an unreadable `uri` is a bad argument,
+    // not a server fault. MCP 2026-07-28 renumbered resource-not-found from
+    // -32002 to -32602 for exactly this reason; raising it as an McpError here
+    // means both eras report it correctly instead of collapsing to -32603.
+    throw new McpError(ErrorCode.InvalidParams, `Unknown resource: ${uri}`);
   });
 
   // True when the connected client declared the MCP Apps UI extension at


### PR DESCRIPTION
## What

The vcad MCP server now fully speaks the stateless [MCP 2026-07-28 revision](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude) — alongside every earlier revision back to 2024-11-05, on the same endpoint and same stdio process. Clients need no configuration change.

The TypeScript SDK doesn't implement the revision yet (1.30.0's `LATEST_PROTOCOL_VERSION` is still `2025-11-25`), so this is a **dual-era front end** — a shape the spec explicitly sanctions. Modern requests (recognized by per-request `_meta` protocol metadata or a modern-only method) are bridged onto a real SDK `Server` over an in-process transport pair; legacy `initialize` traffic stays on the SDK path untouched. No duplication of the ~2k-line dispatch layer, and the HTTP entry already built a fresh `Server` per request.

## Surface

- **`server/discover`** + per-request version negotiation (`UnsupportedProtocolVersionError` −32022 with the supported list)
- **Header–body validation**: `MCP-Protocol-Version` / `Mcp-Method` / `Mcp-Name`, `HeaderMismatch` −32020, base64 sentinel decoding
- **`resultType`** on every result, `serverInfo` in result `_meta`, `ttlMs`/`cacheScope` cache hints, deterministic `tools/list` order
- **MRTR** (SEP-2322): a URL-mode elicitation mid-call (e.g. `authorize_spend`) terminates the request with `input_required`; retrying with `inputResponses` completes it. Deterministic `input_N` keys — no `requestState` needed. Capability-gated per spec.
- **Tasks extension** (SEP-2663): opted-in clients get `resultType:"task"` handles from long-running tools (routing, solvers, optimization, video); the call finishes in the background on a held-open bridge. `tasks/get` polls, `tasks/update` feeds parked elicitations (the tool resumes in place), `tasks/cancel` is cooperative. 30-min in-process TTL, honestly reported.
- **`subscriptions/listen`**: long-lived SSE stream (HTTP) / shared channel (stdio) honoring `toolsListChanged` (fires on `set_tool_packs`) and Tasks `taskIds`; static types omitted from the ack rather than faked.
- **Notification streaming**: a modern `tools/call` reply lazily upgrades JSON → SSE on the first `notifications/progress`, keeping validation failures on the spec-required 400+JSON path. `notifications/message` gated on the request's `logLevel` `_meta` key.
- Resource-not-found renumbered −32002 → −32602 at the source, so both eras report it correctly.

vcad needed no architectural change to go stateless: cross-call state has always ridden on a server-minted `document_id` passed as an ordinary tool argument — exactly the pattern SEP-2567 prescribes.

## Verification

- 31 conformance tests in `protocol-2026.test.ts`, including an MRTR round-trip against the real `authorize_spend` elicitation (decline → order revoked) and a task lifecycle to terminal
- Full suite: 1074 passed / 97 files; `tsc --noEmit` clean
- Live HTTP smoke against `dist/http.js`: modern discover/tasks/listen and legacy `initialize` all answer correctly on one endpoint

## Follow-ups (out of scope)

- Emit `notifications/progress` from the router/solvers so the SSE upgrade path carries real progress
- Durable task records via the session store (limited value: a half-run background tool can't resume across a restart anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)