### PR TITLE
feat(mcp): durable Tasks-extension records across server restarts

### DIFF
--- a/changelog/entries/2026-07-29-durable-task-records.json
+++ b/changelog/entries/2026-07-29-durable-task-records.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-29-durable-task-records",
+  "version": "0.9.4",
+  "date": "2026-07-29",
+  "category": "fix",
+  "title": "Task handles survive server restarts",
+  "summary": "Finished MCP task records persist across restarts, and a taskId orphaned mid-run reports the restart honestly instead of 'Unknown taskId'.",
+  "features": ["mcp", "tasks", "durability"],
+  "mcpTools": []
+}

--- a/packages/mcp/src/__tests__/protocol-2026.test.ts
+++ b/packages/mcp/src/__tests__/protocol-2026.test.ts
@@ -23,6 +23,7 @@ import {
   isModernMessage,
   handleModernRequest,
   taskIdBootToken,
+  flushTaskPersists,
 } from "../protocol-2026.js";
 
 /**
@@ -665,8 +666,7 @@ describe("task durability (restart survival)", () => {
 
   it("hydrates a terminal task from the durable store after a simulated restart", async () => {
     const taskId = await runTaskToTerminal();
-    // Give the fire-and-forget persist a beat to land on disk.
-    await new Promise((r) => setTimeout(r, 100));
+    await flushTaskPersists(); // wait for the terminal record to land on disk
     resetTasksForTest(); // wipe the warm cache = the restart
     const got = await call(
       request(200, "tasks/get", { taskId }),

--- a/packages/mcp/src/__tests__/protocol-2026.test.ts
+++ b/packages/mcp/src/__tests__/protocol-2026.test.ts
@@ -1,6 +1,11 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import nodePath from "node:path";
 import { Engine } from "@vcad/engine";
 import { createServer } from "../server.js";
+import { currentBootToken } from "../tools/session-core.js";
+import { FileTaskStore, taskDir } from "../task-store.js";
 import { InMemoryFabricateStore } from "../fabricate/store.js";
 import type { Order } from "../fabricate/types.js";
 import {
@@ -17,6 +22,7 @@ import {
   ERR_UNSUPPORTED_PROTOCOL_VERSION,
   isModernMessage,
   handleModernRequest,
+  taskIdBootToken,
 } from "../protocol-2026.js";
 
 /**
@@ -589,5 +595,170 @@ describe("resources", () => {
       headersFor("resources/read", "ui://vcad/does-not-exist"),
     );
     expect(body.error!.code).toBe(-32602);
+  });
+});
+
+describe("task durability (restart survival)", () => {
+  const TASK_META = {
+    ...META,
+    [META_CLIENT_CAPABILITIES]: { extensions: { [TASKS_EXTENSION]: {} } },
+  };
+
+  let tmpDir: string;
+  let savedEnv: Record<string, string | undefined>;
+  const ENV_KEYS = [
+    "VCAD_MCP_SESSION_DIR",
+    "VCAD_MCP_DISK_SESSIONS",
+    "SUPABASE_URL",
+    "SUPABASE_SERVICE_ROLE_KEY",
+  ] as const;
+
+  beforeEach(async () => {
+    savedEnv = {};
+    for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+    for (const k of ENV_KEYS) delete process.env[k];
+    tmpDir = await fs.mkdtemp(nodePath.join(os.tmpdir(), "vcad-task-store-"));
+    process.env.VCAD_MCP_SESSION_DIR = tmpDir;
+    resetTasksForTest();
+  });
+  afterEach(async () => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Run route_nets as a task and poll it to terminal; returns the taskId. */
+  async function runTaskToTerminal(): Promise<string> {
+    const created = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: TASK_META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    const taskId = created.body.result!.taskId as string;
+    let status = "working";
+    for (let i = 0; i < 100 && (status === "working" || status === "input_required"); i++) {
+      await new Promise((r) => setTimeout(r, 50));
+      const got = await call(
+        request(10 + i, "tasks/get", { taskId }),
+        headersFor("tasks/get"),
+      );
+      status = got.body.result!.status as string;
+    }
+    expect(status).toBe("completed");
+    return taskId;
+  }
+
+  it("embeds the current boot token in minted taskIds", async () => {
+    const taskId = await runTaskToTerminal();
+    expect(taskIdBootToken(taskId)).toBe(currentBootToken());
+  });
+
+  it("hydrates a terminal task from the durable store after a simulated restart", async () => {
+    const taskId = await runTaskToTerminal();
+    // Give the fire-and-forget persist a beat to land on disk.
+    await new Promise((r) => setTimeout(r, 100));
+    resetTasksForTest(); // wipe the warm cache = the restart
+    const got = await call(
+      request(200, "tasks/get", { taskId }),
+      headersFor("tasks/get"),
+    );
+    expect(got.status).toBe(200);
+    expect(got.body.result!.status).toBe("completed");
+    expect((got.body.result!.result as { isError?: boolean }).isError).toBe(true);
+  });
+
+  it("reports a prior-boot taskId with no durable record as failed-by-restart", async () => {
+    // A boot token that cannot be ours (tokens are 4 base64url chars).
+    const foreign = currentBootToken() === "ZZZZ" ? "YYYY" : "ZZZZ";
+    const taskId = `task_${foreign}_deadbeef`;
+    const got = await call(
+      request(1, "tasks/get", { taskId }),
+      headersFor("tasks/get"),
+    );
+    expect(got.status).toBe(200);
+    expect(got.body.error).toBeUndefined();
+    expect(got.body.result!.status).toBe("failed");
+    expect(got.body.result!.statusMessage).toMatch(/server restarted/i);
+    // update/cancel have nothing to act on: same explanation, as an error.
+    const cancelled = await call(
+      request(2, "tasks/cancel", { taskId }),
+      headersFor("tasks/cancel"),
+    );
+    expect(cancelled.body.error!.code).toBe(-32602);
+    expect(cancelled.body.error!.message).toMatch(/restarted/i);
+  });
+
+  it("still reports a same-boot unknown taskId as invalid params (a typo, not a restart)", async () => {
+    const { body } = await call(
+      request(1, "tasks/get", { taskId: `task_${currentBootToken()}_nope` }),
+      headersFor("tasks/get"),
+    );
+    expect(body.error!.code).toBe(-32602);
+    expect(body.error!.message).toMatch(/minted by this server process/);
+  });
+
+  it("treats an expired stored record as a miss (TTL still prunes)", async () => {
+    const store = new FileTaskStore(taskDir());
+    const taskId = `task_${currentBootToken()}_expired1`;
+    await store.save({
+      taskId,
+      status: "completed",
+      createdAt: new Date().toISOString(),
+      lastUpdatedAt: new Date().toISOString(),
+      expiresAt: Date.now() - 1_000,
+      toolName: "route_nets",
+      result: { resultType: "complete" },
+    });
+    expect(await store.load(taskId)).toBeNull();
+    const { body } = await call(
+      request(1, "tasks/get", { taskId }),
+      headersFor("tasks/get"),
+    );
+    expect(body.error!.code).toBe(-32602);
+  });
+
+  it("notes on the handle when the store is not durable", async () => {
+    process.env.VCAD_MCP_DISK_SESSIONS = "0"; // force the in-memory store
+    const created = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: TASK_META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    expect(created.body.result!.statusMessage).toMatch(/not survive a server restart/);
+  });
+
+  it("omits the durability note when the store is durable", async () => {
+    const created = await call(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "route_nets",
+          arguments: { document_id: "doc_does_not_exist" },
+          _meta: TASK_META,
+        },
+      },
+      headersFor("tools/call", "route_nets"),
+    );
+    expect(created.body.result!.statusMessage).not.toMatch(/not survive/);
   });
 });

--- a/packages/mcp/src/protocol-2026.ts
+++ b/packages/mcp/src/protocol-2026.ts
@@ -410,7 +410,22 @@ function touchTask(t: TaskRecord, status?: TaskStatus, message?: string): void {
     if (t.statusMessage !== undefined) stored.statusMessage = t.statusMessage;
     if (t.result !== undefined) stored.result = t.result;
     if (t.error !== undefined) stored.error = t.error;
-    void createTaskStore().save(stored);
+    const persist = createTaskStore()
+      .save(stored)
+      .finally(() => pendingPersists.delete(persist));
+    pendingPersists.add(persist);
+  }
+}
+
+/** In-flight terminal-record writes. Tracked so a caller (tests, shutdown)
+ *  can await them — the store itself never throws, so these only ever
+ *  resolve. */
+const pendingPersists = new Set<Promise<void>>();
+
+/** Await every in-flight terminal-record persist. */
+export async function flushTaskPersists(): Promise<void> {
+  while (pendingPersists.size > 0) {
+    await Promise.all([...pendingPersists]);
   }
 }
 

--- a/packages/mcp/src/protocol-2026.ts
+++ b/packages/mcp/src/protocol-2026.ts
@@ -33,9 +33,13 @@
  *     client declares it, calls to known long-running tools return a
  *     `CreateTaskResult` immediately and finish in the background; clients
  *     poll `tasks/get`, feed elicitations via `tasks/update`, and cancel
- *     cooperatively via `tasks/cancel`. Tasks live in process memory with a
- *     TTL — durable for the life of the stdio process or warm HTTP instance,
- *     which is exactly the durability vcad sessions already have.
+ *     cooperatively via `tasks/cancel`. Live tasks sit in process memory with
+ *     a TTL; terminal records (completed/failed/cancelled) also persist to the
+ *     durable task store (task-store.ts — same env gating as vcad sessions),
+ *     and `tasks/get` hydrates from it on a cache miss. An in-flight task
+ *     cannot survive a restart (its bridge dies with the process): its taskId
+ *     carries the minting boot token, so a poll after a restart reports an
+ *     honest `failed`-by-restart status instead of an unknown-id error.
  *   - `subscriptions/listen`: a long-lived notification stream serving
  *     `toolsListChanged` (fired when `set_tool_packs` re-shapes the surface)
  *     and `notifications/tasks` for subscribed task ids.
@@ -49,6 +53,9 @@ import { randomUUID } from "node:crypto";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { currentBootToken } from "./tools/session-core.js";
+import { isSessionStoreDurable } from "./session-store.js";
+import { createTaskStore, type StoredTask } from "./task-store.js";
 
 /** The protocol revision this module implements. */
 export const PROTOCOL_2026 = "2026-07-28";
@@ -387,6 +394,32 @@ function touchTask(t: TaskRecord, status?: TaskStatus, message?: string): void {
   if (message !== undefined) t.statusMessage = message;
   t.lastUpdatedAt = new Date().toISOString();
   bus.emit(EVT_TASK, detailedTask(t));
+  // Terminal states are the serializable part of a task's life: persist them
+  // so `tasks/get` still answers after a restart. Best-effort by contract —
+  // the store never throws, and an in-flight task cannot be persisted at all
+  // (its bridge dies with the process; the boot token in the id covers it).
+  if (t.status === "completed" || t.status === "failed" || t.status === "cancelled") {
+    const stored: StoredTask = {
+      taskId: t.taskId,
+      status: t.status,
+      createdAt: t.createdAt,
+      lastUpdatedAt: t.lastUpdatedAt,
+      expiresAt: t.expiresAt,
+      toolName: t.toolName,
+    };
+    if (t.statusMessage !== undefined) stored.statusMessage = t.statusMessage;
+    if (t.result !== undefined) stored.result = t.result;
+    if (t.error !== undefined) stored.error = t.error;
+    void createTaskStore().save(stored);
+  }
+}
+
+/** Extract the boot-token segment of a taskId, or null for a foreign-format
+ *  id. Mirrors session-core's sessionIdBootToken: a token that isn't ours
+ *  means the minting process is gone (restart, or another instance). */
+export function taskIdBootToken(taskId: string): string | null {
+  const m = /^task_([A-Za-z0-9_-]{4})_/.exec(taskId);
+  return m ? m[1] : null;
 }
 
 /** The wire shape of a task: base fields plus status-specific ones inlined. */
@@ -781,6 +814,14 @@ export async function handleModernRequest(
     if (asTask) {
       pruneTasks();
       const record = createTaskRecord(params.name as string);
+      // Durability honesty, mirroring the session-minting tools: when nothing
+      // survives a restart, say so on the handle instead of implying the TTL
+      // is the only way to lose it.
+      if (!isSessionStoreDurable()) {
+        record.statusMessage =
+          `${record.statusMessage} (note: this server's task store is ` +
+          `in-memory only — this handle will not survive a server restart)`;
+      }
       const owned = bridge; // background closure owns the bridge from here
       bridge = undefined;
       runTaskInBackground(record, owned, method, forwarded, inputResponses);
@@ -885,7 +926,10 @@ function stripModernFields(
 function createTaskRecord(toolName: string): TaskRecord {
   const now = new Date().toISOString();
   const record: TaskRecord = {
-    taskId: `task_${randomUUID().slice(0, 13)}`,
+    // The minting process's boot token rides in the id (same scheme as
+    // session ids): after a restart, an orphaned in-flight taskId is
+    // mechanically separable from a typo.
+    taskId: `task_${currentBootToken()}_${randomUUID().slice(0, 13)}`,
     status: "working",
     statusMessage: `running ${toolName}`,
     createdAt: now,
@@ -986,21 +1030,95 @@ export function taskElicitation(
   });
 }
 
-function handleTaskMethod(
+/** Re-cache a durably-stored terminal record as a resident TaskRecord so
+ *  subsequent polls are warm. Terminal by construction: no pending inputs, no
+ *  bridge to dispose. */
+function rehydrateTask(stored: StoredTask): TaskRecord {
+  const record: TaskRecord = {
+    taskId: stored.taskId,
+    status: stored.status,
+    statusMessage: stored.statusMessage,
+    createdAt: stored.createdAt,
+    lastUpdatedAt: stored.lastUpdatedAt,
+    expiresAt: stored.expiresAt,
+    toolName: stored.toolName,
+    inputRequests: {},
+    pendingInputs: new Map(),
+    result: stored.result,
+    error: stored.error,
+    cancelRequested: false,
+  };
+  tasks.set(record.taskId, record);
+  return record;
+}
+
+/**
+ * A taskId from a previous boot with no durable terminal record: the process
+ * died with the tool call in flight (a background bridge cannot survive a
+ * restart), so the task's true outcome is "failed". `tasks/get` reports
+ * exactly that; `tasks/update` / `tasks/cancel` have nothing to act on and
+ * error with the same explanation.
+ */
+function orphanedTaskResponse(
+  id: string | number,
+  method: string,
+  taskId: string,
+): ModernResponse {
+  const message =
+    `The server restarted while this task was running: taskId '${taskId}' was ` +
+    `minted by a previous server process (this one booted as ` +
+    `'${currentBootToken()}') and its in-flight tool call did not survive the ` +
+    `restart. Re-issue the original tools/call to run it again.`;
+  if (method === "tasks/get") {
+    const now = new Date().toISOString();
+    const result: Record<string, unknown> = {
+      resultType: "complete",
+      taskId,
+      status: "failed",
+      statusMessage: message,
+      createdAt: now,
+      lastUpdatedAt: now,
+      ttlMs: TASK_TTL_MS,
+      pollIntervalMs: TASK_POLL_INTERVAL_MS,
+      error: { code: ERR_INTERNAL, message },
+    };
+    return { status: 200, body: { jsonrpc: "2.0", id, result } };
+  }
+  return {
+    status: 200,
+    body: errorResponse(id, ERR_INVALID_PARAMS, message),
+  };
+}
+
+async function handleTaskMethod(
   id: string | number,
   method: string,
   params: Record<string, unknown>,
-): ModernResponse {
+): Promise<ModernResponse> {
   pruneTasks();
   const taskId = typeof params.taskId === "string" ? params.taskId : "";
-  const record = tasks.get(taskId);
+  let record = tasks.get(taskId);
   if (!record) {
+    // Cache miss: hydrate from the durable store before reporting unknown —
+    // a task that finished before a restart still has its terminal record.
+    const stored = await createTaskStore().load(taskId);
+    if (stored) record = rehydrateTask(stored);
+  }
+  if (!record) {
+    const mintToken = taskIdBootToken(taskId);
+    if (mintToken !== null && mintToken !== currentBootToken()) {
+      // Orphaned by a restart: the id was minted by a process that is gone
+      // and no terminal record survived, so the call died mid-run. Report an
+      // honest `failed` task, not an unknown-id error — the remediation is
+      // to re-issue the call, not to fix the argument.
+      return orphanedTaskResponse(id, method, taskId);
+    }
     return {
       status: 200,
       body: errorResponse(
         id,
         ERR_INVALID_PARAMS,
-        `Unknown taskId '${taskId}' — expired, cancelled long ago, or from a previous server instance`,
+        `Unknown taskId '${taskId}' — expired, cancelled long ago, or mistyped (it was minted by this server process)`,
       ),
     };
   }

--- a/packages/mcp/src/task-store.ts
+++ b/packages/mcp/src/task-store.ts
@@ -1,0 +1,199 @@
+/**
+ * Durable backing store for Tasks-extension records (protocol-2026.ts).
+ *
+ * WHY: task records live in a process-local Map with a 30-minute TTL, so a
+ * restart (routine on serverless) makes every outstanding taskId report
+ * "Unknown taskId" — including tasks that FINISHED before the restart, whose
+ * results are perfectly serializable. A half-executed background tool cannot
+ * resume after a restart (the bridge and its in-flight rpc die with the
+ * process), so this store does not attempt resumable execution. It persists
+ * TERMINAL records only (completed / failed / cancelled): `tasks/get` hydrates
+ * from here on a cache miss before reporting unknown, so a client that polls
+ * after a restart still gets its result.
+ *
+ * Mirrors session-store.ts exactly: file store under the local session dir,
+ * Supabase (`mcp_tasks`, migration 037) when the service-role env is present,
+ * in-memory no-op otherwise. Best-effort throughout — a store failure never
+ * turns a finished task into an error.
+ */
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+import { sessionDir, sessionFetch, useFileSessionStore } from "./session-store.js";
+
+/** The serializable subset of a task record — terminal states only. */
+export interface StoredTask {
+  taskId: string;
+  status: "completed" | "failed" | "cancelled";
+  statusMessage?: string;
+  createdAt: string;
+  lastUpdatedAt: string;
+  /** Epoch ms; a load past this is treated as a miss (TTL still prunes). */
+  expiresAt: number;
+  toolName: string;
+  result?: Record<string, unknown>;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export interface TaskStore {
+  /** Fetch a terminal task record, or null on miss/expiry. Never throws. */
+  load(taskId: string): Promise<StoredTask | null>;
+  /** Persist a terminal record. Best-effort: errors are logged, never thrown. */
+  save(task: StoredTask): Promise<void>;
+}
+
+/** No-op store: today's behavior — nothing survives the process. */
+export class InMemoryTaskStore implements TaskStore {
+  async load(): Promise<StoredTask | null> {
+    return null;
+  }
+  async save(): Promise<void> {
+    /* nothing durable */
+  }
+}
+
+function isStoredTask(v: unknown): v is StoredTask {
+  const t = v as StoredTask | null;
+  return (
+    !!t &&
+    typeof t.taskId === "string" &&
+    (t.status === "completed" || t.status === "failed" || t.status === "cancelled") &&
+    typeof t.expiresAt === "number"
+  );
+}
+
+/**
+ * Disk-backed store for local runs. One JSON file per task under a `tasks/`
+ * subdirectory of the session dir, so `VCAD_MCP_SESSION_DIR` relocates both.
+ * Same write-then-rename and never-escape-the-dir discipline as
+ * FileSessionStore.
+ */
+export class FileTaskStore implements TaskStore {
+  constructor(private dir: string) {}
+
+  private pathFor(taskId: string): string | null {
+    if (!/^[A-Za-z0-9_-]{1,128}$/.test(taskId)) return null;
+    return nodePath.join(this.dir, `${taskId}.json`);
+  }
+
+  async load(taskId: string): Promise<StoredTask | null> {
+    const file = this.pathFor(taskId);
+    if (!file) return null;
+    try {
+      const raw = await fs.readFile(file, "utf8");
+      const task = JSON.parse(raw) as unknown;
+      if (!isStoredTask(task)) return null;
+      if (task.expiresAt <= Date.now()) {
+        await fs.rm(file, { force: true }).catch(() => {});
+        return null;
+      }
+      return task;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        console.error("[task-store] file load failed:", err);
+      }
+      return null;
+    }
+  }
+
+  async save(task: StoredTask): Promise<void> {
+    const file = this.pathFor(task.taskId);
+    if (!file) return;
+    try {
+      await fs.mkdir(this.dir, { recursive: true });
+      const tmp = `${file}.${process.pid}.tmp`;
+      await fs.writeFile(tmp, JSON.stringify(task), "utf8");
+      await fs.rename(tmp, file);
+    } catch (err) {
+      console.error("[task-store] file save failed:", err);
+    }
+  }
+}
+
+/** Where local task records persist: `<sessionDir>/tasks`. */
+export function taskDir(): string {
+  return nodePath.join(sessionDir(), "tasks");
+}
+
+/**
+ * Cloud-backed store over the `mcp_tasks` table (service role only, migration
+ * 037). Capability-keyed by the unguessable taskId alone — tasks have no user
+ * scoping, matching the anonymous session store's model.
+ */
+export class SupabaseTaskStore implements TaskStore {
+  constructor(private cfg: { supabaseUrl: string; serviceRoleKey: string }) {}
+
+  private headers(extra: Record<string, string> = {}): Record<string, string> {
+    return {
+      apikey: this.cfg.serviceRoleKey,
+      Authorization: `Bearer ${this.cfg.serviceRoleKey}`,
+      "Content-Type": "application/json",
+      ...extra,
+    };
+  }
+
+  private url(query = ""): string {
+    return `${this.cfg.supabaseUrl}/rest/v1/mcp_tasks${query}`;
+  }
+
+  async load(taskId: string): Promise<StoredTask | null> {
+    try {
+      const res = await sessionFetch(
+        this.url(`?task_id=eq.${encodeURIComponent(taskId)}&select=record&limit=1`),
+        {
+          method: "GET",
+          headers: this.headers({ Accept: "application/vnd.pgrst.object+json" }),
+        },
+      );
+      if (!res.ok) return null; // 406 = zero rows → miss
+      const row = (await res.json()) as { record?: unknown };
+      const task = row?.record;
+      if (!isStoredTask(task) || task.expiresAt <= Date.now()) return null;
+      return task;
+    } catch (err) {
+      console.error("[task-store] load failed:", err);
+      return null;
+    }
+  }
+
+  async save(task: StoredTask): Promise<void> {
+    try {
+      const res = await sessionFetch(this.url("?on_conflict=task_id"), {
+        method: "POST",
+        headers: this.headers({
+          Prefer: "resolution=merge-duplicates,return=minimal",
+        }),
+        body: JSON.stringify([
+          {
+            task_id: task.taskId,
+            record: task,
+            expires_at: new Date(task.expiresAt).toISOString(),
+          },
+        ]),
+      });
+      if (!res.ok) {
+        console.error(
+          "[task-store] save failed:",
+          res.status,
+          await res.text().catch(() => ""),
+        );
+      }
+    } catch (err) {
+      console.error("[task-store] save failed:", err);
+    }
+  }
+}
+
+/**
+ * Choose the store impl from env, mirroring `createSessionStore`'s gating:
+ * Supabase when the service-role env is present, disk for local runs, else the
+ * in-memory no-op. Constructed per use — stores hold no connection state.
+ */
+export function createTaskStore(): TaskStore {
+  const url = (process.env.SUPABASE_URL || "").replace(/\/+$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  if (url && key) {
+    return new SupabaseTaskStore({ supabaseUrl: url, serviceRoleKey: key });
+  }
+  if (useFileSessionStore()) return new FileTaskStore(taskDir());
+  return new InMemoryTaskStore();
+}

--- a/supabase/migrations/037_mcp_tasks.sql
+++ b/supabase/migrations/037_mcp_tasks.sql
@@ -1,0 +1,53 @@
+-- Durable Tasks-extension records (capability-keyed) — the backing for
+-- protocol-2026.ts's task store (packages/mcp/src/task-store.ts).
+--
+-- WHY: Tasks-extension records (io.modelcontextprotocol/tasks, SEP-2663) live
+-- in a process-local Map, so on the serverless deploy a restart made every
+-- outstanding taskId report "Unknown taskId" — including tasks that FINISHED
+-- before the restart. Terminal records (completed / failed / cancelled) are
+-- perfectly serializable, so they persist here and `tasks/get` hydrates from
+-- this table on a cache miss. In-flight tasks cannot resume (the in-process
+-- bridge dies with the instance) and are reported as failed-by-restart via the
+-- boot token embedded in the taskId — no row needed.
+--
+-- Same model as mcp_artifacts (migration 033): service-role-only table keyed
+-- by the unguessable id; possession of the id IS the capability.
+
+create table if not exists mcp_tasks (
+  -- The task id ("task_<boot-token>_<random>"). Possession = access.
+  task_id text primary key,
+  -- The full serialized StoredTask (taskId, status, statusMessage,
+  -- timestamps, toolName, result, error). Kept as one blob so the wire shape
+  -- round-trips without column drift.
+  record jsonb not null,
+  created_at timestamptz not null default now(),
+  -- TTL, mirrored from the in-memory registry (TASK_TTL_MS, 30 min). Reads
+  -- treat an expired row as absent.
+  expires_at timestamptz not null
+);
+
+create index if not exists mcp_tasks_expires_idx on mcp_tasks (expires_at);
+
+-- RLS on + no policies = deny all to anon/authenticated; service_role
+-- bypasses RLS, so only the MCP server ever reads or writes rows.
+alter table mcp_tasks enable row level security;
+
+grant all on mcp_tasks to service_role;
+
+-- Tasks are transient by design — sweep expired rows. Callable manually or
+-- from a scheduled job (same follow-up wiring as cleanup_expired_mcp_artifacts,
+-- migration 033).
+create or replace function cleanup_expired_mcp_tasks()
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  swept integer;
+begin
+  delete from mcp_tasks where expires_at < now();
+  get diagnostics swept = row_count;
+  return swept;
+end;
+$$;


### PR DESCRIPTION
## What

Stacked on #743 (retarget to `main` after it merges). Completes the first follow-up from that PR: **Tasks-extension records now survive server restarts** — without pretending a half-run background tool can resume (it can't; the in-process bridge dies with the process).

Three guarantees:

1. **Terminal tasks survive.** When a task reaches completed/failed/cancelled, the serializable record (taskId, status, statusMessage, timestamps, toolName, result, error) persists to a durable task store (`packages/mcp/src/task-store.ts`, mirroring the session-store pattern exactly): file store under `<sessionDir>/tasks` locally, Supabase `mcp_tasks` (migration 037, capability-keyed + service-role-only like `mcp_artifacts`) when the env is present, in-memory no-op otherwise. `tasks/get` hydrates from the store on a cache miss before reporting unknown, and re-caches.
2. **Orphaned in-flight tasks report honestly.** taskIds now embed the minting process's boot token (`task_<tok>_<random>`, same scheme as session ids). A prior-boot taskId with no durable terminal record gets a `status:"failed"` task result explaining the server restarted mid-run and the call should be re-issued — not an unknown-id error. A same-boot unknown id still errors as a typo.
3. **Durability honesty.** When `isSessionStoreDurable()` is false, the `CreateTaskResult` statusMessage notes the handle will not survive a restart (the session-minting tools' pattern).

## Not included

- Migration 037 is **not pushed to prod** — deploy with `supabase db push`.
- The other #743 follow-up (real `notifications/progress` from router/solvers) needs progress hooks through the kernel/WASM boundary and stays deferred.

## Verification

- 7 new tests in `protocol-2026.test.ts` (env-isolated temp dir, per the durability-smoke pattern): terminal round-trip through a simulated restart, failed-by-restart orphan reporting on get and cancel, typo-vs-restart distinction, TTL expiry through the store, and both durability-note branches
- Full suite: 1081 passed / 97 files; `tsc --noEmit` clean; `deprecated-surface` tripwire green

🤖 Generated with [Claude Code](https://claude.com/claude-code)