### PR TITLE
fix(mcp): route MCP 2026-07-28 requests through the Vercel entry

### DIFF
--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -90,6 +90,14 @@ import { getStaleness } from "./edge-config.js";
 // server (http.ts).
 export { handleLiveRequest } from "./live-route.js";
 export { handleArtifactRequest } from "./artifact-route.js";
+// MCP 2026-07-28 dual-era front end, re-exported for the transport entries
+// (http.ts here; services/mcp/entry.ts on Vercel) so both route modern
+// requests identically.
+export {
+  isModernMessage,
+  handleModernRequest,
+  listenClosureResponse,
+} from "./protocol-2026.js";
 export { flushArtifacts, artifactStoreInfo } from "./tools/artifact-store.js";
 import {
   getViewerHtml,

--- a/services/mcp/entry.ts
+++ b/services/mcp/entry.ts
@@ -19,6 +19,9 @@ import {
   flushTelemetry,
   handleLiveRequest,
   handleArtifactRequest,
+  isModernMessage,
+  handleModernRequest,
+  listenClosureResponse,
   flushArtifacts,
   artifactStoreInfo,
 } from "@vcad/mcp/server";
@@ -187,7 +190,88 @@ export default async function handler(
     // assumeUiClient: stateless per-request Server — the UI-extension
     // capability from `initialize` never reaches tools/call, so attach the
     // inline `_meta` preview unconditionally (see ServerContext in @vcad/mcp).
-    const server = await createServer(engine, { user, assumeUiClient: true });
+    const makeServer = () =>
+      createServer(engine, { user, assumeUiClient: true });
+
+    // ── MCP 2026-07-28 (dual-era) ─────────────────────────────────
+    // A request carrying modern per-request `_meta` (or a modern-only
+    // method) is served by the modern handler; legacy `initialize` traffic
+    // falls through to the SDK transport below. Mirrors http.ts, minus SSE:
+    // Vercel buffers responses (see enableJsonResponse below), so replies
+    // are always single JSON objects here. That also means
+    // `subscriptions/listen` cannot hold a stream open on this deployment —
+    // answer it with the spec's graceful-closure response (the empty result
+    // that tells the client the subscription ended cleanly, deliverable
+    // over stdio or the standalone HTTP server instead).
+    if (req.method === "POST") {
+      const rawBody = await readRequestBody(req);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawBody);
+      } catch {
+        sendJson(res, 400, {
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32700, message: "Parse error" },
+        });
+        return;
+      }
+
+      if (isModernMessage(parsed, req.headers)) {
+        try {
+          const method = (parsed as { method?: string } | null)?.method;
+          if (method === "subscriptions/listen") {
+            sendJson(res, 200, listenClosureResponse(parsed));
+            return;
+          }
+          const { status, body } = await handleModernRequest(parsed, {
+            createServer: makeServer,
+            headers: req.headers,
+          });
+          if (body === null) {
+            res.writeHead(status);
+            res.end();
+          } else {
+            sendJson(res, status, body);
+          }
+        } finally {
+          await Promise.all([flushTelemetry(), flushArtifacts()]);
+        }
+        return;
+      }
+
+      await handleLegacyMcp(req, res, makeServer, parsed);
+      return;
+    }
+
+    await handleLegacyMcp(req, res, makeServer);
+  } catch (err) {
+    console.error("[vcad-mcp] Error:", err);
+    if (!res.headersSent) {
+      sendJson(res, 500, { error: "Internal server error" });
+    }
+  }
+}
+
+/** Read a POST body as a UTF-8 string (bounded by Vercel's own body limits). */
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c: Buffer) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/** The pre-2026 (`initialize`-handshake) path on the SDK's own transport. */
+async function handleLegacyMcp(
+  req: IncomingMessage,
+  res: ServerResponse,
+  makeServer: () => ReturnType<typeof createServer>,
+  parsedBody?: unknown,
+): Promise<void> {
+  try {
+    const server = await makeServer();
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless
       enableJsonResponse: true, // return JSON instead of SSE — Vercel buffers responses and adds Content-Length which breaks SSE streaming
@@ -196,7 +280,14 @@ export default async function handler(
     await server.connect(transport);
 
     try {
-      await transport.handleRequest(req, res);
+      // The POST body stream was already consumed by the dual-era router, so
+      // hand the parsed body through — the SDK skips its own read when given
+      // one. GET/DELETE pass no body.
+      if (parsedBody !== undefined) {
+        await transport.handleRequest(req, res, parsedBody);
+      } else {
+        await transport.handleRequest(req, res);
+      }
     } finally {
       // Drain PostHog captures AND pending durable artifact writes before
       // the serverless instance can freeze — an in-flight fetch is killed


### PR DESCRIPTION
## What

#743's dual-era front end was wired into `packages/mcp/src/http.ts` (standalone/Fly), but production (`mcp.vcad.io`) serves `/mcp` through `services/mcp/entry.ts` — which still handed everything to the SDK transport. Prod smoke after the merge showed modern requests rejected with the SDK's `Unsupported protocol version: 2026-07-28` while legacy clients were unaffected.

## Fix

- `entry.ts` reads the POST body, routes modern messages to `handleModernRequest`, and passes the parsed body through to the SDK transport for legacy traffic (the stream is consumed once).
- `subscriptions/listen` gets the spec's graceful-closure response on this deployment: Vercel buffers responses (`enableJsonResponse` exists for the same reason), so a notification stream can't be held open here — stdio and the standalone HTTP server carry that feature.
- Modern branch drains telemetry/artifacts in the same `finally` pattern as legacy.
- Dual-era helpers re-exported from `@vcad/mcp/server` so both entries route identically.

## Verification

- `tsc` clean for `packages/mcp` and `services/mcp/entry.ts`; protocol conformance suite (31 tests) green.
- Post-merge: will re-run the prod smoke (discover / tools_call / version negotiation / header mismatch / legacy initialize) against mcp.vcad.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)