### PR TITLE
feat(mcp): stream real progress from nine long-running kernel tools

### DIFF
--- a/changelog/entries/2026-07-29-kernel-chunked-progress.json
+++ b/changelog/entries/2026-07-29-kernel-chunked-progress.json
@@ -1,0 +1,22 @@
+{
+  "id": "2026-07-29-kernel-chunked-progress",
+  "version": "0.9.4",
+  "date": "2026-07-29",
+  "category": "feat",
+  "title": "Live progress from long-running kernel tools",
+  "summary": "Nine kernel-bound tools now stream real notifications/progress while they run, instead of going silent for minutes and reporting everything at the end.",
+  "features": [
+    "mcp"
+  ],
+  "mcpTools": [
+    "fab_prep",
+    "topology_optimize",
+    "simulate_flow",
+    "simulate_photonics",
+    "simulate_charged_particles",
+    "optimize_electrodes",
+    "simulate_neutron_shield",
+    "simulate_lattice_gauge",
+    "minimize_energy"
+  ]
+}

--- a/crates/vcad-ecad-fabprep/src/lib.rs
+++ b/crates/vcad-ecad-fabprep/src/lib.rs
@@ -301,144 +301,224 @@ fn refused(pcb: &Pcb, opts: &FabPrepOptions, why: String) -> FabPrepOutcome {
     }
 }
 
-/// Run the whole fab-prep pipeline against `pcb`, mutating it in place.
-///
-/// Never panics on a difficult board: a run that cannot converge returns a
-/// report with `converged: false` and the offenders named, and it is the
-/// caller's job (see [`package::write_fab_package`]) not to ship it.
-pub fn run_fab_prep(pcb: &mut Pcb, opts: &FabPrepOptions) -> FabPrepOutcome {
-    // 0. Waivers. A name that matches no rule is refused outright: a typo in a
-    //    safety valve that silently does nothing is worse than no valve.
-    let known: BTreeSet<String> = delta::ALL_RULES.iter().map(delta::rule_name).collect();
-    let (accepted, unknown): (BTreeSet<String>, Vec<String>) = {
-        let mut ok = BTreeSet::new();
-        let mut bad = Vec::new();
-        for r in &opts.accept_rules {
-            match known.iter().find(|k| k.eq_ignore_ascii_case(r)) {
-                Some(k) => {
-                    ok.insert(k.clone());
-                }
-                None => bad.push(r.clone()),
-            }
-        }
-        (ok, bad)
-    };
+/// What one call to [`FabPrepSession::round`] concluded — enough for a caller
+/// to narrate progress between rounds without holding the receipt yet.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RoundStatus {
+    /// The fix loop is finished (converged or blocked); call
+    /// [`FabPrepSession::finish`] next.
+    pub done: bool,
+    /// 1-based number of the round that just ran, or of the check that ended
+    /// the loop.
+    pub round: usize,
+    /// Route-attributable violations at the start of this round.
+    pub attributable: usize,
+    /// Total rounds the session may still run, including this one.
+    pub max_rounds: usize,
+}
 
-    if !unknown.is_empty() {
-        return refused(
-            pcb,
-            opts,
-            format!(
-                "unrecognised rule name(s) in the waiver list: {}. Valid names: {}",
-                unknown.join(", "),
-                known.iter().cloned().collect::<Vec<_>>().join(", ")
-            ),
+/// Stepwise driver for the fab-prep pipeline.
+///
+/// [`FabPrepSession::begin`] runs waiver validation, calibration, the stripped
+/// baseline and the up-front verdict pass; each [`FabPrepSession::round`] runs
+/// one strip-and-re-route iteration; [`FabPrepSession::finish`] restores the
+/// best board if the loop wandered, prunes, and builds the receipt.
+///
+/// [`run_fab_prep`] is implemented on top of this driver, so the chunked path
+/// and the one-shot path are the same code — a caller that steps the session
+/// (to surface progress between rounds) gets a bit-identical outcome.
+pub struct FabPrepSession {
+    opts: FabPrepOptions,
+    accepted: BTreeSet<String>,
+    calibration: CalibrationReport,
+    baseline: Vec<vcad_ecad_pcb::drc::DrcViolation>,
+    entry_connectivity: usize,
+    initial_verdict: Option<VerdictSummary>,
+    rounds: Vec<RoundSummary>,
+    blocker: Option<String>,
+    converged: bool,
+    previous: Option<(BTreeSet<String>, usize)>,
+    best: Option<(usize, Pcb)>,
+    non_improving: usize,
+    round_index: usize,
+    done: bool,
+}
+
+/// Consecutive rounds allowed to not improve before the loop gives up. One
+/// bad round can be a productive intermediate; two in a row is wandering.
+const MAX_NON_IMPROVING: usize = 2;
+
+impl FabPrepSession {
+    /// Set up a run: validate waivers, calibrate (opt-in), measure the
+    /// stripped-board baseline and arrival connectivity, and route or certify
+    /// whatever the board arrived unrouted.
+    ///
+    /// A refusal (an unrecognised waiver name) comes back as `Err` carrying the
+    /// same non-converging [`FabPrepOutcome`] the one-shot path reports.
+    pub fn begin(pcb: &mut Pcb, opts: &FabPrepOptions) -> Result<Self, Box<FabPrepOutcome>> {
+        // 0. Waivers. A name that matches no rule is refused outright: a typo in a
+        //    safety valve that silently does nothing is worse than no valve.
+        let known: BTreeSet<String> = delta::ALL_RULES.iter().map(delta::rule_name).collect();
+        let (accepted, unknown): (BTreeSet<String>, Vec<String>) = {
+            let mut ok = BTreeSet::new();
+            let mut bad = Vec::new();
+            for r in &opts.accept_rules {
+                match known.iter().find(|k| k.eq_ignore_ascii_case(r)) {
+                    Some(k) => {
+                        ok.insert(k.clone());
+                    }
+                    None => bad.push(r.clone()),
+                }
+            }
+            (ok, bad)
+        };
+
+        if !unknown.is_empty() {
+            return Err(Box::new(refused(
+                pcb,
+                opts,
+                format!(
+                    "unrecognised rule name(s) in the waiver list: {}. Valid names: {}",
+                    unknown.join(", "),
+                    known.iter().cloned().collect::<Vec<_>>().join(", ")
+                ),
+            )));
+        }
+
+        // 1. Rule calibration, before anything is measured — the baseline and the
+        //    final must be judged under identical rules or the delta is fiction.
+        let calibration = if opts.calibrate_rules {
+            calibrate::calibrate_rules(pcb)
+        } else {
+            CalibrationReport::default()
+        };
+
+        // 2. Baseline: the same board, same rules, with every trace and via
+        //    removed. This is the floor the fixture arrives with.
+        let baseline = {
+            let mut stripped = pcb.clone();
+            stripped.traces.clear();
+            stripped.trace_arcs.clear();
+            stripped.vias.clear();
+            check_drc(&stripped)
+        };
+        log::info!(
+            "fab-prep: fixture baseline = {} violations (stripped board)",
+            baseline.len()
         );
+
+        // 2b. Connectivity as the board arrived. The fix loop strips nets to clear
+        //     violations, which means it has a trivially "successful" move available
+        //     to it: delete the copper and the geometric violation goes with it. The
+        //     resulting board is DRC-clean and electrically useless. Recording what
+        //     the netlist realized on arrival lets the verdict refuse that trade.
+        let entry_connectivity = connectivity_count(&check_drc(pcb));
+
+        // 3. Route or certify whatever the board arrived unrouted.
+        let initial_verdict = opts.route_remaining.then(|| {
+            let v = verdict::route_remaining(pcb, opts.verdict);
+            log::info!(
+                "fab-prep: verdict ladder routed {} / proved-infeasible {} / unknown {}",
+                v.routed,
+                v.proved_infeasible,
+                v.unknown
+            );
+            v
+        });
+
+        Ok(Self {
+            opts: opts.clone(),
+            accepted,
+            calibration,
+            baseline,
+            entry_connectivity,
+            initial_verdict,
+            rounds: Vec::new(),
+            blocker: None,
+            converged: false,
+            previous: None,
+            // A round strips whole nets and hands them back to the router, so a round
+            // whose re-route fails leaves the board sparser than it found it. Left
+            // unguarded the loop can wander downhill for its whole round budget and
+            // return a board materially worse than the one it was given. Keep the best
+            // board seen and restore it if the loop never converges: fab-prep may fail
+            // to improve a board, but it must never hand back a worse one.
+            best: None,
+            non_improving: 0,
+            round_index: 0,
+            done: false,
+        })
     }
 
-    // 1. Rule calibration, before anything is measured — the baseline and the
-    //    final must be judged under identical rules or the delta is fiction.
-    let calibration = if opts.calibrate_rules {
-        calibrate::calibrate_rules(pcb)
-    } else {
-        CalibrationReport::default()
-    };
+    /// One iteration of the fix loop: census the route-attributable offenders,
+    /// strip their nets, hand them back to the (session-probed) ladder,
+    /// re-check. Returns `done: true` once the loop has converged or blocked.
+    pub fn round(&mut self, pcb: &mut Pcb) -> RoundStatus {
+        let max_rounds = self.opts.max_rounds;
+        if self.done || self.round_index > max_rounds {
+            self.done = true;
+            return RoundStatus {
+                done: true,
+                round: self.round_index,
+                attributable: 0,
+                max_rounds,
+            };
+        }
+        let round = self.round_index;
+        let status = |done: bool, attributable: usize| RoundStatus {
+            done,
+            round: round + 1,
+            attributable,
+            max_rounds,
+        };
 
-    // 2. Baseline: the same board, same rules, with every trace and via
-    //    removed. This is the floor the fixture arrives with.
-    let baseline = {
-        let mut stripped = pcb.clone();
-        stripped.traces.clear();
-        stripped.trace_arcs.clear();
-        stripped.vias.clear();
-        check_drc(&stripped)
-    };
-    log::info!(
-        "fab-prep: fixture baseline = {} violations (stripped board)",
-        baseline.len()
-    );
-
-    // 2b. Connectivity as the board arrived. The fix loop strips nets to clear
-    //     violations, which means it has a trivially "successful" move available
-    //     to it: delete the copper and the geometric violation goes with it. The
-    //     resulting board is DRC-clean and electrically useless. Recording what
-    //     the netlist realized on arrival lets the verdict refuse that trade.
-    let entry_connectivity = connectivity_count(&check_drc(pcb));
-
-    // 3. Route or certify whatever the board arrived unrouted.
-    let initial_verdict = opts.route_remaining.then(|| {
-        let v = verdict::route_remaining(pcb, opts.verdict);
-        log::info!(
-            "fab-prep: verdict ladder routed {} / proved-infeasible {} / unknown {}",
-            v.routed,
-            v.proved_infeasible,
-            v.unknown
-        );
-        v
-    });
-
-    // 4. The fix loop: census the route-attributable offenders, strip their
-    //    nets, hand them back to the (session-probed) ladder, re-check.
-    let mut rounds: Vec<RoundSummary> = Vec::new();
-    let mut blocker: Option<String> = None;
-    let mut converged = false;
-    let mut previous: Option<(BTreeSet<String>, usize)> = None;
-    // A round strips whole nets and hands them back to the router, so a round
-    // whose re-route fails leaves the board sparser than it found it. Left
-    // unguarded the loop can wander downhill for its whole round budget and
-    // return a board materially worse than the one it was given. Keep the best
-    // board seen and restore it if the loop never converges: fab-prep may fail
-    // to improve a board, but it must never hand back a worse one.
-    let mut best: Option<(usize, Pcb)> = None;
-    let mut non_improving = 0usize;
-    /// Consecutive rounds allowed to not improve before the loop gives up. One
-    /// bad round can be a productive intermediate; two in a row is wandering.
-    const MAX_NON_IMPROVING: usize = 2;
-
-    for round in 0..=opts.max_rounds {
         let now = check_drc(pcb);
-        let regression = connectivity_count(&now).saturating_sub(entry_connectivity);
-        let delta = DrcDelta::compute(&baseline, &now, &accepted);
+        let regression = connectivity_count(&now).saturating_sub(self.entry_connectivity);
+        let delta = DrcDelta::compute(&self.baseline, &now, &self.accepted);
         let attributable = delta.route_attributable_fixable;
         if attributable == 0 && regression == 0 {
-            converged = true;
-            best = None;
-            break;
+            self.converged = true;
+            self.best = None;
+            self.done = true;
+            return status(true, attributable);
         }
         // Score a candidate board on both axes at once. Scoring on
         // `attributable` alone would rank "stripped the net, never re-routed
         // it" as the best board on offer.
         let score = attributable + regression;
-        match &best {
-            Some((n, _)) if *n <= score => non_improving += 1,
+        match &self.best {
+            Some((n, _)) if *n <= score => self.non_improving += 1,
             _ => {
-                non_improving = 0;
-                best = Some((score, pcb.clone()));
+                self.non_improving = 0;
+                self.best = Some((score, pcb.clone()));
             }
         }
         if attributable == 0 {
             // Geometrically clean, but the loop got there by removing copper.
-            blocker = Some(format!(
+            self.blocker = Some(format!(
                 "the board is geometrically clean but {regression} more net(s) are unconnected or \
                  islanded than when it arrived — the loop cleared violations by removing copper it \
                  could not re-route, which is not a fix"
             ));
-            break;
+            self.done = true;
+            return status(true, attributable);
         }
-        if non_improving >= MAX_NON_IMPROVING {
-            blocker = Some(format!(
+        if self.non_improving >= MAX_NON_IMPROVING {
+            self.blocker = Some(format!(
                 "the fix loop stopped improving — {MAX_NON_IMPROVING} consecutive rounds failed to \
                  beat the best board seen"
             ));
-            break;
+            self.done = true;
+            return status(true, attributable);
         }
-        if round == opts.max_rounds {
+        if round == max_rounds {
             // Blockers say why the loop STOPPED and never restate the count —
             // `headline()` owns that number, and a blocker carrying a stale
             // count (the prune below can still change it) reads as a
             // contradiction in the receipt.
-            blocker = Some(format!("the round limit ({}) was reached", opts.max_rounds));
-            break;
+            self.blocker = Some(format!("the round limit ({max_rounds}) was reached"));
+            self.done = true;
+            return status(true, attributable);
         }
 
         // Only nets that actually own copper can be stripped and re-routed. An
@@ -464,27 +544,29 @@ pub fn run_fab_prep(pcb: &mut Pcb, opts: &FabPrepOptions) -> FabPrepOutcome {
             .filter(|n| with_copper.contains(n))
             .collect();
         if offending.is_empty() {
-            blocker = Some(
+            self.blocker = Some(
                 "the remaining offenders name no net carrying board-level copper — the \
                  strip-and-re-route loop cannot reach them"
                     .to_string(),
             );
-            break;
+            self.done = true;
+            return status(true, attributable);
         }
         // Oscillation guard: the same net set failing to reduce the count means
         // the ladder is returning the same copper. Stop and report rather than
         // burning the remaining rounds on it.
-        if let Some((prev_nets, prev_count)) = &previous {
+        if let Some((prev_nets, prev_count)) = &self.previous {
             if prev_nets == &offending && attributable >= *prev_count {
-                blocker = Some(format!(
+                self.blocker = Some(format!(
                     "the fix loop stalled: round {round} re-stripped the same {} net(s) without \
                      reducing the count",
                     offending.len()
                 ));
-                break;
+                self.done = true;
+                return status(true, attributable);
             }
         }
-        previous = Some((offending.clone(), attributable));
+        self.previous = Some((offending.clone(), attributable));
 
         let (stripped_traces, _arcs, stripped_vias) = verdict::strip_nets(pcb, &offending);
         log::info!(
@@ -493,8 +575,8 @@ pub fn run_fab_prep(pcb: &mut Pcb, opts: &FabPrepOptions) -> FabPrepOutcome {
             round + 1,
             offending.len()
         );
-        let verdict = verdict::route_remaining(pcb, opts.verdict);
-        rounds.push(RoundSummary {
+        let verdict = verdict::route_remaining(pcb, self.opts.verdict);
+        self.rounds.push(RoundSummary {
             round: round + 1,
             attributable_before: attributable,
             offending_nets: offending.into_iter().collect(),
@@ -502,82 +584,120 @@ pub fn run_fab_prep(pcb: &mut Pcb, opts: &FabPrepOptions) -> FabPrepOutcome {
             stripped_vias,
             verdict,
         });
+        self.round_index += 1;
+        status(false, attributable)
     }
 
-    // 4b. The loop ended without converging: hand back the best board it saw
-    //     rather than whatever the last (failed) round happened to leave.
-    let mut restored_best = false;
-    if !converged {
-        if let Some((best_score, board)) = best {
-            let now = check_drc(pcb);
-            let score = DrcDelta::compute(&baseline, &now, &accepted).route_attributable_fixable
-                + connectivity_count(&now).saturating_sub(entry_connectivity);
-            if best_score < score {
-                log::info!(
-                    "fab-prep: restoring the best board seen (score {best_score} vs {score})"
-                );
-                *pcb = board;
-                restored_best = true;
-            }
-        }
-    }
-
-    // 5. Prune copper that reaches no pad or pour of its net. Removing copper
-    //    can only remove geometric violations, so this cannot invalidate a
-    //    convergence reached above — but the final DRC below is what the
-    //    receipt reports either way.
-    let (pruned_traces, pruned_vias) = if opts.prune_dangling {
-        vcad_ecad_pcb::drc::prune_dangling_copper(pcb)
-    } else {
-        (0, 0)
-    };
-
-    // 6. Final DRC and the delta that is the receipt.
-    let violations = check_drc(pcb);
-    let delta = DrcDelta::compute(&baseline, &violations, &accepted);
-    let connectivity = Connectivity {
-        on_arrival: entry_connectivity,
-        on_completion: connectivity_count(&violations),
-    };
-    // The prune runs after the loop's last check, so re-derive convergence from
-    // the numbers actually being reported rather than trusting the loop's flag.
-    let converged =
-        converged && delta.route_attributable_fixable == 0 && connectivity.regression() == 0;
-    if converged {
-        blocker = None;
-    } else if blocker.is_none() {
-        blocker = Some(if connectivity.regression() > 0 {
-            format!(
-                "{} more net(s) are unconnected or islanded than when the board arrived",
-                connectivity.regression()
-            )
-        } else {
-            "violations appeared in the post-prune check".to_string()
-        });
-    }
-    if restored_best {
-        if let Some(why) = &mut blocker {
-            why.push_str(" (the best board the loop saw was restored)");
-        }
-    }
-
-    FabPrepOutcome {
-        report: FabPrepReport {
-            converged,
-            blocker,
-            calibration_requested: opts.calibrate_rules,
+    /// Restore the best board if the loop wandered, prune dangling copper, run
+    /// the final DRC, and build the receipt.
+    pub fn finish(self, pcb: &mut Pcb) -> FabPrepOutcome {
+        let Self {
+            opts,
+            accepted,
             calibration,
+            baseline,
+            entry_connectivity,
             initial_verdict,
             rounds,
-            pruned_traces,
-            pruned_vias,
-            connectivity,
-            accepted_rules: accepted.iter().cloned().collect(),
-            delta,
-            board: BoardStats::of(pcb),
-        },
-        violations,
+            mut blocker,
+            converged,
+            best,
+            ..
+        } = self;
+
+        // 4b. The loop ended without converging: hand back the best board it saw
+        //     rather than whatever the last (failed) round happened to leave.
+        let mut restored_best = false;
+        if !converged {
+            if let Some((best_score, board)) = best {
+                let now = check_drc(pcb);
+                let score = DrcDelta::compute(&baseline, &now, &accepted)
+                    .route_attributable_fixable
+                    + connectivity_count(&now).saturating_sub(entry_connectivity);
+                if best_score < score {
+                    log::info!(
+                        "fab-prep: restoring the best board seen (score {best_score} vs {score})"
+                    );
+                    *pcb = board;
+                    restored_best = true;
+                }
+            }
+        }
+
+        // 5. Prune copper that reaches no pad or pour of its net. Removing copper
+        //    can only remove geometric violations, so this cannot invalidate a
+        //    convergence reached above — but the final DRC below is what the
+        //    receipt reports either way.
+        let (pruned_traces, pruned_vias) = if opts.prune_dangling {
+            vcad_ecad_pcb::drc::prune_dangling_copper(pcb)
+        } else {
+            (0, 0)
+        };
+
+        // 6. Final DRC and the delta that is the receipt.
+        let violations = check_drc(pcb);
+        let delta = DrcDelta::compute(&baseline, &violations, &accepted);
+        let connectivity = Connectivity {
+            on_arrival: entry_connectivity,
+            on_completion: connectivity_count(&violations),
+        };
+        // The prune runs after the loop's last check, so re-derive convergence from
+        // the numbers actually being reported rather than trusting the loop's flag.
+        let converged =
+            converged && delta.route_attributable_fixable == 0 && connectivity.regression() == 0;
+        if converged {
+            blocker = None;
+        } else if blocker.is_none() {
+            blocker = Some(if connectivity.regression() > 0 {
+                format!(
+                    "{} more net(s) are unconnected or islanded than when the board arrived",
+                    connectivity.regression()
+                )
+            } else {
+                "violations appeared in the post-prune check".to_string()
+            });
+        }
+        if restored_best {
+            if let Some(why) = &mut blocker {
+                why.push_str(" (the best board the loop saw was restored)");
+            }
+        }
+
+        FabPrepOutcome {
+            report: FabPrepReport {
+                converged,
+                blocker,
+                calibration_requested: opts.calibrate_rules,
+                calibration,
+                initial_verdict,
+                rounds,
+                pruned_traces,
+                pruned_vias,
+                connectivity,
+                accepted_rules: accepted.iter().cloned().collect(),
+                delta,
+                board: BoardStats::of(pcb),
+            },
+            violations,
+        }
     }
+}
+
+/// Run the whole fab-prep pipeline against `pcb`, mutating it in place.
+///
+/// Never panics on a difficult board: a run that cannot converge returns a
+/// report with `converged: false` and the offenders named, and it is the
+/// caller's job (see [`package::write_fab_package`]) not to ship it.
+///
+/// This is the one-shot form of [`FabPrepSession`]; callers that want to
+/// observe progress between rounds drive the session directly.
+pub fn run_fab_prep(pcb: &mut Pcb, opts: &FabPrepOptions) -> FabPrepOutcome {
+    let mut session = match FabPrepSession::begin(pcb, opts) {
+        Ok(s) => s,
+        Err(outcome) => return *outcome,
+    };
+    while !session.round(pcb).done {}
+    session.finish(pcb)
 }
 
 #[cfg(test)]
@@ -861,6 +981,52 @@ mod tests {
             "the refusal must name the typo and the valid options: {:?}",
             report.blocker
         );
+    }
+
+    /// Driving the session round-by-round (the streamed-progress path) must
+    /// produce exactly the outcome of the one-shot call on the same board.
+    #[test]
+    fn stepwise_session_matches_the_one_shot_run() {
+        let mut make = || {
+            let mut pcb = test_board();
+            with_smd_pad(&mut pcb, "R1", "1", 2.0, 2.0, "A");
+            with_smd_pad(&mut pcb, "R1", "2", 8.0, 2.0, "A");
+            with_smd_pad(&mut pcb, "R2", "1", 5.0, 0.5, "B");
+            with_smd_pad(&mut pcb, "R2", "2", 5.0, 4.0, "B");
+            with_trace(&mut pcb, "A", 2.0, 2.0, 8.0, 2.0);
+            with_trace(&mut pcb, "B", 5.0, 0.5, 5.0, 4.0);
+            pcb
+        };
+        let opts = FabPrepOptions {
+            route_remaining: false,
+            prune_dangling: false,
+            max_rounds: 2,
+            ..Default::default()
+        };
+
+        let mut one_shot_pcb = make();
+        let one_shot = run_fab_prep(&mut one_shot_pcb, &opts);
+
+        let mut stepped_pcb = make();
+        let mut session = FabPrepSession::begin(&mut stepped_pcb, &opts).expect("no refusal");
+        let mut statuses = Vec::new();
+        loop {
+            let s = session.round(&mut stepped_pcb);
+            statuses.push(s);
+            if s.done {
+                break;
+            }
+        }
+        let stepped = session.finish(&mut stepped_pcb);
+
+        assert_eq!(one_shot.report, stepped.report);
+        assert_eq!(one_shot.violations, stepped.violations);
+        assert_eq!(
+            serde_json::to_string(&one_shot_pcb).unwrap(),
+            serde_json::to_string(&stepped_pcb).unwrap()
+        );
+        assert!(statuses.len() >= 2, "the loop must have visibly stepped");
+        assert!(statuses.last().unwrap().done);
     }
 
     #[test]

--- a/crates/vcad-kernel-atoms/src/minimize.rs
+++ b/crates/vcad-kernel-atoms/src/minimize.rs
@@ -8,7 +8,7 @@
 
 use crate::potential::ForceField;
 use crate::system::AtomSystem;
-use phyz_md::field::fire::{fire, FireOptions};
+use crate::vec3;
 
 /// Options controlling a FIRE relaxation.
 #[derive(Debug, Clone, Copy)]
@@ -49,40 +49,285 @@ pub struct MinimizeResult {
 
 /// Relax `sys` in place to a local energy minimum using FIRE. Velocities are
 /// used as the internal FIRE state and left near zero on return.
+///
+/// Implemented as an unbounded [`MinimizeRun`] drive, so the one-shot and
+/// chunked paths are identical by construction; the parity test in this
+/// module pins the stepwise loop against `phyz_md::field::fire` itself.
 pub fn minimize(
     ff: &dyn ForceField,
     sys: &mut AtomSystem,
     opts: &MinimizeOptions,
 ) -> MinimizeResult {
-    let fire_opts = FireOptions {
-        max_iters: opts.max_iters,
-        force_tol: opts.force_tol,
-        dt: opts.dt,
-        dt_max: opts.dt_max,
-    };
-    // Move positions/velocities into locals so phyz-md's FIRE can drive them
-    // while the force closure re-materializes positions on `sys` for the
-    // AtomSystem-based ForceField.
-    let masses = sys.masses.clone();
-    let mut positions = std::mem::take(&mut sys.positions);
-    let mut velocities = std::mem::take(&mut sys.velocities);
-    let res = fire(
-        &mut positions,
-        &mut velocities,
-        &masses,
-        &fire_opts,
-        |pos| {
-            sys.positions.clear();
-            sys.positions.extend_from_slice(pos);
-            ff.energy_forces(sys)
-        },
-    );
-    sys.positions = positions;
-    sys.velocities = velocities;
-    MinimizeResult {
-        converged: res.converged,
-        iters: res.iters,
-        energy: res.energy,
-        max_force: res.max_force,
+    let mut run = MinimizeRun::new(ff, sys, opts);
+    run.advance(ff, sys, usize::MAX);
+    run.finish(sys)
+}
+
+fn max_force_component(forces: &[[f64; 3]]) -> f64 {
+    let mut m = 0.0;
+    for f in forces {
+        for &c in f {
+            m = f64::max(m, c.abs());
+        }
+    }
+    m
+}
+
+/// Stepwise FIRE relaxation: [`MinimizeRun::new`] performs the initial
+/// force evaluation, each [`MinimizeRun::advance`] runs up to a budget of
+/// FIRE iterations, and [`MinimizeRun::finish`] restores the relaxed
+/// positions onto the system and returns the [`MinimizeResult`]. All FIRE
+/// state (timestep, mixing, velocity memory) lives in the run, so a
+/// chunked drive is bit-identical to a single [`minimize`] call — the
+/// iteration body mirrors [`phyz_md::field::fire::fire`] operation for
+/// operation, and the `stepwise_fire_matches_phyz_fire` test pins it.
+pub struct MinimizeRun {
+    opts: MinimizeOptions,
+    positions: Vec<[f64; 3]>,
+    velocities: Vec<[f64; 3]>,
+    masses: Vec<f64>,
+    forces: Vec<[f64; 3]>,
+    energy: f64,
+    max_force: f64,
+    dt: f64,
+    alpha: f64,
+    steps_since_neg: usize,
+    iters: usize,
+    converged: bool,
+}
+
+// Standard FIRE parameters (identical to phyz-md's).
+const N_MIN: usize = 5;
+const F_INC: f64 = 1.1;
+const F_DEC: f64 = 0.5;
+const ALPHA_START: f64 = 0.1;
+const F_ALPHA: f64 = 0.99;
+
+impl MinimizeRun {
+    /// Take the system's positions/velocities and perform the initial
+    /// force evaluation. `sys.positions` is left empty until
+    /// [`Self::finish`] restores it (the force field re-materializes
+    /// positions on `sys` per evaluation, exactly as [`minimize`] does).
+    pub fn new(ff: &dyn ForceField, sys: &mut AtomSystem, opts: &MinimizeOptions) -> Self {
+        let masses = sys.masses.clone();
+        let positions = std::mem::take(&mut sys.positions);
+        let mut velocities = std::mem::take(&mut sys.velocities);
+        velocities.fill([0.0; 3]);
+        let (energy, forces) = Self::eval(ff, sys, &positions);
+        let max_force = max_force_component(&forces);
+        let converged = max_force <= opts.force_tol;
+        MinimizeRun {
+            opts: *opts,
+            positions,
+            velocities,
+            masses,
+            forces,
+            energy,
+            max_force,
+            dt: opts.dt,
+            alpha: ALPHA_START,
+            steps_since_neg: 0,
+            iters: 0,
+            converged,
+        }
+    }
+
+    fn eval(ff: &dyn ForceField, sys: &mut AtomSystem, pos: &[[f64; 3]]) -> (f64, Vec<[f64; 3]>) {
+        sys.positions.clear();
+        sys.positions.extend_from_slice(pos);
+        ff.energy_forces(sys)
+    }
+
+    /// Whether the run is finished (converged or out of iterations).
+    pub fn done(&self) -> bool {
+        self.converged || self.iters >= self.opts.max_iters
+    }
+
+    /// FIRE iterations performed so far.
+    pub fn iters(&self) -> usize {
+        self.iters
+    }
+
+    /// The iteration budget.
+    pub fn max_iters(&self) -> usize {
+        self.opts.max_iters
+    }
+
+    /// Current potential energy (eV).
+    pub fn energy(&self) -> f64 {
+        self.energy
+    }
+
+    /// Current max force component (eV/Å).
+    pub fn max_force(&self) -> f64 {
+        self.max_force
+    }
+
+    /// Run up to `budget` FIRE iterations (min 1). Returns `true` when
+    /// the run is finished.
+    pub fn advance(&mut self, ff: &dyn ForceField, sys: &mut AtomSystem, budget: usize) -> bool {
+        let n = self.positions.len();
+        let mut left = budget.max(1);
+        while !self.done() && left > 0 {
+            self.iters += 1;
+            left -= 1;
+            // MD half-kick + drift + kick with the current forces
+            // (velocity-Verlet).
+            for i in 0..n {
+                let inv_m = phyz_md::field::units::FORCE_TO_ACCEL / self.masses[i];
+                let a = vec3::scale(self.forces[i], inv_m);
+                vec3::add_assign(&mut self.velocities[i], vec3::scale(a, 0.5 * self.dt));
+                let dx = vec3::scale(self.velocities[i], self.dt);
+                vec3::add_assign(&mut self.positions[i], dx);
+            }
+            let (e_new, f_new) = Self::eval(ff, sys, &self.positions);
+            self.energy = e_new;
+            self.forces = f_new;
+            for i in 0..n {
+                let inv_m = phyz_md::field::units::FORCE_TO_ACCEL / self.masses[i];
+                let a = vec3::scale(self.forces[i], inv_m);
+                vec3::add_assign(&mut self.velocities[i], vec3::scale(a, 0.5 * self.dt));
+            }
+
+            // FIRE: P = F · v
+            let mut power = 0.0;
+            let mut vnorm2 = 0.0;
+            let mut fnorm2 = 0.0;
+            for i in 0..n {
+                power += vec3::dot(self.forces[i], self.velocities[i]);
+                vnorm2 += vec3::norm2(self.velocities[i]);
+                fnorm2 += vec3::norm2(self.forces[i]);
+            }
+            let vnorm = vnorm2.sqrt();
+            let fnorm = fnorm2.sqrt().max(1e-30);
+            // v = (1-alpha) v + alpha |v| fhat
+            for i in 0..n {
+                let fhat = vec3::scale(self.forces[i], 1.0 / fnorm);
+                self.velocities[i] = vec3::add(
+                    vec3::scale(self.velocities[i], 1.0 - self.alpha),
+                    vec3::scale(fhat, self.alpha * vnorm),
+                );
+            }
+            if power > 0.0 {
+                self.steps_since_neg += 1;
+                if self.steps_since_neg > N_MIN {
+                    self.dt = (self.dt * F_INC).min(self.opts.dt_max);
+                    self.alpha *= F_ALPHA;
+                }
+            } else {
+                self.steps_since_neg = 0;
+                self.dt *= F_DEC;
+                self.alpha = ALPHA_START;
+                self.velocities.fill([0.0; 3]);
+            }
+
+            self.max_force = max_force_component(&self.forces);
+            if self.max_force <= self.opts.force_tol {
+                self.converged = true;
+            }
+        }
+        self.done()
+    }
+
+    /// Restore positions/velocities onto `sys` and return the result.
+    pub fn finish(self, sys: &mut AtomSystem) -> MinimizeResult {
+        sys.positions = self.positions;
+        sys.velocities = self.velocities;
+        MinimizeResult {
+            converged: self.converged,
+            iters: if self.converged {
+                self.iters
+            } else {
+                self.opts.max_iters
+            },
+            energy: self.energy,
+            max_force: self.max_force,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::potential::LennardJones;
+
+    fn dimer() -> AtomSystem {
+        AtomSystem {
+            elements: vec!["Ar".into(), "Ar".into()],
+            numbers: vec![18, 18],
+            masses: vec![39.948, 39.948],
+            charges: vec![0.0, 0.0],
+            positions: vec![[0.0; 3], [3.9, 0.0, 0.0]],
+            velocities: vec![[0.0; 3]; 2],
+            bonds: Vec::new(),
+            cell: None,
+        }
+    }
+
+    fn lj() -> LennardJones {
+        LennardJones::monatomic(0.0103, 3.4, 12.0)
+    }
+
+    /// The stepwise loop must be bit-identical to phyz-md's `fire` — phyz
+    /// is the oracle for the mirrored iteration body.
+    #[test]
+    fn stepwise_fire_matches_phyz_fire() {
+        use phyz_md::field::fire::{fire, FireOptions};
+        let opts = MinimizeOptions::default();
+        let ff = lj();
+
+        // Oracle: drive phyz fire exactly as the old one-shot did.
+        let mut oracle_sys = dimer();
+        let masses = oracle_sys.masses.clone();
+        let mut positions = std::mem::take(&mut oracle_sys.positions);
+        let mut velocities = std::mem::take(&mut oracle_sys.velocities);
+        let fire_opts = FireOptions {
+            max_iters: opts.max_iters,
+            force_tol: opts.force_tol,
+            dt: opts.dt,
+            dt_max: opts.dt_max,
+        };
+        let oracle = fire(
+            &mut positions,
+            &mut velocities,
+            &masses,
+            &fire_opts,
+            |pos| {
+                oracle_sys.positions.clear();
+                oracle_sys.positions.extend_from_slice(pos);
+                ff.energy_forces(&oracle_sys)
+            },
+        );
+
+        // Chunked drive with a tiny odd budget.
+        let mut sys = dimer();
+        let mut run = MinimizeRun::new(&ff, &mut sys, &opts);
+        let mut calls = 0;
+        while !run.advance(&ff, &mut sys, 3) {
+            calls += 1;
+        }
+        assert!(calls > 2, "budget too generous to exercise chunking");
+        let res = run.finish(&mut sys);
+
+        assert_eq!(res.converged, oracle.converged);
+        assert_eq!(res.iters, oracle.iters);
+        assert_eq!(res.energy.to_bits(), oracle.energy.to_bits());
+        assert_eq!(res.max_force.to_bits(), oracle.max_force.to_bits());
+        for (a, b) in sys.positions.iter().zip(&positions) {
+            for c in 0..3 {
+                assert_eq!(a[c].to_bits(), b[c].to_bits());
+            }
+        }
+    }
+
+    /// One-shot `minimize` rides the stepper; sanity-check it converges.
+    #[test]
+    fn one_shot_minimize_converges_on_the_dimer() {
+        let mut sys = dimer();
+        let res = minimize(&lj(), &mut sys, &MinimizeOptions::default());
+        assert!(res.converged);
+        let r = (sys.positions[1][0] - sys.positions[0][0]).abs();
+        let r_min = 2.0f64.powf(1.0 / 6.0) * 3.4;
+        assert!((r - r_min).abs() < 1e-2, "r = {r}");
     }
 }

--- a/crates/vcad-kernel-atoms/src/wasm.rs
+++ b/crates/vcad-kernel-atoms/src/wasm.rs
@@ -195,6 +195,94 @@ pub fn atoms_minimize(
     serde_json::to_string(&out).map_err(err)
 }
 
+/// Stepwise energy minimization: the FIRE iteration loop in budgeted
+/// chunks so a host can stream progress between kernel calls. All FIRE
+/// state lives in the run, so the result is bit-identical to
+/// `atoms_minimize`.
+///
+/// Usage: `new AtomsMinimizeRun(molJson, cfgJson, maxIters, forceTol)` →
+/// `advance(budget)` (iterations) until `{done: true}` → `finish()` for
+/// the same `{ result, molecule }` JSON `atoms_minimize` returns.
+#[wasm_bindgen]
+pub struct AtomsMinimizeRun {
+    ff: Box<dyn ForceField>,
+    sys: AtomSystem,
+    run: Option<crate::minimize::MinimizeRun>,
+}
+
+#[wasm_bindgen]
+impl AtomsMinimizeRun {
+    /// Parse the molecule/config, build the force field, and perform the
+    /// initial force evaluation.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        molecule_json: &str,
+        config_json: &str,
+        max_iters: usize,
+        force_tol: f64,
+    ) -> Result<AtomsMinimizeRun, JsValue> {
+        let mol: MoleculeSystem = serde_json::from_str(molecule_json).map_err(err)?;
+        let cfg: MdConfig = parse_config(config_json)?;
+        let mut sys = AtomSystem::from_ir(&mol).map_err(err)?;
+        let ff = build_force_field(&cfg, &sys);
+        let opts = MinimizeOptions {
+            max_iters,
+            force_tol,
+            ..Default::default()
+        };
+        let run = crate::minimize::MinimizeRun::new(ff.as_ref(), &mut sys, &opts);
+        Ok(AtomsMinimizeRun {
+            ff,
+            sys,
+            run: Some(run),
+        })
+    }
+
+    /// Run up to `budget` FIRE iterations. Returns
+    /// `{ done, steps, total, energy, maxForce }` JSON (steps =
+    /// iterations performed, total = the iteration budget).
+    pub fn advance(&mut self, budget: usize) -> Result<String, JsValue> {
+        let run = self
+            .run
+            .as_mut()
+            .ok_or_else(|| err("AtomsMinimizeRun already finished"))?;
+        let done = run.advance(self.ff.as_ref(), &mut self.sys, budget.max(1));
+        serde_json::to_string(&serde_json::json!({
+            "done": done,
+            "steps": run.iters(),
+            "total": run.max_iters(),
+            "energy": run.energy(),
+            "maxForce": run.max_force(),
+        }))
+        .map_err(err)
+    }
+
+    /// Assemble the same `{ result, molecule }` JSON `atoms_minimize`
+    /// returns (advance to completion first). The run is consumed.
+    pub fn finish(&mut self) -> Result<String, JsValue> {
+        let run = self
+            .run
+            .take()
+            .ok_or_else(|| err("AtomsMinimizeRun already finished"))?;
+        if !run.done() {
+            return Err(err(
+                "AtomsMinimizeRun has not finished — call advance() to completion first",
+            ));
+        }
+        let res = run.finish(&mut self.sys);
+        let out = serde_json::json!({
+            "result": {
+                "converged": res.converged,
+                "iters": res.iters,
+                "energy": res.energy,
+                "maxForce": res.max_force,
+            },
+            "molecule": self.sys.to_ir(),
+        });
+        serde_json::to_string(&out).map_err(err)
+    }
+}
+
 /// Homogenize a periodic structure into bulk material properties — density,
 /// cubic elastic constants, and VRH isotropic moduli — as a `MaterialCard`
 /// JSON. The atoms → continuum bridge: the returned density (kg/m³) and

--- a/crates/vcad-kernel-flow/src/solve.rs
+++ b/crates/vcad-kernel-flow/src/solve.rs
@@ -168,273 +168,357 @@ pub struct Solution {
     pub wall_heat_walls_only_w: Option<f64>,
 }
 
-/// Run the lattice to steady state.
-pub fn solve_steady(model: &FlowModel, opts: &SolveOptions) -> Result<Solution, SolveError> {
-    model.validate()?;
+/// What a bounded [`FlowStepper::advance`] call concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlowProgress {
+    /// Budget exhausted; the field is not steady yet. Call `advance` again.
+    Running,
+    /// The field went steady; take the result with [`FlowStepper::into_solution`].
+    Converged,
+}
 
-    let (nx, ny, nz) = (
-        model.divisions[0] as isize,
-        model.divisions[1] as isize,
-        model.divisions[2] as isize,
-    );
-    let n = (nx * ny * nz) as usize;
-    let dx_m = model.voxel_mm() / 1000.0;
+/// Stepwise driver for the steady LBM solve: [`FlowStepper::new`] builds the
+/// lattice, each [`FlowStepper::advance`] runs up to a budget of timesteps, so
+/// a host can surface progress (steps, residual) between chunks.
+/// [`solve_steady`] drives this to completion, so the chunked and one-shot
+/// paths are identical by construction — chunk boundaries cannot change the
+/// result because steadiness checks key off the absolute step count.
+pub struct FlowStepper {
+    model: FlowModel,
+    opts: SolveOptions,
+    scaling: Scaling,
+    omega: f64,
+    force_prefactor: f64,
+    u_in_lat: [f64; 3],
+    rho_out_lat: f64,
+    a_lat: [f64; 3],
+    buoy_lat_per_k: [f64; 3],
+    t_ref_buoy: f64,
+    t_scale: f64,
+    has_buoyancy: bool,
+    omega_g: Option<f64>,
+    temp: Vec<f64>,
+    temp_prev: Vec<f64>,
+    g: Vec<f64>,
+    g_new: Vec<f64>,
+    q_wall_lat: f64,
+    q_inlet_lat: f64,
+    q_outlet_lat: f64,
+    f: Vec<f64>,
+    f_new: Vec<f64>,
+    vel: Vec<[f64; 3]>,
+    rho: Vec<f64>,
+    vel_prev: Vec<[f64; 3]>,
+    steps: usize,
+    residual: f64,
+    dx_m: f64,
+    u_floor: f64,
+    solution: Option<Solution>,
+}
 
-    let inlet_speed = norm(model.inlet_velocity_m_s);
-    let u_ref = match opts.u_ref_m_s {
-        Some(u) if u > 0.0 => u,
-        _ if inlet_speed > 0.0 => inlet_speed,
-        _ => return Err(SolveError::NoReference),
-    };
-    let scaling = Scaling::derive(dx_m, model.fluid.kinematic_viscosity_m2_s(), u_ref)?;
-    let tau = scaling.tau;
-    let omega = 1.0 / tau;
-    let force_prefactor = 1.0 - 0.5 * omega;
+impl FlowStepper {
+    /// Validate the model, derive the unit scaling, and initialize the lattice.
+    pub fn new(model: &FlowModel, opts: &SolveOptions) -> Result<Self, SolveError> {
+        model.validate()?;
 
-    let u_in_lat = [
-        scaling.velocity_to_lattice(model.inlet_velocity_m_s[0]),
-        scaling.velocity_to_lattice(model.inlet_velocity_m_s[1]),
-        scaling.velocity_to_lattice(model.inlet_velocity_m_s[2]),
-    ];
-    let c_lat = scaling.dx_m / scaling.dt_s;
-    let rho_out_lat =
-        1.0 + model.outlet_gauge_pa / (CS2 * model.fluid.density_kg_m3 * c_lat * c_lat);
-    let a_lat = [
-        scaling.accel_to_lattice(model.body_force_n_m3[0] / model.fluid.density_kg_m3),
-        scaling.accel_to_lattice(model.body_force_n_m3[1] / model.fluid.density_kg_m3),
-        scaling.accel_to_lattice(model.body_force_n_m3[2] / model.fluid.density_kg_m3),
-    ];
+        let (nx, ny, nz) = (
+            model.divisions[0] as isize,
+            model.divisions[1] as isize,
+            model.divisions[2] as isize,
+        );
+        let n = (nx * ny * nz) as usize;
+        let dx_m = model.voxel_mm() / 1000.0;
 
-    // Thermal transport setup (M1/M3).
-    let thermal = model.thermal;
-    let (buoy_lat_per_k, t_ref_buoy, t_scale) = if let Some(t) = &thermal {
-        let alpha_lat = t.diffusivity_m2_s * scaling.dt_s / (scaling.dx_m * scaling.dx_m);
-        // Scalar relaxation time must sit in the same validated window
-        // as the flow lattice.
-        let tau_g = 3.0 * alpha_lat + 0.5;
-        if !(crate::lattice::TAU_MIN..=crate::lattice::TAU_MAX).contains(&tau_g) {
-            return Err(SolveError::ThermalUnstable { alpha_lat });
-        }
-        // Buoyant acceleration per kelvin: a = −g·β·(T − T_ref).
-        let (bl, tref) = match t.buoyancy {
-            Some(b) => (
-                [
-                    scaling.accel_to_lattice(-b.gravity_m_s2[0] * b.beta_per_k),
-                    scaling.accel_to_lattice(-b.gravity_m_s2[1] * b.beta_per_k),
-                    scaling.accel_to_lattice(-b.gravity_m_s2[2] * b.beta_per_k),
-                ],
-                b.t_ref_c,
-            ),
-            None => ([0.0; 3], 0.0),
+        let inlet_speed = norm(model.inlet_velocity_m_s);
+        let u_ref = match opts.u_ref_m_s {
+            Some(u) if u > 0.0 => u,
+            _ if inlet_speed > 0.0 => inlet_speed,
+            _ => return Err(SolveError::NoReference),
         };
-        let mut spread = (t.inlet_temp_c - t.initial_temp_c).abs();
-        if let Some(w) = t.wall_temp_c {
-            spread = spread
-                .max((w - t.initial_temp_c).abs())
-                .max((w - t.inlet_temp_c).abs());
-        }
-        if let Some(st) = &model.solid_temp_c {
-            for v in st.iter().filter(|v| v.is_finite()) {
-                spread = spread
-                    .max((v - t.initial_temp_c).abs())
-                    .max((v - t.inlet_temp_c).abs());
-            }
-        }
-        (bl, tref, spread.max(1e-9))
-    } else {
-        ([0.0; 3], 0.0, 1.0)
-    };
-    let has_buoyancy = buoy_lat_per_k.iter().any(|b| *b != 0.0);
-    let mut temp: Vec<f64> = match &thermal {
-        Some(t) => vec![t.initial_temp_c; n],
-        None => Vec::new(),
-    };
-    let mut temp_prev = temp.clone();
-    // Second distribution for the temperature scalar (the FV route was
-    // tried and rejected: cell-centered upwind advection on the LBM
-    // velocity field violates the maximum principle near the inlet
-    // because its discrete divergence differs from the lattice's; the
-    // double-distribution scalar inherits the lattice's continuity).
-    // g carries θ = T − T_inlet so boundary fluxes are baseline-free.
-    let omega_g = thermal.map(|t| {
-        1.0 / (3.0 * t.diffusivity_m2_s * scaling.dt_s / (scaling.dx_m * scaling.dx_m) + 0.5)
-    });
-    let mut g: Vec<f64> = match &thermal {
-        Some(t) => {
-            let theta0 = t.initial_temp_c - t.inlet_temp_c;
-            let mut g = vec![0.0; n * Q];
-            for x in 0..n {
-                for q in 0..Q {
-                    g[x * Q + q] = W[q] * theta0;
-                }
-            }
-            g
-        }
-        None => Vec::new(),
-    };
-    let mut g_new = g.clone();
-    // Boundary θ-exchange accumulators (per step, lattice units):
-    // Dirichlet walls, inlet, outlet — the audit's second route.
-    let mut q_wall_lat = 0.0f64;
-    let mut q_inlet_lat = 0.0f64;
-    let mut q_outlet_lat = 0.0f64;
+        let scaling = Scaling::derive(dx_m, model.fluid.kinematic_viscosity_m2_s(), u_ref)?;
+        let tau = scaling.tau;
+        let omega = 1.0 / tau;
+        let force_prefactor = 1.0 - 0.5 * omega;
 
-    let cells = &model.cells;
-    let mut f: Vec<f64> = vec![0.0; n * Q];
-    let feq0 = equilibrium(1.0, [0.0; 3]);
-    for x in 0..n {
-        f[x * Q..(x + 1) * Q].copy_from_slice(&feq0);
-    }
-    let mut f_new = f.clone();
-    let mut vel = vec![[0.0f64; 3]; n];
-    let mut rho = vec![1.0f64; n];
-    let mut vel_prev = vel.clone();
+        let u_in_lat = [
+            scaling.velocity_to_lattice(model.inlet_velocity_m_s[0]),
+            scaling.velocity_to_lattice(model.inlet_velocity_m_s[1]),
+            scaling.velocity_to_lattice(model.inlet_velocity_m_s[2]),
+        ];
+        let c_lat = scaling.dx_m / scaling.dt_s;
+        let rho_out_lat =
+            1.0 + model.outlet_gauge_pa / (CS2 * model.fluid.density_kg_m3 * c_lat * c_lat);
+        let a_lat = [
+            scaling.accel_to_lattice(model.body_force_n_m3[0] / model.fluid.density_kg_m3),
+            scaling.accel_to_lattice(model.body_force_n_m3[1] / model.fluid.density_kg_m3),
+            scaling.accel_to_lattice(model.body_force_n_m3[2] / model.fluid.density_kg_m3),
+        ];
 
-    let idx = |i: isize, j: isize, k: isize| -> usize { ((k * ny + j) * nx + i) as usize };
-
-    let mut steps = 0usize;
-    let mut residual = f64::INFINITY;
-    let u_floor = scaling.u_lattice.max(1e-12);
-
-    while steps < opts.max_steps {
-        // Smoothstep inlet ramp: avoids the impulsive-start shock.
-        let s = if opts.ramp_steps == 0 {
-            1.0
-        } else {
-            let t = ((steps + 1) as f64 / opts.ramp_steps as f64).min(1.0);
-            t * t * (3.0 - 2.0 * t)
-        };
-        let u_in_now = [u_in_lat[0] * s, u_in_lat[1] * s, u_in_lat[2] * s];
-
-        // Collision (fluid cells only), macroscopic update included.
-        for x in 0..n {
-            if cells[x] != Cell::Fluid {
-                continue;
+        // Thermal transport setup (M1/M3).
+        let thermal = model.thermal;
+        let (buoy_lat_per_k, t_ref_buoy, t_scale) = if let Some(t) = &thermal {
+            let alpha_lat = t.diffusivity_m2_s * scaling.dt_s / (scaling.dx_m * scaling.dx_m);
+            // Scalar relaxation time must sit in the same validated window
+            // as the flow lattice.
+            let tau_g = 3.0 * alpha_lat + 0.5;
+            if !(crate::lattice::TAU_MIN..=crate::lattice::TAU_MAX).contains(&tau_g) {
+                return Err(SolveError::ThermalUnstable { alpha_lat });
             }
-            // Scalar moment first: θ from g, so buoyancy sees this
-            // step's temperature.
-            if let (Some(t), Some(_)) = (&thermal, omega_g) {
-                let gx = &g[x * Q..(x + 1) * Q];
-                let theta: f64 = gx.iter().sum();
-                temp[x] = theta + t.inlet_temp_c;
-            }
-            let fx = &mut f[x * Q..(x + 1) * Q];
-            let mut r = 0.0;
-            let mut m = [0.0f64; 3];
-            for (i, fi) in fx.iter().enumerate() {
-                r += fi;
-                m[0] += fi * C[i][0] as f64;
-                m[1] += fi * C[i][1] as f64;
-                m[2] += fi * C[i][2] as f64;
-            }
-            // Per-cell acceleration: global body force plus Boussinesq
-            // buoyancy when a temperature field is coupled in.
-            let a_cell = if has_buoyancy {
-                let dtc = temp[x] - t_ref_buoy;
-                [
-                    a_lat[0] + buoy_lat_per_k[0] * dtc,
-                    a_lat[1] + buoy_lat_per_k[1] * dtc,
-                    a_lat[2] + buoy_lat_per_k[2] * dtc,
-                ]
-            } else {
-                a_lat
+            // Buoyant acceleration per kelvin: a = −g·β·(T − T_ref).
+            let (bl, tref) = match t.buoyancy {
+                Some(b) => (
+                    [
+                        scaling.accel_to_lattice(-b.gravity_m_s2[0] * b.beta_per_k),
+                        scaling.accel_to_lattice(-b.gravity_m_s2[1] * b.beta_per_k),
+                        scaling.accel_to_lattice(-b.gravity_m_s2[2] * b.beta_per_k),
+                    ],
+                    b.t_ref_c,
+                ),
+                None => ([0.0; 3], 0.0),
             };
-            let u = [
-                (m[0] + 0.5 * a_cell[0] * r) / r,
-                (m[1] + 0.5 * a_cell[1] * r) / r,
-                (m[2] + 0.5 * a_cell[2] * r) / r,
-            ];
-            rho[x] = r;
-            vel[x] = u;
-            let feq = equilibrium(r, u);
-            for i in 0..Q {
-                let cu = C[i][0] as f64 * u[0] + C[i][1] as f64 * u[1] + C[i][2] as f64 * u[2];
-                let ca = C[i][0] as f64 * a_cell[0]
-                    + C[i][1] as f64 * a_cell[1]
-                    + C[i][2] as f64 * a_cell[2];
-                let ua = u[0] * a_cell[0] + u[1] * a_cell[1] + u[2] * a_cell[2];
-                let guo = force_prefactor * W[i] * r * (3.0 * (ca - ua) + 9.0 * cu * ca);
-                fx[i] += -omega * (fx[i] - feq[i]) + guo;
+            let mut spread = (t.inlet_temp_c - t.initial_temp_c).abs();
+            if let Some(w) = t.wall_temp_c {
+                spread = spread
+                    .max((w - t.initial_temp_c).abs())
+                    .max((w - t.inlet_temp_c).abs());
             }
-            // Scalar BGK collision toward w_i·θ·(1 + 3c·u).
-            if let (Some(t), Some(og)) = (&thermal, omega_g) {
-                let gx = &mut g[x * Q..(x + 1) * Q];
-                let theta = temp[x] - t.inlet_temp_c;
-                for (i, gi) in gx.iter_mut().enumerate() {
-                    let cu = C[i][0] as f64 * u[0] + C[i][1] as f64 * u[1] + C[i][2] as f64 * u[2];
-                    let geq = W[i] * theta * (1.0 + 3.0 * cu);
-                    *gi += -og * (*gi - geq);
+            if let Some(st) = &model.solid_temp_c {
+                for v in st.iter().filter(|v| v.is_finite()) {
+                    spread = spread
+                        .max((v - t.initial_temp_c).abs())
+                        .max((v - t.inlet_temp_c).abs());
                 }
             }
-        }
-
-        // Streaming (pull) with boundary rules.
-        for k in 0..nz {
-            for j in 0..ny {
-                for i in 0..nx {
-                    let x = idx(i, j, k);
-                    if cells[x] != Cell::Fluid {
-                        continue;
-                    }
-                    let dst = &mut f_new[x * Q..(x + 1) * Q];
+            (bl, tref, spread.max(1e-9))
+        } else {
+            ([0.0; 3], 0.0, 1.0)
+        };
+        let has_buoyancy = buoy_lat_per_k.iter().any(|b| *b != 0.0);
+        let temp: Vec<f64> = match &thermal {
+            Some(t) => vec![t.initial_temp_c; n],
+            None => Vec::new(),
+        };
+        let temp_prev = temp.clone();
+        // Second distribution for the temperature scalar (the FV route was
+        // tried and rejected: cell-centered upwind advection on the LBM
+        // velocity field violates the maximum principle near the inlet
+        // because its discrete divergence differs from the lattice's; the
+        // double-distribution scalar inherits the lattice's continuity).
+        // g carries θ = T − T_inlet so boundary fluxes are baseline-free.
+        let omega_g = thermal.map(|t| {
+            1.0 / (3.0 * t.diffusivity_m2_s * scaling.dt_s / (scaling.dx_m * scaling.dx_m) + 0.5)
+        });
+        let g: Vec<f64> = match &thermal {
+            Some(t) => {
+                let theta0 = t.initial_temp_c - t.inlet_temp_c;
+                let mut g = vec![0.0; n * Q];
+                for x in 0..n {
                     for q in 0..Q {
-                        let (mut si, mut sj, mut sk) = (
-                            i - C[q][0] as isize,
-                            j - C[q][1] as isize,
-                            k - C[q][2] as isize,
-                        );
-                        let mut outside = false;
-                        for (axis, s, nmax) in
-                            [(0usize, &mut si, nx), (1, &mut sj, ny), (2, &mut sk, nz)]
-                        {
-                            if *s < 0 || *s >= nmax {
-                                if model.periodic[axis] {
-                                    *s = (*s + nmax) % nmax;
-                                } else {
-                                    outside = true;
-                                }
-                            }
-                        }
-                        let src_kind = if outside {
-                            Cell::Solid
-                        } else {
-                            cells[idx(si, sj, sk)]
-                        };
-                        dst[q] = match src_kind {
-                            Cell::Fluid => f[idx(si, sj, sk) * Q + q],
-                            Cell::Solid => f[x * Q + OPP[q]],
-                            Cell::Inlet => {
-                                let cu = C[q][0] as f64 * u_in_now[0]
-                                    + C[q][1] as f64 * u_in_now[1]
-                                    + C[q][2] as f64 * u_in_now[2];
-                                f[x * Q + OPP[q]] + 6.0 * W[q] * cu
-                            }
-                            Cell::Outlet => {
-                                let u = vel[x];
-                                let cu = C[q][0] as f64 * u[0]
-                                    + C[q][1] as f64 * u[1]
-                                    + C[q][2] as f64 * u[2];
-                                let uu = u[0] * u[0] + u[1] * u[1] + u[2] * u[2];
-                                -f[x * Q + OPP[q]]
-                                    + 2.0 * W[q] * rho_out_lat * (1.0 + 4.5 * cu * cu - 1.5 * uu)
-                            }
-                        };
+                        g[x * Q + q] = W[q] * theta0;
+                    }
+                }
+                g
+            }
+            None => Vec::new(),
+        };
+        let g_new = g.clone();
+        // Boundary θ-exchange accumulators (per step, lattice units):
+        // Dirichlet walls, inlet, outlet — the audit's second route.
+        let q_wall_lat = 0.0f64;
+        let q_inlet_lat = 0.0f64;
+        let q_outlet_lat = 0.0f64;
+
+        let mut f: Vec<f64> = vec![0.0; n * Q];
+        let feq0 = equilibrium(1.0, [0.0; 3]);
+        for x in 0..n {
+            f[x * Q..(x + 1) * Q].copy_from_slice(&feq0);
+        }
+        let f_new = f.clone();
+        let vel = vec![[0.0f64; 3]; n];
+        let rho = vec![1.0f64; n];
+        let vel_prev = vel.clone();
+        let u_floor = scaling.u_lattice.max(1e-12);
+
+        Ok(Self {
+            model: model.clone(),
+            opts: *opts,
+            scaling,
+            omega,
+            force_prefactor,
+            u_in_lat,
+            rho_out_lat,
+            a_lat,
+            buoy_lat_per_k,
+            t_ref_buoy,
+            t_scale,
+            has_buoyancy,
+            omega_g,
+            temp,
+            temp_prev,
+            g,
+            g_new,
+            q_wall_lat,
+            q_inlet_lat,
+            q_outlet_lat,
+            f,
+            f_new,
+            vel,
+            rho,
+            vel_prev,
+            steps: 0,
+            residual: f64::INFINITY,
+            dx_m,
+            u_floor,
+            solution: None,
+        })
+    }
+
+    /// Timesteps taken so far.
+    pub fn steps(&self) -> usize {
+        self.steps
+    }
+
+    /// Last steadiness residual observed (∞ before the first check).
+    pub fn residual(&self) -> f64 {
+        self.residual
+    }
+
+    /// The hard step budget this solve fails at.
+    pub fn max_steps(&self) -> usize {
+        self.opts.max_steps
+    }
+
+    /// The converged solution, once `advance` has reported [`FlowProgress::Converged`].
+    pub fn into_solution(self) -> Option<Solution> {
+        self.solution
+    }
+
+    /// Run up to `budget` timesteps. Returns [`FlowProgress::Converged`] once
+    /// the field is steady; errors exactly as the one-shot solve does
+    /// (divergence, or the step budget running out before steadiness).
+    pub fn advance(&mut self, budget: usize) -> Result<FlowProgress, SolveError> {
+        if self.solution.is_some() {
+            return Ok(FlowProgress::Converged);
+        }
+        let opts = self.opts;
+        let scaling = self.scaling;
+        let omega = self.omega;
+        let force_prefactor = self.force_prefactor;
+        let u_in_lat = self.u_in_lat;
+        let rho_out_lat = self.rho_out_lat;
+        let a_lat = self.a_lat;
+        let buoy_lat_per_k = self.buoy_lat_per_k;
+        let t_ref_buoy = self.t_ref_buoy;
+        let t_scale = self.t_scale;
+        let has_buoyancy = self.has_buoyancy;
+        let omega_g = self.omega_g;
+        let dx_m = self.dx_m;
+        let u_floor = self.u_floor;
+        let Self {
+            model,
+            temp,
+            temp_prev,
+            g,
+            g_new,
+            q_wall_lat,
+            q_inlet_lat,
+            q_outlet_lat,
+            f,
+            f_new,
+            vel,
+            rho,
+            vel_prev,
+            steps,
+            residual,
+            solution,
+            ..
+        } = self;
+        let (nx, ny, nz) = (
+            model.divisions[0] as isize,
+            model.divisions[1] as isize,
+            model.divisions[2] as isize,
+        );
+        let n = (nx * ny * nz) as usize;
+        let thermal = model.thermal;
+        let cells = &model.cells;
+        let idx = |i: isize, j: isize, k: isize| -> usize { ((k * ny + j) * nx + i) as usize };
+        let mut ran = 0usize;
+
+        while *steps < opts.max_steps && ran < budget {
+            ran += 1;
+            // Smoothstep inlet ramp: avoids the impulsive-start shock.
+            let s = if opts.ramp_steps == 0 {
+                1.0
+            } else {
+                let t = ((*steps + 1) as f64 / opts.ramp_steps as f64).min(1.0);
+                t * t * (3.0 - 2.0 * t)
+            };
+            let u_in_now = [u_in_lat[0] * s, u_in_lat[1] * s, u_in_lat[2] * s];
+
+            // Collision (fluid cells only), macroscopic update included.
+            for x in 0..n {
+                if cells[x] != Cell::Fluid {
+                    continue;
+                }
+                // Scalar moment first: θ from g, so buoyancy sees this
+                // step's temperature.
+                if let (Some(t), Some(_)) = (&thermal, omega_g) {
+                    let gx = &g[x * Q..(x + 1) * Q];
+                    let theta: f64 = gx.iter().sum();
+                    temp[x] = theta + t.inlet_temp_c;
+                }
+                let fx = &mut f[x * Q..(x + 1) * Q];
+                let mut r = 0.0;
+                let mut m = [0.0f64; 3];
+                for (i, fi) in fx.iter().enumerate() {
+                    r += fi;
+                    m[0] += fi * C[i][0] as f64;
+                    m[1] += fi * C[i][1] as f64;
+                    m[2] += fi * C[i][2] as f64;
+                }
+                // Per-cell acceleration: global body force plus Boussinesq
+                // buoyancy when a temperature field is coupled in.
+                let a_cell = if has_buoyancy {
+                    let dtc = temp[x] - t_ref_buoy;
+                    [
+                        a_lat[0] + buoy_lat_per_k[0] * dtc,
+                        a_lat[1] + buoy_lat_per_k[1] * dtc,
+                        a_lat[2] + buoy_lat_per_k[2] * dtc,
+                    ]
+                } else {
+                    a_lat
+                };
+                let u = [
+                    (m[0] + 0.5 * a_cell[0] * r) / r,
+                    (m[1] + 0.5 * a_cell[1] * r) / r,
+                    (m[2] + 0.5 * a_cell[2] * r) / r,
+                ];
+                rho[x] = r;
+                vel[x] = u;
+                let feq = equilibrium(r, u);
+                for i in 0..Q {
+                    let cu = C[i][0] as f64 * u[0] + C[i][1] as f64 * u[1] + C[i][2] as f64 * u[2];
+                    let ca = C[i][0] as f64 * a_cell[0]
+                        + C[i][1] as f64 * a_cell[1]
+                        + C[i][2] as f64 * a_cell[2];
+                    let ua = u[0] * a_cell[0] + u[1] * a_cell[1] + u[2] * a_cell[2];
+                    let guo = force_prefactor * W[i] * r * (3.0 * (ca - ua) + 9.0 * cu * ca);
+                    fx[i] += -omega * (fx[i] - feq[i]) + guo;
+                }
+                // Scalar BGK collision toward w_i·θ·(1 + 3c·u).
+                if let (Some(t), Some(og)) = (&thermal, omega_g) {
+                    let gx = &mut g[x * Q..(x + 1) * Q];
+                    let theta = temp[x] - t.inlet_temp_c;
+                    for (i, gi) in gx.iter_mut().enumerate() {
+                        let cu =
+                            C[i][0] as f64 * u[0] + C[i][1] as f64 * u[1] + C[i][2] as f64 * u[2];
+                        let geq = W[i] * theta * (1.0 + 3.0 * cu);
+                        *gi += -og * (*gi - geq);
                     }
                 }
             }
-        }
-        std::mem::swap(&mut f, &mut f_new);
 
-        // Thermal scalar streaming (M1): pull the g distribution with
-        // boundary rules mirroring the flow lattice — bounce-back =
-        // adiabatic wall, anti-bounce-back = Dirichlet surface (inlet
-        // theta = 0, isothermal walls theta_w), copy-own = zero-gradient
-        // outlet. Per-step boundary theta-exchange is accumulated as the
-        // audit's link-level route.
-        if let Some(t) = &thermal {
-            q_wall_lat = 0.0;
-            q_inlet_lat = 0.0;
-            q_outlet_lat = 0.0;
+            // Streaming (pull) with boundary rules.
             for k in 0..nz {
                 for j in 0..ny {
                     for i in 0..nx {
@@ -442,6 +526,7 @@ pub fn solve_steady(model: &FlowModel, opts: &SolveOptions) -> Result<Solution, 
                         if cells[x] != Cell::Fluid {
                             continue;
                         }
+                        let dst = &mut f_new[x * Q..(x + 1) * Q];
                         for q in 0..Q {
                             let (mut si, mut sj, mut sk) = (
                                 i - C[q][0] as isize,
@@ -460,118 +545,202 @@ pub fn solve_steady(model: &FlowModel, opts: &SolveOptions) -> Result<Solution, 
                                     }
                                 }
                             }
-                            let g_out = g[x * Q + OPP[q]];
                             let src_kind = if outside {
                                 Cell::Solid
                             } else {
                                 cells[idx(si, sj, sk)]
                             };
-                            let val = match src_kind {
-                                Cell::Fluid => g[idx(si, sj, sk) * Q + q],
-                                Cell::Solid => {
-                                    let wall_theta = if outside {
-                                        t.wall_temp_c.map(|w| w - t.inlet_temp_c)
-                                    } else {
-                                        let sx = idx(si, sj, sk);
-                                        model
-                                            .solid_temp_c
-                                            .as_ref()
-                                            .map(|st| st[sx])
-                                            .filter(|v| v.is_finite())
-                                            .or(t.wall_temp_c)
-                                            .map(|w| w - t.inlet_temp_c)
-                                    };
-                                    match wall_theta {
-                                        // Dirichlet: anti-bounce-back.
-                                        Some(tw) => {
-                                            let v = -g_out + 2.0 * W[q] * tw;
-                                            q_wall_lat += v - g_out;
-                                            v
-                                        }
-                                        // Adiabatic: bounce-back (link
-                                        // nets exactly zero).
-                                        None => g_out,
-                                    }
-                                }
+                            dst[q] = match src_kind {
+                                Cell::Fluid => f[idx(si, sj, sk) * Q + q],
+                                Cell::Solid => f[x * Q + OPP[q]],
                                 Cell::Inlet => {
-                                    // Dirichlet theta = 0 at the inlet
-                                    // surface, moving at the (ramped)
-                                    // inlet velocity.
                                     let cu = C[q][0] as f64 * u_in_now[0]
                                         + C[q][1] as f64 * u_in_now[1]
                                         + C[q][2] as f64 * u_in_now[2];
-                                    let v = -g_out + 2.0 * W[q] * 0.0 * (1.0 + 3.0 * cu);
-                                    q_inlet_lat += v - g_out;
-                                    v
+                                    f[x * Q + OPP[q]] + 6.0 * W[q] * cu
                                 }
                                 Cell::Outlet => {
-                                    // Zero-gradient: copy own
-                                    // post-collision value.
-                                    let v = g[x * Q + q];
-                                    q_outlet_lat += g_out - v;
-                                    v
+                                    let u = vel[x];
+                                    let cu = C[q][0] as f64 * u[0]
+                                        + C[q][1] as f64 * u[1]
+                                        + C[q][2] as f64 * u[2];
+                                    let uu = u[0] * u[0] + u[1] * u[1] + u[2] * u[2];
+                                    -f[x * Q + OPP[q]]
+                                        + 2.0
+                                            * W[q]
+                                            * rho_out_lat
+                                            * (1.0 + 4.5 * cu * cu - 1.5 * uu)
                                 }
                             };
-                            g_new[x * Q + q] = val;
                         }
                     }
                 }
             }
-            std::mem::swap(&mut g, &mut g_new);
-        }
-        steps += 1;
+            std::mem::swap(f, f_new);
 
-        if steps.is_multiple_of(opts.check_every) && steps >= opts.ramp_steps {
-            let mut max_delta = 0.0f64;
-            let mut max_tdelta = 0.0f64;
-            let mut finite = true;
-            for x in 0..n {
-                if cells[x] != Cell::Fluid {
-                    continue;
-                }
-                let (u, p) = (vel[x], vel_prev[x]);
-                for a in 0..3 {
-                    if !u[a].is_finite() {
-                        finite = false;
+            // Thermal scalar streaming (M1): pull the g distribution with
+            // boundary rules mirroring the flow lattice — bounce-back =
+            // adiabatic wall, anti-bounce-back = Dirichlet surface (inlet
+            // theta = 0, isothermal walls theta_w), copy-own = zero-gradient
+            // outlet. Per-step boundary theta-exchange is accumulated as the
+            // audit's link-level route.
+            if let Some(t) = &thermal {
+                *q_wall_lat = 0.0;
+                *q_inlet_lat = 0.0;
+                *q_outlet_lat = 0.0;
+                for k in 0..nz {
+                    for j in 0..ny {
+                        for i in 0..nx {
+                            let x = idx(i, j, k);
+                            if cells[x] != Cell::Fluid {
+                                continue;
+                            }
+                            for q in 0..Q {
+                                let (mut si, mut sj, mut sk) = (
+                                    i - C[q][0] as isize,
+                                    j - C[q][1] as isize,
+                                    k - C[q][2] as isize,
+                                );
+                                let mut outside = false;
+                                for (axis, s, nmax) in
+                                    [(0usize, &mut si, nx), (1, &mut sj, ny), (2, &mut sk, nz)]
+                                {
+                                    if *s < 0 || *s >= nmax {
+                                        if model.periodic[axis] {
+                                            *s = (*s + nmax) % nmax;
+                                        } else {
+                                            outside = true;
+                                        }
+                                    }
+                                }
+                                let g_out = g[x * Q + OPP[q]];
+                                let src_kind = if outside {
+                                    Cell::Solid
+                                } else {
+                                    cells[idx(si, sj, sk)]
+                                };
+                                let val = match src_kind {
+                                    Cell::Fluid => g[idx(si, sj, sk) * Q + q],
+                                    Cell::Solid => {
+                                        let wall_theta = if outside {
+                                            t.wall_temp_c.map(|w| w - t.inlet_temp_c)
+                                        } else {
+                                            let sx = idx(si, sj, sk);
+                                            model
+                                                .solid_temp_c
+                                                .as_ref()
+                                                .map(|st| st[sx])
+                                                .filter(|v| v.is_finite())
+                                                .or(t.wall_temp_c)
+                                                .map(|w| w - t.inlet_temp_c)
+                                        };
+                                        match wall_theta {
+                                            // Dirichlet: anti-bounce-back.
+                                            Some(tw) => {
+                                                let v = -g_out + 2.0 * W[q] * tw;
+                                                *q_wall_lat += v - g_out;
+                                                v
+                                            }
+                                            // Adiabatic: bounce-back (link
+                                            // nets exactly zero).
+                                            None => g_out,
+                                        }
+                                    }
+                                    Cell::Inlet => {
+                                        // Dirichlet theta = 0 at the inlet
+                                        // surface, moving at the (ramped)
+                                        // inlet velocity.
+                                        let cu = C[q][0] as f64 * u_in_now[0]
+                                            + C[q][1] as f64 * u_in_now[1]
+                                            + C[q][2] as f64 * u_in_now[2];
+                                        let v = -g_out + 2.0 * W[q] * 0.0 * (1.0 + 3.0 * cu);
+                                        *q_inlet_lat += v - g_out;
+                                        v
+                                    }
+                                    Cell::Outlet => {
+                                        // Zero-gradient: copy own
+                                        // post-collision value.
+                                        let v = g[x * Q + q];
+                                        *q_outlet_lat += g_out - v;
+                                        v
+                                    }
+                                };
+                                g_new[x * Q + q] = val;
+                            }
+                        }
                     }
-                    max_delta = max_delta.max((u[a] - p[a]).abs());
                 }
+                std::mem::swap(g, g_new);
+            }
+            *steps += 1;
+
+            if steps.is_multiple_of(opts.check_every) && *steps >= opts.ramp_steps {
+                let mut max_delta = 0.0f64;
+                let mut max_tdelta = 0.0f64;
+                let mut finite = true;
+                for x in 0..n {
+                    if cells[x] != Cell::Fluid {
+                        continue;
+                    }
+                    let (u, p) = (vel[x], vel_prev[x]);
+                    for a in 0..3 {
+                        if !u[a].is_finite() {
+                            finite = false;
+                        }
+                        max_delta = max_delta.max((u[a] - p[a]).abs());
+                    }
+                    if thermal.is_some() {
+                        if !temp[x].is_finite() {
+                            finite = false;
+                        }
+                        max_tdelta = max_tdelta.max((temp[x] - temp_prev[x]).abs());
+                    }
+                }
+                if !finite {
+                    return Err(SolveError::Diverged { step: *steps });
+                }
+                *residual = (max_delta / u_floor).max(max_tdelta / t_scale);
+                vel_prev.copy_from_slice(vel);
                 if thermal.is_some() {
-                    if !temp[x].is_finite() {
-                        finite = false;
-                    }
-                    max_tdelta = max_tdelta.max((temp[x] - temp_prev[x]).abs());
+                    temp_prev.copy_from_slice(temp);
+                }
+                if *residual < opts.steady_tol {
+                    *solution = Some(finish(
+                        model,
+                        &scaling,
+                        *steps,
+                        *residual,
+                        vel,
+                        rho,
+                        temp,
+                        (*q_wall_lat, *q_inlet_lat, *q_outlet_lat),
+                        dx_m,
+                    ));
+                    return Ok(FlowProgress::Converged);
                 }
             }
-            if !finite {
-                return Err(SolveError::Diverged { step: steps });
-            }
-            residual = (max_delta / u_floor).max(max_tdelta / t_scale);
-            vel_prev.copy_from_slice(&vel);
-            if thermal.is_some() {
-                temp_prev.copy_from_slice(&temp);
-            }
-            if residual < opts.steady_tol {
-                return Ok(finish(
-                    model,
-                    &scaling,
-                    steps,
-                    residual,
-                    &vel,
-                    &rho,
-                    &temp,
-                    (q_wall_lat, q_inlet_lat, q_outlet_lat),
-                    dx_m,
-                ));
-            }
         }
-    }
 
-    Err(SolveError::NotConverged {
-        steps,
-        residual,
-        tol: opts.steady_tol,
-    })
+        if *steps >= opts.max_steps {
+            return Err(SolveError::NotConverged {
+                steps: *steps,
+                residual: *residual,
+                tol: opts.steady_tol,
+            });
+        }
+        Ok(FlowProgress::Running)
+    }
+}
+
+/// Run the lattice to steady state.
+pub fn solve_steady(model: &FlowModel, opts: &SolveOptions) -> Result<Solution, SolveError> {
+    let mut stepper = FlowStepper::new(model, opts)?;
+    match stepper.advance(usize::MAX)? {
+        FlowProgress::Converged => Ok(stepper
+            .into_solution()
+            .expect("Converged advance stores the solution")),
+        FlowProgress::Running => unreachable!("an unbounded advance either converges or errors"),
+    }
 }
 
 /// Assemble the SI solution from the converged lattice fields.
@@ -1039,6 +1208,27 @@ mod tests {
         m.inlet_velocity_m_s = [u, 0.0, 0.0];
         m.thermal = Some(crate::model::ThermalTransport::AIR_20C);
         m
+    }
+
+    /// Driving the stepper in small chunks (the streamed-progress path) must
+    /// produce exactly the one-shot solution on the same model.
+    #[test]
+    fn chunked_stepper_matches_the_one_shot_solve() {
+        let m = thermal_duct(20, 5, 0.08);
+        let opts = SolveOptions::default();
+        let one_shot = solve_steady(&m, &opts).expect("one-shot duct");
+
+        let mut stepper = FlowStepper::new(&m, &opts).expect("stepper");
+        let mut chunks = 0usize;
+        loop {
+            match stepper.advance(500).expect("advance") {
+                FlowProgress::Converged => break,
+                FlowProgress::Running => chunks += 1,
+            }
+        }
+        assert!(chunks >= 2, "the solve must have visibly chunked");
+        let stepped = stepper.into_solution().expect("solution");
+        assert_eq!(one_shot, stepped);
     }
 
     /// M1: adiabatic duct conserves enthalpy — outlet temperature equals

--- a/crates/vcad-kernel-neutronics/src/spec.rs
+++ b/crates/vcad-kernel-neutronics/src/spec.rs
@@ -29,7 +29,9 @@ use crate::geometry::{Geometry, Layer};
 use crate::groups::group_of_energy_ev;
 use crate::materials;
 use crate::tally::Estimate;
-use crate::transport::{run, ConfigError, RunConfig, RunResult, Source};
+use crate::transport::{
+    run, ConfigError, RunConfig, RunResult, Source, TransportProgress, TransportRun,
+};
 
 /// A literal value or the name of a document parameter.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -403,6 +405,57 @@ pub fn evaluate(
         })
         .collect();
     Ok((doses, result))
+}
+
+/// Stepwise form of [`evaluate`]: resolve once, transport whole batches
+/// under a budget via the inner [`TransportRun`], then assemble the same
+/// `(doses, result)` pair — bit-identical to the one-shot (each batch
+/// owns an independent RNG stream).
+pub struct EvaluateRun {
+    resolved: ResolvedShield,
+    run: TransportRun,
+}
+
+impl EvaluateRun {
+    /// Resolve the spec and set up the transport tallies.
+    pub fn new(spec: &ShieldSpec, params: &BTreeMap<String, f64>) -> Result<Self, SpecError> {
+        let resolved = spec.resolve(params)?;
+        let run = TransportRun::new(&resolved.config)
+            .map_err(|e: ConfigError| SpecError::Config(e.to_string()))?;
+        Ok(EvaluateRun { resolved, run })
+    }
+
+    /// Batches transported so far.
+    pub fn batches_done(&self) -> usize {
+        self.run.batches_done()
+    }
+
+    /// Total batches this run will transport.
+    pub fn total_batches(&self) -> usize {
+        self.run.total_batches()
+    }
+
+    /// Transport up to `budget` whole batches (min 1).
+    pub fn advance(&mut self, budget: usize) -> TransportProgress {
+        self.run.advance(budget)
+    }
+
+    /// Assemble the same payload [`evaluate`] returns (advance to
+    /// completion first).
+    pub fn finish(self) -> (Vec<DetectorDose>, RunResult, ResolvedShield) {
+        let result = self.run.finish();
+        let doses = self
+            .resolved
+            .detector_regions
+            .iter()
+            .map(|(label, region)| DetectorDose {
+                label: label.clone(),
+                dose_usv_per_h: result
+                    .dose_rate_usv_per_h(*region, self.resolved.source_rate_n_per_s),
+            })
+            .collect();
+        (doses, result, self.resolved)
+    }
 }
 
 /// The compass pass: d(dose at `detector_label`)/d(named thickness

--- a/crates/vcad-kernel-neutronics/src/transport.rs
+++ b/crates/vcad-kernel-neutronics/src/transport.rs
@@ -315,54 +315,138 @@ fn sample_row(row: &[f64; N_GROUPS], u: f64) -> usize {
 }
 
 /// Run the Monte Carlo. Deterministic in `config` (including seed).
+///
+/// Implemented as an unbounded [`TransportRun`] drive, so the one-shot
+/// and chunked paths are identical by construction.
 pub fn run(config: &RunConfig) -> Result<RunResult, ConfigError> {
-    config.geometry.validate().map_err(ConfigError::Geometry)?;
-    let kind = match (&config.geometry, config.source) {
-        (Geometry::Sphere(_), Source::IsotropicPoint) => GeomKind::Sphere,
-        (Geometry::Slab(_), Source::BeamPlusX | Source::IsotropicHalfSpace) => GeomKind::Slab,
-        _ => return Err(ConfigError::SourceGeometryMismatch),
-    };
-    if config.source_group >= N_GROUPS {
-        return Err(ConfigError::BadSourceGroup(config.source_group));
+    let mut run = TransportRun::new(config)?;
+    run.advance(usize::MAX);
+    Ok(run.finish())
+}
+
+/// What a bounded [`TransportRun::advance`] call concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportProgress {
+    /// Budget exhausted; more batches remain. Call `advance` again.
+    Running,
+    /// All batches done; take the result with [`TransportRun::finish`].
+    Done,
+}
+
+/// Stepwise driver for the Monte Carlo: [`TransportRun::new`] validates
+/// the config, each [`TransportRun::advance`] transports up to a budget
+/// of whole batches (each batch owns an independent RNG stream, so
+/// chunked runs are bit-identical to [`run`]), and
+/// [`TransportRun::finish`] assembles the [`RunResult`].
+pub struct TransportRun {
+    config: RunConfig,
+    kind: GeomKind,
+    bounds: Vec<f64>,
+    n_regions: usize,
+    volumes: Vec<f64>,
+    h_factors: [f64; N_GROUPS],
+    flux_b: Vec<Vec<[f64; N_GROUPS]>>,
+    dose_b: Vec<Vec<f64>>,
+    current_b: Vec<Vec<[f64; N_GROUPS]>>,
+    absorbed_b: Vec<f64>,
+    leak_out_b: Vec<f64>,
+    leak_back_b: Vec<f64>,
+    th_frac_b: Vec<f64>,
+    th_cols_b: Vec<f64>,
+    th_r2_b: Vec<f64>,
+    truncated: u64,
+    balance_max_dev: f64,
+    batches_done: usize,
+}
+
+impl TransportRun {
+    /// Validate the config and set up the tallies.
+    pub fn new(config: &RunConfig) -> Result<Self, ConfigError> {
+        config.geometry.validate().map_err(ConfigError::Geometry)?;
+        let kind = match (&config.geometry, config.source) {
+            (Geometry::Sphere(_), Source::IsotropicPoint) => GeomKind::Sphere,
+            (Geometry::Slab(_), Source::BeamPlusX | Source::IsotropicHalfSpace) => GeomKind::Slab,
+            _ => return Err(ConfigError::SourceGeometryMismatch),
+        };
+        if config.source_group >= N_GROUPS {
+            return Err(ConfigError::BadSourceGroup(config.source_group));
+        }
+        if config.batches < 2 || config.histories_per_batch == 0 {
+            return Err(ConfigError::DegenerateStatistics);
+        }
+
+        let bounds = config.geometry.boundaries_cm();
+        let n_regions = config.geometry.region_count();
+        let volumes: Vec<f64> = (0..n_regions)
+            .map(|i| config.geometry.region_volume_cc(i))
+            .collect();
+        let h_factors = group_dose_factors_psv_cm2();
+        let nb = config.batches;
+        Ok(TransportRun {
+            config: config.clone(),
+            kind,
+            bounds,
+            n_regions,
+            volumes,
+            h_factors,
+            flux_b: vec![vec![[0.0f64; N_GROUPS]; n_regions]; nb],
+            dose_b: vec![vec![0.0f64; n_regions]; nb],
+            current_b: vec![vec![[0.0f64; N_GROUPS]; n_regions]; nb],
+            absorbed_b: vec![0.0f64; nb],
+            leak_out_b: vec![0.0f64; nb],
+            leak_back_b: vec![0.0f64; nb],
+            th_frac_b: vec![0.0f64; nb],
+            th_cols_b: vec![0.0f64; nb],
+            th_r2_b: vec![0.0f64; nb],
+            truncated: 0,
+            balance_max_dev: 0.0,
+            batches_done: 0,
+        })
     }
-    if config.batches < 2 || config.histories_per_batch == 0 {
-        return Err(ConfigError::DegenerateStatistics);
+
+    /// Batches transported so far.
+    pub fn batches_done(&self) -> usize {
+        self.batches_done
     }
 
-    let bounds = config.geometry.boundaries_cm();
-    let n_regions = config.geometry.region_count();
-    let mats: Vec<_> = config
-        .geometry
-        .layers()
-        .iter()
-        .map(|l| &l.material)
-        .collect();
-    let volumes: Vec<f64> = (0..n_regions)
-        .map(|i| config.geometry.region_volume_cc(i))
-        .collect();
-    let h_factors = group_dose_factors_psv_cm2();
-    let hpb = config.histories_per_batch;
+    /// Total batches this run will transport.
+    pub fn total_batches(&self) -> usize {
+        self.config.batches
+    }
 
-    // Per-batch reduced values.
-    let nb = config.batches;
-    let mut flux_b = vec![vec![[0.0f64; N_GROUPS]; n_regions]; nb];
-    let mut dose_b = vec![vec![0.0f64; n_regions]; nb];
-    let mut current_b = vec![vec![[0.0f64; N_GROUPS]; n_regions]; nb];
-    let mut absorbed_b = vec![0.0f64; nb];
-    let mut leak_out_b = vec![0.0f64; nb];
-    let mut leak_back_b = vec![0.0f64; nb];
-    let mut th_frac_b = vec![0.0f64; nb];
-    let mut th_cols_b = vec![0.0f64; nb];
-    let mut th_r2_b = vec![0.0f64; nb];
-    let mut truncated: u64 = 0;
-    let mut balance_max_dev: f64 = 0.0;
+    /// Transport up to `budget` whole batches (min 1).
+    pub fn advance(&mut self, budget: usize) -> TransportProgress {
+        let total = self.config.batches;
+        let mut left = budget.max(1);
+        while self.batches_done < total && left > 0 {
+            self.run_batch(self.batches_done);
+            self.batches_done += 1;
+            left -= 1;
+        }
+        if self.batches_done < total {
+            TransportProgress::Running
+        } else {
+            TransportProgress::Done
+        }
+    }
 
-    for (batch, ((flux, dose), current)) in flux_b
-        .iter_mut()
-        .zip(dose_b.iter_mut())
-        .zip(current_b.iter_mut())
-        .enumerate()
-    {
+    /// Transport one batch on its own RNG stream and reduce its tallies.
+    fn run_batch(&mut self, batch: usize) {
+        let config = &self.config;
+        let kind = self.kind;
+        let bounds = &self.bounds;
+        let n_regions = self.n_regions;
+        let mats: Vec<_> = config
+            .geometry
+            .layers()
+            .iter()
+            .map(|l| &l.material)
+            .collect();
+        let hpb = config.histories_per_batch;
+        let flux = &mut self.flux_b[batch];
+        let dose = &mut self.dose_b[batch];
+        let current = &mut self.current_b[batch];
+
         let mut rng = Rng::stream(config.seed, batch as u64);
         let mut track = vec![[0.0f64; N_GROUPS]; n_regions];
         let mut cur = vec![[0.0f64; N_GROUPS]; n_regions];
@@ -479,93 +563,105 @@ pub fn run(config: &RunConfig) -> Result<RunResult, ConfigError> {
         let h = hpb as f64;
         for r in 0..n_regions {
             for g in 0..N_GROUPS {
-                flux[r][g] = track[r][g] / (volumes[r] * h);
+                flux[r][g] = track[r][g] / (self.volumes[r] * h);
                 current[r][g] = cur[r][g] / h;
-                dose[r] += h_factors[g] * flux[r][g];
+                dose[r] += self.h_factors[g] * flux[r][g];
             }
         }
-        absorbed_b[batch] = absorbed as f64 / h;
-        leak_out_b[batch] = leak_out as f64 / h;
-        leak_back_b[batch] = leak_back as f64 / h;
+        self.absorbed_b[batch] = absorbed as f64 / h;
+        self.leak_out_b[batch] = leak_out as f64 / h;
+        self.leak_back_b[batch] = leak_back as f64 / h;
         let live = h - batch_trunc as f64;
         if live > 0.0 {
             let dev = ((absorbed + leak_out + leak_back) as f64 / live - 1.0).abs();
-            balance_max_dev = balance_max_dev.max(dev);
+            self.balance_max_dev = self.balance_max_dev.max(dev);
         }
-        th_frac_b[batch] = th_count as f64 / h;
-        th_cols_b[batch] = if th_count > 0 {
+        self.th_frac_b[batch] = th_count as f64 / h;
+        self.th_cols_b[batch] = if th_count > 0 {
             th_cols as f64 / th_count as f64
         } else {
             0.0
         };
-        th_r2_b[batch] = if th_count > 0 {
+        self.th_r2_b[batch] = if th_count > 0 {
             th_r2 / th_count as f64
         } else {
             0.0
         };
-        truncated += batch_trunc;
+        self.truncated += batch_trunc;
     }
 
-    // Assemble estimates.
-    let mut flux_per_source = Vec::with_capacity(n_regions);
-    let mut dose_per_source_psv = Vec::with_capacity(n_regions);
-    let mut net_outward_current = Vec::with_capacity(n_regions);
-    let mut col = vec![0.0f64; nb];
-    for r in 0..n_regions {
-        let mut fg: [Estimate; N_GROUPS] = [Estimate::from_batches(&[0.0, 0.0]); N_GROUPS];
-        let mut cg: [Estimate; N_GROUPS] = [Estimate::from_batches(&[0.0, 0.0]); N_GROUPS];
-        for g in 0..N_GROUPS {
-            for b in 0..nb {
-                col[b] = flux_b[b][r][g];
+    /// Assemble the result from the transported batches. Callable once
+    /// `advance` has reported [`TransportProgress::Done`]; the batch
+    /// estimates are only honest over the full batch count, so finishing
+    /// early panics (a programming error, not a physics outcome).
+    pub fn finish(self) -> RunResult {
+        assert_eq!(
+            self.batches_done, self.config.batches,
+            "TransportRun::finish called before all batches were transported"
+        );
+        let config = &self.config;
+        let n_regions = self.n_regions;
+        let nb = config.batches;
+        let mut flux_per_source = Vec::with_capacity(n_regions);
+        let mut dose_per_source_psv = Vec::with_capacity(n_regions);
+        let mut net_outward_current = Vec::with_capacity(n_regions);
+        let mut col = vec![0.0f64; nb];
+        for r in 0..n_regions {
+            let mut fg: [Estimate; N_GROUPS] = [Estimate::from_batches(&[0.0, 0.0]); N_GROUPS];
+            let mut cg: [Estimate; N_GROUPS] = [Estimate::from_batches(&[0.0, 0.0]); N_GROUPS];
+            for g in 0..N_GROUPS {
+                for (b, c) in col.iter_mut().enumerate() {
+                    *c = self.flux_b[b][r][g];
+                }
+                fg[g] = Estimate::from_batches(&col);
+                for (b, c) in col.iter_mut().enumerate() {
+                    *c = self.current_b[b][r][g];
+                }
+                cg[g] = Estimate::from_batches(&col);
             }
-            fg[g] = Estimate::from_batches(&col);
-            for b in 0..nb {
-                col[b] = current_b[b][r][g];
+            flux_per_source.push(fg);
+            net_outward_current.push(cg);
+            for (b, c) in col.iter_mut().enumerate() {
+                *c = self.dose_b[b][r];
             }
-            cg[g] = Estimate::from_batches(&col);
+            dose_per_source_psv.push(Estimate::from_batches(&col));
         }
-        flux_per_source.push(fg);
-        net_outward_current.push(cg);
-        for b in 0..nb {
-            col[b] = dose_b[b][r];
-        }
-        dose_per_source_psv.push(Estimate::from_batches(&col));
-    }
 
-    let thermalization = if kind == GeomKind::Sphere {
-        Some(Thermalization {
-            fraction: Estimate::from_batches(&th_frac_b),
-            mean_collisions: Estimate::from_batches(&th_cols_b),
-            mean_r2_cm2: Estimate::from_batches(&th_r2_b),
-        })
-    } else {
-        None
-    };
+        let thermalization = if self.kind == GeomKind::Sphere {
+            Some(Thermalization {
+                fraction: Estimate::from_batches(&self.th_frac_b),
+                mean_collisions: Estimate::from_batches(&self.th_cols_b),
+                mean_r2_cm2: Estimate::from_batches(&self.th_r2_b),
+            })
+        } else {
+            None
+        };
 
-    Ok(RunResult {
-        flux_per_source,
-        dose_per_source_psv,
-        net_outward_current,
-        absorbed: Estimate::from_batches(&absorbed_b),
-        leaked_out: Estimate::from_batches(&leak_out_b),
-        leaked_back: Estimate::from_batches(&leak_back_b),
-        balance_max_dev,
-        truncated_histories: truncated,
-        total_histories: (config.batches * hpb) as u64,
-        thermalization,
-        provenance: RunProvenance {
-            seed: config.seed,
-            histories_per_batch: hpb,
-            batches: config.batches,
-            max_collisions: config.max_collisions,
-            groups: N_GROUPS,
-            energy_model: match config.energy_model {
-                EnergyModel::Multigroup => "multigroup".to_string(),
-                EnergyModel::ExactKinematics => "exact-kinematics".to_string(),
+        RunResult {
+            flux_per_source,
+            dose_per_source_psv,
+            net_outward_current,
+            absorbed: Estimate::from_batches(&self.absorbed_b),
+            leaked_out: Estimate::from_batches(&self.leak_out_b),
+            leaked_back: Estimate::from_batches(&self.leak_back_b),
+            balance_max_dev: self.balance_max_dev,
+            truncated_histories: self.truncated,
+            total_histories: (config.batches * config.histories_per_batch) as u64,
+            thermalization,
+            provenance: RunProvenance {
+                seed: config.seed,
+                histories_per_batch: config.histories_per_batch,
+                batches: config.batches,
+                max_collisions: config.max_collisions,
+                groups: N_GROUPS,
+                energy_model: match config.energy_model {
+                    EnergyModel::Multigroup => "multigroup".to_string(),
+                    EnergyModel::ExactKinematics => "exact-kinematics".to_string(),
+                },
+                library: LIBRARY_VERSION.to_string(),
             },
-            library: LIBRARY_VERSION.to_string(),
-        },
-    })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -609,6 +705,54 @@ mod tests {
         let c3 = RunConfig::new(g(), Source::IsotropicPoint, 500, 54321);
         let r3 = run(&c3).unwrap();
         assert_ne!(r1.flux_per_source[0][0].mean, r3.flux_per_source[0][0].mean);
+    }
+
+    #[test]
+    fn chunked_run_matches_the_one_shot() {
+        let g = || {
+            Geometry::Sphere(vec![
+                Layer::new(crate::materials::water(), 100.0),
+                Layer::new(crate::materials::air(), 50.0),
+            ])
+        };
+        let c = RunConfig::new(g(), Source::IsotropicPoint, 300, 99);
+        let one_shot = run(&c).unwrap();
+        let mut chunked = TransportRun::new(&c).unwrap();
+        let mut calls = 0;
+        while chunked.advance(3) == TransportProgress::Running {
+            calls += 1;
+        }
+        assert!(calls > 2, "budget too generous to exercise chunking");
+        let r = chunked.finish();
+        // Bit-identical: every batch owns an independent RNG stream, so
+        // chunk boundaries cannot perturb the physics.
+        for reg in 0..2 {
+            for gr in 0..N_GROUPS {
+                assert_eq!(
+                    one_shot.flux_per_source[reg][gr].mean.to_bits(),
+                    r.flux_per_source[reg][gr].mean.to_bits()
+                );
+                assert_eq!(
+                    one_shot.flux_per_source[reg][gr].rse.to_bits(),
+                    r.flux_per_source[reg][gr].rse.to_bits()
+                );
+            }
+            assert_eq!(
+                one_shot.dose_per_source_psv[reg].mean.to_bits(),
+                r.dose_per_source_psv[reg].mean.to_bits()
+            );
+        }
+        assert_eq!(one_shot.absorbed.mean.to_bits(), r.absorbed.mean.to_bits());
+        assert_eq!(
+            one_shot.leaked_out.mean.to_bits(),
+            r.leaked_out.mean.to_bits()
+        );
+        assert_eq!(
+            one_shot.balance_max_dev.to_bits(),
+            r.balance_max_dev.to_bits()
+        );
+        assert_eq!(one_shot.truncated_histories, r.truncated_histories);
+        assert_eq!(one_shot.provenance, r.provenance);
     }
 
     #[test]

--- a/crates/vcad-kernel-particle/src/optimize.rs
+++ b/crates/vcad-kernel-particle/src/optimize.rs
@@ -143,6 +143,120 @@ pub fn maximize(
     }
 }
 
+/// A multi-start FD-ascent plan over the box `[lo, hi]`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MultiStart {
+    /// Lower bounds per variable.
+    pub lo: Vec<f64>,
+    /// Upper bounds per variable.
+    pub hi: Vec<f64>,
+    /// Explicit first start point; when present it replaces the first
+    /// seed fraction's point.
+    pub explicit_start: Option<Vec<f64>>,
+    /// Seed fractions of the box, one start each (e.g. `[0.2, 0.5, 0.8]`).
+    pub seed_fractions: Vec<f64>,
+    /// Ascent options shared by every start.
+    pub opts: FdOptions,
+}
+
+impl MultiStart {
+    /// The start point for start index `k`.
+    fn x0(&self, k: usize) -> Vec<f64> {
+        if k == 0 {
+            if let Some(x0) = &self.explicit_start {
+                return x0.clone();
+            }
+        }
+        let f = self.seed_fractions[k];
+        self.lo
+            .iter()
+            .zip(&self.hi)
+            .map(|(a, b)| a + f * (b - a))
+            .collect()
+    }
+}
+
+/// Stepwise driver for a multi-start [`maximize`] search: each
+/// [`MultiStartRun::advance_one`] runs exactly one complete start, so a
+/// host can stream per-start progress. The one-shot
+/// [`multi_start_maximize`] is implemented on top, making the two paths
+/// identical by construction.
+#[derive(Debug, Clone)]
+pub struct MultiStartRun {
+    plan: MultiStart,
+    /// Per-start results, in start order.
+    starts: Vec<FdResult>,
+    best: Option<usize>,
+}
+
+impl MultiStartRun {
+    /// Set up the run. Panics if the plan has no seed fractions.
+    pub fn new(plan: MultiStart) -> Self {
+        assert!(
+            !plan.seed_fractions.is_empty(),
+            "multi-start needs at least one seed fraction"
+        );
+        MultiStartRun {
+            plan,
+            starts: Vec::new(),
+            best: None,
+        }
+    }
+
+    /// Starts completed so far.
+    pub fn starts_done(&self) -> usize {
+        self.starts.len()
+    }
+
+    /// Total starts this run will perform.
+    pub fn total_starts(&self) -> usize {
+        self.plan.seed_fractions.len()
+    }
+
+    /// Run the next start to completion against `f`. Returns the just-
+    /// finished start's result, or `None` when every start already ran.
+    pub fn advance_one(&mut self, f: &mut dyn FnMut(&[f64]) -> f64) -> Option<&FdResult> {
+        let k = self.starts.len();
+        if k >= self.total_starts() {
+            return None;
+        }
+        let x0 = self.plan.x0(k);
+        let r = maximize(f, &x0, &self.plan.lo, &self.plan.hi, &self.plan.opts);
+        let better = self
+            .best
+            .map(|b| r.value > self.starts[b].value)
+            .unwrap_or(true);
+        self.starts.push(r);
+        if better {
+            self.best = Some(k);
+        }
+        self.starts.last()
+    }
+
+    /// Per-start results so far, in start order.
+    pub fn starts(&self) -> &[FdResult] {
+        &self.starts
+    }
+
+    /// The best start so far (`None` before the first `advance_one`).
+    pub fn best(&self) -> Option<&FdResult> {
+        self.best.map(|b| &self.starts[b])
+    }
+}
+
+/// One-shot multi-start maximize: every start in [`MultiStart`] run to
+/// completion via [`MultiStartRun`]. Returns `(per-start results, best
+/// index)`.
+pub fn multi_start_maximize(
+    f: &mut dyn FnMut(&[f64]) -> f64,
+    plan: MultiStart,
+) -> (Vec<FdResult>, usize) {
+    let mut run = MultiStartRun::new(plan);
+    while run.advance_one(f).is_some() {}
+    let best = run.best.expect("at least one start ran");
+    (run.starts, best)
+}
+
 /// An objective that returns its value and gradient together.
 pub type ValueAndGradFn = dyn FnMut(&[f64]) -> (f64, Vec<f64>);
 
@@ -224,6 +338,34 @@ pub fn maximize_with_gradient(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stepwise_multi_start_matches_the_one_shot() {
+        // Multimodal 1D objective; three seeds land in different basins.
+        let obj = |x: &[f64]| (3.0 * x[0]).sin() + 0.5 * x[0];
+        let plan = MultiStart {
+            lo: vec![0.0],
+            hi: vec![6.0],
+            explicit_start: None,
+            seed_fractions: vec![0.2, 0.5, 0.8],
+            opts: FdOptions::default(),
+        };
+        let (one_shot, best_idx) = multi_start_maximize(&mut { obj }, plan.clone());
+        let mut run = MultiStartRun::new(plan);
+        let mut f = obj;
+        let mut n = 0;
+        while run.advance_one(&mut f).is_some() {
+            n += 1;
+            assert_eq!(run.starts_done(), n);
+        }
+        assert_eq!(n, 3);
+        // Bit-identical per start and same winner.
+        assert_eq!(run.starts(), &one_shot[..]);
+        assert_eq!(
+            run.best().unwrap().value.to_bits(),
+            one_shot[best_idx].value.to_bits()
+        );
+    }
 
     #[test]
     fn gradient_driven_ascent_climbs() {

--- a/crates/vcad-kernel-particle/src/trace.rs
+++ b/crates/vcad-kernel-particle/src/trace.rs
@@ -474,9 +474,30 @@ impl<'a> Tracer<'a> {
 
     /// Launch `n` particles at rest on the launch shell, on a deterministic
     /// grid of polar angles (uniform in cos θ), and trace each.
+    ///
+    /// Implemented over [`Self::launch_ensemble_range`], so a chunked
+    /// drive over subranges is bit-identical by construction.
     pub fn launch_ensemble(&self, species: Species, n: usize) -> Vec<TraceOutcome> {
         let n = n.max(2);
-        (0..n)
+        self.launch_ensemble_range(species, n, 0, n)
+    }
+
+    /// Trace the particles `start..end` of the same deterministic
+    /// `n`-particle launch grid [`Self::launch_ensemble`] uses. Each
+    /// particle depends only on `(k, n)`, so concatenating range results
+    /// reproduces the full ensemble bit-identically — the seam the
+    /// chunked WASM driver stands on. `n` is clamped to ≥ 2 exactly as
+    /// in `launch_ensemble`; `end` is clamped to `n`.
+    pub fn launch_ensemble_range(
+        &self,
+        species: Species,
+        n: usize,
+        start: usize,
+        end: usize,
+    ) -> Vec<TraceOutcome> {
+        let n = n.max(2);
+        let end = end.min(n);
+        (start..end)
             .map(|k| {
                 let c = -self.opts.launch_cos_max
                     + 2.0 * self.opts.launch_cos_max * k as f64 / (n - 1) as f64;
@@ -570,6 +591,33 @@ mod tests {
                 o.fate,
                 o.core_passes
             );
+        }
+    }
+
+    #[test]
+    fn chunked_ensemble_ranges_match_the_one_shot() {
+        // Concatenated launch_ensemble_range chunks must reproduce
+        // launch_ensemble bit-identically (each particle depends only on
+        // its index and the ensemble size).
+        let device = Device::classic_fusor(120.0, 40.0, 5, 1.0, -30_000.0);
+        let sol = solve(&device, 61, 121, &SolveOptions::default()).unwrap();
+        let fields = FieldMap::new(&device, &sol);
+        let tracer = Tracer::new(&device, &fields, &sol, TraceOptions::default());
+        let n = 9;
+        let one_shot = tracer.launch_ensemble(DEUTERON, n);
+        let mut chunked = Vec::new();
+        let mut start = 0;
+        while start < n {
+            let end = (start + 4).min(n);
+            chunked.extend(tracer.launch_ensemble_range(DEUTERON, n, start, end));
+            start = end;
+        }
+        assert_eq!(one_shot.len(), chunked.len());
+        for (a, b) in one_shot.iter().zip(&chunked) {
+            assert_eq!(a.fate, b.fate);
+            assert_eq!(a.core_passes, b.core_passes);
+            assert_eq!(a.ddn_sigma_v_m3.to_bits(), b.ddn_sigma_v_m3.to_bits());
+            assert_eq!(a.energy_drift_rel.to_bits(), b.energy_drift_rel.to_bits());
         }
     }
 

--- a/crates/vcad-kernel-photonics/src/sim.rs
+++ b/crates/vcad-kernel-photonics/src/sim.rs
@@ -959,6 +959,41 @@ mod tests {
     use super::*;
     use crate::waveform::Waveform;
 
+    /// Chunked stepping (`run(a)` then `run(b)`) must be bit-identical to one
+    /// `run(a + b)` — the contract the stepwise MCP progress seam relies on.
+    #[test]
+    fn chunked_run_matches_one_shot_run() {
+        let n = 40;
+        let build = || {
+            let mut sim = Simulation::new(GridSpec::new(n, n, 0.05), Polarization::Tm);
+            sim.set_cpml(crate::CpmlSpec::uniform(8));
+            sim.add_source(Source::point(n / 2, n / 2, Waveform::gaussian(2.0, 0.6)));
+            let f = sim.add_flux(crate::monitor::FluxSpec::Vertical {
+                i: n - 12,
+                j0: 10,
+                j1: n - 10,
+                freqs: vec![2.0],
+            });
+            (sim, f)
+        };
+        let (mut one_shot, f1) = build();
+        one_shot.run(150);
+        let (mut chunked, f2) = build();
+        chunked.run(37);
+        chunked.run(63);
+        chunked.run(50);
+        for i in 0..=n {
+            for j in 0..=n {
+                assert_eq!(
+                    one_shot.ez_at(i, j).to_bits(),
+                    chunked.ez_at(i, j).to_bits(),
+                    "field diverged at ({i},{j})"
+                );
+            }
+        }
+        assert_eq!(one_shot.flux_power(f1), chunked.flux_power(f2));
+    }
+
     /// A centered point source in a symmetric vacuum PEC box must produce
     /// exactly symmetric fields — mirror and transpose. Catches staggering
     /// and sign bugs at machine precision.

--- a/crates/vcad-kernel-qcd/src/spec.rs
+++ b/crates/vcad-kernel-qcd/src/spec.rs
@@ -260,131 +260,262 @@ impl SimSpec {
 }
 
 /// Run a validated spec to completion.
+///
+/// Implemented as an unbounded [`SimRun`] drive, so the one-shot and
+/// chunked paths are identical by construction.
 pub fn run(spec: &SimSpec) -> Result<SimResult, SpecError> {
-    spec.validate()?;
-    match spec.gauge {
-        Gauge::Su2 => run_generic::<Su2>(spec),
-        Gauge::Su3 => run_generic::<Su3>(spec),
-    }
+    let mut run = SimRun::new(spec)?;
+    run.advance(usize::MAX);
+    run.finish()
 }
 
-fn run_generic<G: GaugeGroup>(spec: &SimSpec) -> Result<SimResult, SpecError> {
-    let mut rng = Rng::seeded(spec.seed);
-    let mut lat: Lattice<G> = if spec.hot_start {
-        Lattice::hot(spec.dims, &mut rng)
-    } else {
-        Lattice::cold(spec.dims)
-    };
+/// What a bounded [`SimRun::advance`] call concluded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunProgress {
+    /// Budget exhausted; more sweeps remain. Call `advance` again.
+    Running,
+    /// All sweeps done; take the result with [`SimRun::finish`].
+    Done,
+}
 
-    let sweep = |lat: &mut Lattice<G>, rng: &mut Rng| {
-        heatbath_sweep(lat, spec.beta, rng);
-        for _ in 0..spec.overrelax_per_heatbath {
-            overrelax_sweep(lat, rng);
+/// In-flight state of one gauge-group-specific run.
+struct RunState<G: GaugeGroup> {
+    spec: SimSpec,
+    rng: Rng,
+    lat: Lattice<G>,
+    sym_loops: Vec<(usize, usize)>,
+    tmp_loops: Vec<(usize, usize)>,
+    plaq_series: Vec<f64>,
+    sym_series: Vec<Vec<f64>>,
+    tmp_series: Vec<Vec<f64>>,
+    poly_series: Vec<f64>,
+    flux: Option<FluxTubeAccumulator>,
+    /// Compound sweeps (thermalization + measurement) completed so far.
+    sweeps_done: usize,
+}
+
+impl<G: GaugeGroup> RunState<G> {
+    fn new(spec: &SimSpec) -> Self {
+        let mut rng = Rng::seeded(spec.seed);
+        let lat: Lattice<G> = if spec.hot_start {
+            Lattice::hot(spec.dims, &mut rng)
+        } else {
+            Lattice::cold(spec.dims)
+        };
+        let sym_loops: Vec<(usize, usize)> = (1..=spec.max_wilson_extent)
+            .flat_map(|r| (1..=spec.max_wilson_extent).map(move |t| (r, t)))
+            .filter(|&(r, t)| r <= t) // W(r,t) = W(t,r) by plane averaging
+            .collect();
+        let max_temporal_t = spec.dims[3] / 2;
+        let tmp_loops: Vec<(usize, usize)> = if spec.measure_temporal_loops {
+            (1..=spec.max_wilson_extent)
+                .flat_map(|r| (1..=max_temporal_t).map(move |t| (r, t)))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let sym_series = vec![Vec::new(); sym_loops.len()];
+        let tmp_series = vec![Vec::new(); tmp_loops.len()];
+        let flux = spec
+            .flux_tube
+            .map(|ft| FluxTubeAccumulator::new(spec.dims, ft.separation));
+        RunState {
+            spec: spec.clone(),
+            rng,
+            lat,
+            sym_loops,
+            tmp_loops,
+            plaq_series: Vec::with_capacity(spec.measurement_sweeps),
+            sym_series,
+            tmp_series,
+            poly_series: Vec::new(),
+            flux,
+            sweeps_done: 0,
         }
-    };
-
-    for _ in 0..spec.thermalization_sweeps {
-        sweep(&mut lat, &mut rng);
     }
 
-    let sym_loops: Vec<(usize, usize)> = (1..=spec.max_wilson_extent)
-        .flat_map(|r| (1..=spec.max_wilson_extent).map(move |t| (r, t)))
-        .filter(|&(r, t)| r <= t) // W(r,t) = W(t,r) by plane averaging
-        .collect();
-    let max_temporal_t = spec.dims[3] / 2;
-    let tmp_loops: Vec<(usize, usize)> = if spec.measure_temporal_loops {
-        (1..=spec.max_wilson_extent)
-            .flat_map(|r| (1..=max_temporal_t).map(move |t| (r, t)))
-            .collect()
-    } else {
-        Vec::new()
-    };
+    fn total_sweeps(&self) -> usize {
+        self.spec.thermalization_sweeps + self.spec.measurement_sweeps
+    }
 
-    let mut plaq_series = Vec::with_capacity(spec.measurement_sweeps);
-    let mut sym_series: Vec<Vec<f64>> = vec![Vec::new(); sym_loops.len()];
-    let mut tmp_series: Vec<Vec<f64>> = vec![Vec::new(); tmp_loops.len()];
-    let mut poly_series: Vec<f64> = Vec::new();
-    let mut flux = spec
-        .flux_tube
-        .map(|ft| FluxTubeAccumulator::new(spec.dims, ft.separation));
+    fn sweep(&mut self) {
+        heatbath_sweep(&mut self.lat, self.spec.beta, &mut self.rng);
+        for _ in 0..self.spec.overrelax_per_heatbath {
+            overrelax_sweep(&mut self.lat, &mut self.rng);
+        }
+    }
 
-    for _ in 0..spec.measurement_sweeps {
-        sweep(&mut lat, &mut rng);
-        plaq_series.push(lat.average_plaquette());
-        let measured: Lattice<G> = match &spec.smear {
-            Some(s) => ape_smear_spatial_n(&lat, s.alpha, s.iterations),
-            None => lat.clone(),
+    fn advance(&mut self, budget: usize) -> RunProgress {
+        let total = self.total_sweeps();
+        let mut left = budget.max(1);
+        while self.sweeps_done < total && left > 0 {
+            self.sweep();
+            if self.sweeps_done >= self.spec.thermalization_sweeps {
+                self.measure();
+            }
+            self.sweeps_done += 1;
+            left -= 1;
+        }
+        if self.sweeps_done < total {
+            RunProgress::Running
+        } else {
+            RunProgress::Done
+        }
+    }
+
+    fn measure(&mut self) {
+        self.plaq_series.push(self.lat.average_plaquette());
+        let measured: Lattice<G> = match &self.spec.smear {
+            Some(s) => ape_smear_spatial_n(&self.lat, s.alpha, s.iterations),
+            None => self.lat.clone(),
         };
-        for (i, &(r, t)) in sym_loops.iter().enumerate() {
-            sym_series[i].push(measured.wilson_loop(r, t));
+        for (i, &(r, t)) in self.sym_loops.iter().enumerate() {
+            self.sym_series[i].push(measured.wilson_loop(r, t));
         }
-        for (i, &(r, t)) in tmp_loops.iter().enumerate() {
-            tmp_series[i].push(measured.wilson_loop_temporal(r, t));
+        for (i, &(r, t)) in self.tmp_loops.iter().enumerate() {
+            self.tmp_series[i].push(measured.wilson_loop_temporal(r, t));
         }
-        if spec.measure_polyakov {
+        if self.spec.measure_polyakov {
             // |volume-average L| per configuration: the finite-volume
             // order parameter (⟨L⟩ itself averages to 0 by center
             // symmetry in the confined phase).
-            let (re, im) = crate::fields::polyakov_field(&lat);
+            let (re, im) = crate::fields::polyakov_field(&self.lat);
             let n = re.len() as f64;
             let mre = re.iter().sum::<f64>() / n;
             let mim = im.iter().sum::<f64>() / n;
-            poly_series.push((mre * mre + mim * mim).sqrt());
+            self.poly_series.push((mre * mre + mim * mim).sqrt());
         }
-        if let Some(acc) = flux.as_mut() {
-            acc.measure(&lat);
+        if let Some(acc) = self.flux.as_mut() {
+            acc.measure(&self.lat);
         }
     }
 
-    // validate() guarantees >= 2 bins, so jackknife cannot fail here.
-    let jk = |series: &[f64]| jackknife(series, spec.bin_size).expect("validated binning");
-    let plaquette = jk(&plaq_series);
-    let collect = |pairs: &[(usize, usize)], series: &[Vec<f64>]| {
-        pairs
-            .iter()
-            .zip(series)
-            .map(|(&(r, t), s)| WilsonLoop { r, t, value: jk(s) })
-            .collect::<Vec<_>>()
-    };
-    let wilson_loops = collect(&sym_loops, &sym_series);
-    let temporal_loops = collect(&tmp_loops, &tmp_series);
-    let polyakov_abs = spec.measure_polyakov.then(|| jk(&poly_series));
-    let flux_tube = flux.map(|acc| {
-        acc.profile(spec.bin_size)
-            .expect("validated binning for flux profile")
-    });
+    fn finish(mut self) -> Result<SimResult, SpecError> {
+        let total_sweeps = self.total_sweeps();
+        let flux = self.flux.take();
+        let spec = &self.spec;
+        // validate() guarantees >= 2 bins, so jackknife cannot fail here.
+        let jk = |series: &[f64]| jackknife(series, spec.bin_size).expect("validated binning");
+        let plaquette = jk(&self.plaq_series);
+        let collect = |pairs: &[(usize, usize)], series: &[Vec<f64>]| {
+            pairs
+                .iter()
+                .zip(series)
+                .map(|(&(r, t), s)| WilsonLoop { r, t, value: jk(s) })
+                .collect::<Vec<_>>()
+        };
+        let wilson_loops = collect(&self.sym_loops, &self.sym_series);
+        let temporal_loops = collect(&self.tmp_loops, &self.tmp_series);
+        let polyakov_abs = spec.measure_polyakov.then(|| jk(&self.poly_series));
+        let flux_tube = flux.map(|acc| {
+            acc.profile(spec.bin_size)
+                .expect("validated binning for flux profile")
+        });
 
-    let (snapshot_out, topological_charge) = match spec.snapshot_cooling {
-        None => (None, None),
-        Some(n_cool) => {
-            let mut cooled = lat.clone();
-            for _ in 0..n_cool {
-                cool_sweep(&mut cooled);
+        let (snapshot_out, topological_charge) = match spec.snapshot_cooling {
+            None => (None, None),
+            Some(n_cool) => {
+                let mut cooled = self.lat.clone();
+                for _ in 0..n_cool {
+                    cool_sweep(&mut cooled);
+                }
+                let snap = snapshot(&cooled);
+                let q = if n_cool >= 1 {
+                    topo_charge_if_su2(&cooled)
+                } else {
+                    None
+                };
+                (Some(snap), q)
             }
-            let snap = snapshot(&cooled);
-            let q = if n_cool >= 1 {
-                topo_charge_if_su2(&cooled)
-            } else {
-                None
-            };
-            (Some(snap), q)
-        }
-    };
+        };
 
-    let total_sweeps = spec.thermalization_sweeps + spec.measurement_sweeps;
-    Ok(SimResult {
-        plaquette,
-        wilson_loops,
-        temporal_loops,
-        polyakov_abs,
-        flux_tube,
-        snapshot: snapshot_out,
-        topological_charge,
-        provenance: Provenance {
-            spec: spec.clone(),
-            total_sweeps,
-        },
-    })
+        Ok(SimResult {
+            plaquette,
+            wilson_loops,
+            temporal_loops,
+            polyakov_abs,
+            flux_tube,
+            snapshot: snapshot_out,
+            topological_charge,
+            provenance: Provenance {
+                spec: self.spec.clone(),
+                total_sweeps,
+            },
+        })
+    }
+}
+
+enum RunInner {
+    Su2(Box<RunState<Su2>>),
+    Su3(Box<RunState<Su3>>),
+}
+
+/// Stepwise driver for a lattice gauge run: [`SimRun::new`] validates the
+/// spec and initializes the lattice (RNG state lives inside, so chunked
+/// runs are bit-identical to [`run`]), each [`SimRun::advance`] performs up
+/// to a budget of compound sweeps, and [`SimRun::finish`] assembles the
+/// [`SimResult`]. A host can surface progress between `advance` calls.
+pub struct SimRun {
+    inner: RunInner,
+}
+
+impl SimRun {
+    /// Validate the spec and initialize the run.
+    pub fn new(spec: &SimSpec) -> Result<Self, SpecError> {
+        spec.validate()?;
+        let inner = match spec.gauge {
+            Gauge::Su2 => RunInner::Su2(Box::new(RunState::new(spec))),
+            Gauge::Su3 => RunInner::Su3(Box::new(RunState::new(spec))),
+        };
+        Ok(SimRun { inner })
+    }
+
+    /// Compound sweeps completed so far.
+    pub fn sweeps_done(&self) -> usize {
+        match &self.inner {
+            RunInner::Su2(s) => s.sweeps_done,
+            RunInner::Su3(s) => s.sweeps_done,
+        }
+    }
+
+    /// Total compound sweeps this run will perform.
+    pub fn total_sweeps(&self) -> usize {
+        match &self.inner {
+            RunInner::Su2(s) => s.total_sweeps(),
+            RunInner::Su3(s) => s.total_sweeps(),
+        }
+    }
+
+    /// Perform up to `budget` compound sweeps (min 1).
+    pub fn advance(&mut self, budget: usize) -> RunProgress {
+        match &mut self.inner {
+            RunInner::Su2(s) => s.advance(budget),
+            RunInner::Su3(s) => s.advance(budget),
+        }
+    }
+
+    /// Assemble the result. Call only after `advance` reported
+    /// [`RunProgress::Done`]; finishing early would jackknife a
+    /// truncated series, so it is an error.
+    pub fn finish(self) -> Result<SimResult, SpecError> {
+        let (done, total) = (self.sweeps_done(), self.total_sweeps());
+        if done < total {
+            return Err(SpecError::StarvedStatistics {
+                measurements: done.saturating_sub(match &self.inner {
+                    RunInner::Su2(s) => s.spec.thermalization_sweeps,
+                    RunInner::Su3(s) => s.spec.thermalization_sweeps,
+                }),
+                bin_size: match &self.inner {
+                    RunInner::Su2(s) => s.spec.bin_size,
+                    RunInner::Su3(s) => s.spec.bin_size,
+                },
+            });
+        }
+        match self.inner {
+            RunInner::Su2(s) => s.finish(),
+            RunInner::Su3(s) => s.finish(),
+        }
+    }
 }
 
 /// Topological charge for SU(2) lattices; `None` for other groups
@@ -455,6 +586,33 @@ pub(crate) mod tests {
             s.validate(),
             Err(SpecError::BadFluxTubeSeparation { .. })
         ));
+    }
+
+    #[test]
+    fn chunked_run_matches_the_one_shot() {
+        // Small odd budget so chunk boundaries land mid-thermalization
+        // and mid-measurement; RNG state lives in the run, so the
+        // result must be bit-identical to the one-shot path.
+        let mut spec = base_spec();
+        spec.measure_polyakov = true;
+        spec.flux_tube = Some(FluxTubeSpec { separation: 1 });
+        let one_shot = run(&spec).unwrap();
+        let mut chunked = SimRun::new(&spec).unwrap();
+        let mut calls = 0;
+        while chunked.advance(7) == RunProgress::Running {
+            calls += 1;
+            assert!(chunked.sweeps_done() <= chunked.total_sweeps());
+        }
+        assert!(calls > 2, "budget too generous to exercise chunking");
+        assert_eq!(chunked.finish().unwrap(), one_shot);
+    }
+
+    #[test]
+    fn early_finish_is_refused() {
+        let spec = base_spec();
+        let mut r = SimRun::new(&spec).unwrap();
+        assert_eq!(r.advance(3), RunProgress::Running);
+        assert!(r.finish().is_err());
     }
 
     #[test]

--- a/crates/vcad-kernel-topopt/src/lib.rs
+++ b/crates/vcad-kernel-topopt/src/lib.rs
@@ -157,26 +157,88 @@ fn validate(spec: &TopoOptSpec) -> Result<(), TopoOptError> {
     Ok(())
 }
 
+pub use simp::SimpStepStatus;
+
+/// Stepwise topology-optimization run: one SIMP iteration per [`TopoOptRun::step`],
+/// so a host can surface convergence progress (compliance, density change)
+/// between iterations. [`optimize`] drives this to completion, so the stepped
+/// and one-shot paths produce identical results by construction.
+pub struct TopoOptRun {
+    domain: Domain,
+    sys: fea::FeSystem,
+    spec: TopoOptSpec,
+    state: simp::SimpState,
+}
+
+impl TopoOptRun {
+    /// Validate the spec and build the FE system for a prepared domain.
+    pub fn begin(domain: Domain, spec: TopoOptSpec) -> Result<Self, TopoOptError> {
+        validate(&spec)?;
+        let sys = fea::FeSystem::build(&domain, spec.poisson, &spec.loads, &spec.supports)?;
+        let state = simp::SimpState::new(&domain, &sys, &spec);
+        Ok(Self {
+            domain,
+            sys,
+            spec,
+            state,
+        })
+    }
+
+    /// Begin inside an axis-aligned box design domain (see [`optimize_box`]).
+    pub fn begin_box(
+        min: [f64; 3],
+        max: [f64; 3],
+        spec: TopoOptSpec,
+    ) -> Result<Self, TopoOptError> {
+        if (0..3).any(|a| !(max[a] - min[a]).is_finite() || max[a] - min[a] <= 0.0) {
+            return Err(TopoOptError::InvalidSpec(
+                "domain box must have positive size on every axis".into(),
+            ));
+        }
+        let domain = Domain::from_bbox(min, max, spec.resolution);
+        Self::begin(domain, spec)
+    }
+
+    /// Begin inside an existing solid's tessellation (see [`optimize_mesh`]).
+    pub fn begin_mesh(mesh: &TriangleMesh, spec: TopoOptSpec) -> Result<Self, TopoOptError> {
+        let domain = Domain::from_mesh(mesh, spec.resolution);
+        Self::begin(domain, spec)
+    }
+
+    /// Total SIMP iterations this run may execute.
+    pub fn max_iterations(&self) -> usize {
+        self.spec.max_iterations
+    }
+
+    /// Run one SIMP iteration; `done` once converged or the budget is spent.
+    pub fn step(&mut self) -> SimpStepStatus {
+        self.state.step(&self.domain, &self.sys, &self.spec)
+    }
+
+    /// Extract the optimized surface mesh and package the result.
+    pub fn finish(self) -> TopoOptResult {
+        let simp = self.state.finish(&self.domain, &self.sys);
+        let nact = self.domain.num_active().max(1) as f64;
+        let volume_fraction_achieved = simp.densities.iter().sum::<f64>() / nact;
+        let mesh =
+            extract::extract_mesh(&self.domain, &simp.densities, self.spec.smooth_iterations);
+        TopoOptResult {
+            mesh,
+            compliance_history: simp.compliance_history,
+            iterations: simp.iterations,
+            converged: simp.converged,
+            volume_fraction_achieved,
+            grid: [self.domain.nx, self.domain.ny, self.domain.nz],
+            voxel_size: self.domain.h,
+        }
+    }
+}
+
 /// Run topology optimization on a prepared design domain.
 pub fn optimize(domain: &Domain, spec: &TopoOptSpec) -> Result<TopoOptResult, TopoOptError> {
-    validate(spec)?;
-    let sys = fea::FeSystem::build(domain, spec.poisson, &spec.loads, &spec.supports)?;
-    let simp = simp::optimize_densities(domain, &sys, spec);
-
-    let nact = domain.num_active().max(1) as f64;
-    let volume_fraction_achieved = simp.densities.iter().sum::<f64>() / nact;
-
-    let mesh = extract::extract_mesh(domain, &simp.densities, spec.smooth_iterations);
-
-    Ok(TopoOptResult {
-        mesh,
-        compliance_history: simp.compliance_history,
-        iterations: simp.iterations,
-        converged: simp.converged,
-        volume_fraction_achieved,
-        grid: [domain.nx, domain.ny, domain.nz],
-        voxel_size: domain.h,
-    })
+    let mut run = TopoOptRun::begin(domain.clone(), spec.clone())?;
+    while !run.step().done {}
+    Ok(run.finish())
 }
 
 /// Optimize within an axis-aligned box design domain.
@@ -232,6 +294,39 @@ mod tests {
         spec.max_iterations = 15;
         spec.volume_fraction = 0.35;
         spec
+    }
+
+    /// Driving the run one step at a time (the streamed-progress path) must
+    /// produce exactly the one-shot result on the same problem.
+    #[test]
+    fn stepwise_run_matches_the_one_shot_optimize() {
+        let mut spec = bracket_spec();
+        spec.resolution = 12;
+        spec.max_iterations = 6;
+        let one_shot = optimize_box([0.0; 3], [24.0, 6.0, 12.0], &spec).unwrap();
+
+        let mut run = TopoOptRun::begin_box([0.0; 3], [24.0, 6.0, 12.0], spec.clone()).unwrap();
+        let mut steps = 0;
+        loop {
+            let s = run.step();
+            assert!(s.compliance.is_finite());
+            steps += 1;
+            if s.done {
+                break;
+            }
+        }
+        let stepped = run.finish();
+
+        assert_eq!(steps, one_shot.iterations);
+        assert_eq!(one_shot.compliance_history, stepped.compliance_history);
+        assert_eq!(one_shot.iterations, stepped.iterations);
+        assert_eq!(one_shot.converged, stepped.converged);
+        assert_eq!(one_shot.mesh.vertices, stepped.mesh.vertices);
+        assert_eq!(one_shot.mesh.indices, stepped.mesh.indices);
+        assert_eq!(
+            one_shot.volume_fraction_achieved,
+            stepped.volume_fraction_achieved
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-topopt/src/simp.rs
+++ b/crates/vcad-kernel-topopt/src/simp.rs
@@ -31,48 +31,95 @@ fn stiffness_scale(x: f64, penalty: f64) -> f64 {
     E_MIN + x.powf(penalty) * (1.0 - E_MIN)
 }
 
-/// Run the SIMP loop on a prepared FE system.
-pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -> SimpResult {
-    let nact = sys.active_elems.len();
-    let vf = spec.volume_fraction.clamp(0.01, 0.99);
+/// What one [`SimpState::step`] concluded — the convergence signal a host can
+/// narrate between iterations.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SimpStepStatus {
+    /// The loop is finished (converged or iteration budget spent).
+    pub done: bool,
+    /// 1-based iteration that just ran (0 if `step` was called after done).
+    pub iteration: usize,
+    /// Compliance after this iteration (lower = stiffer).
+    pub compliance: f64,
+    /// Max density change this iteration (compared against the tolerance).
+    pub change: f64,
+}
 
-    // Densities indexed by active-element position.
-    let mut x = vec![vf; nact];
-    let mut u = vec![0.0f64; sys.ndof];
-    let mut history = Vec::with_capacity(spec.max_iterations);
+/// Mutable state of the SIMP loop, stepped one iteration at a time so a host
+/// can surface progress between iterations. [`optimize_densities`] drives this
+/// to completion, so the stepped and one-shot paths are identical by
+/// construction.
+pub struct SimpState {
+    x: Vec<f64>,
+    u: Vec<f64>,
+    history: Vec<f64>,
+    act_of_elem: Vec<u32>,
+    scales: Vec<f64>,
+    dc: Vec<f64>,
+    cg_max: usize,
+    converged: bool,
+    iterations: usize,
+    done: bool,
+}
 
-    // Map grid element index -> active index for the filter.
-    let mut act_of_elem = vec![u32::MAX; domain.num_elements()];
-    for (ai, &e) in sys.active_elems.iter().enumerate() {
-        act_of_elem[e as usize] = ai as u32;
+impl SimpState {
+    /// Prepare the loop state for a domain/FE-system/spec triple.
+    pub fn new(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -> Self {
+        let nact = sys.active_elems.len();
+        let vf = spec.volume_fraction.clamp(0.01, 0.99);
+
+        // Map grid element index -> active index for the filter.
+        let mut act_of_elem = vec![u32::MAX; domain.num_elements()];
+        for (ai, &e) in sys.active_elems.iter().enumerate() {
+            act_of_elem[e as usize] = ai as u32;
+        }
+
+        Self {
+            // Densities indexed by active-element position.
+            x: vec![vf; nact],
+            u: vec![0.0f64; sys.ndof],
+            history: Vec::with_capacity(spec.max_iterations),
+            act_of_elem,
+            scales: vec![0.0f64; nact],
+            dc: vec![0.0f64; nact],
+            // Solver budget: warm-started PCG needs a full-accuracy solve only on
+            // the first iteration; after that the displacement field tracks the
+            // slowly-changing densities, so a tight cap keeps large grids tractable
+            // (approximate solves are standard practice for OC updates — the
+            // sensitivity signs, not their last digits, drive the design).
+            cg_max: (sys.ndof / 2).clamp(500, 4_000),
+            converged: false,
+            iterations: 0,
+            done: false,
+        }
     }
 
-    // Solver budget: warm-started PCG needs a full-accuracy solve only on
-    // the first iteration; after that the displacement field tracks the
-    // slowly-changing densities, so a tight cap keeps large grids tractable
-    // (approximate solves are standard practice for OC updates — the
-    // sensitivity signs, not their last digits, drive the design).
-    let cg_max = (sys.ndof / 2).clamp(500, 4_000);
+    /// Run one SIMP iteration: FE solve, sensitivities, filter, OC update.
+    pub fn step(&mut self, domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -> SimpStepStatus {
+        if self.done || self.iterations >= spec.max_iterations {
+            self.done = true;
+            return SimpStepStatus {
+                done: true,
+                iteration: 0,
+                compliance: self.history.last().copied().unwrap_or(0.0),
+                change: 0.0,
+            };
+        }
+        let nact = sys.active_elems.len();
+        let vf = spec.volume_fraction.clamp(0.01, 0.99);
+        self.iterations += 1;
 
-    let mut converged = false;
-    let mut iterations = 0;
-    let mut scales = vec![0.0f64; nact];
-    let mut dc = vec![0.0f64; nact];
-
-    for it in 0..spec.max_iterations {
-        iterations = it + 1;
-
-        for (s, &xi) in scales.iter_mut().zip(&x) {
+        for (s, &xi) in self.scales.iter_mut().zip(&self.x) {
             *s = stiffness_scale(xi, spec.penalty);
         }
-        sys.solve(&scales, &mut u, 1e-5, cg_max);
+        sys.solve(&self.scales, &mut self.u, 1e-5, self.cg_max);
 
         // Compliance and element sensitivities.
         let mut compliance = 0.0;
         for (ai, dofs) in sys.edofs.iter().enumerate() {
             let mut ue = [0.0f64; 24];
             for (k, &d) in dofs.iter().enumerate() {
-                ue[k] = u[d as usize];
+                ue[k] = self.u[d as usize];
             }
             // ce = ueᵀ · KE · ue (unit-E element strain energy measure).
             let mut ce = 0.0;
@@ -84,14 +131,20 @@ pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -
                 }
                 ce += ue[r] * acc;
             }
-            compliance += scales[ai] * ce;
-            dc[ai] = -spec.penalty * x[ai].powf(spec.penalty - 1.0) * (1.0 - E_MIN) * ce;
+            compliance += self.scales[ai] * ce;
+            self.dc[ai] = -spec.penalty * self.x[ai].powf(spec.penalty - 1.0) * (1.0 - E_MIN) * ce;
         }
-        history.push(compliance);
+        self.history.push(compliance);
 
         // Mesh-independency (sensitivity) filter, computed on the fly over
         // the voxel neighborhood within `filter_radius`.
-        let dcn = filter_sensitivities(domain, &act_of_elem, &x, &dc, spec.filter_radius);
+        let dcn = filter_sensitivities(
+            domain,
+            &self.act_of_elem,
+            &self.x,
+            &self.dc,
+            spec.filter_radius,
+        );
 
         // Optimality-criteria update with bisection on the volume multiplier.
         let (mut l1, mut l2) = (0.0f64, 1e9f64);
@@ -101,9 +154,9 @@ pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -
             let mut vol = 0.0;
             for ai in 0..nact {
                 let b = (-dcn[ai]).max(0.0) / lmid;
-                let cand = x[ai] * b.sqrt();
-                let lo = (x[ai] - MOVE).max(X_MIN);
-                let hi = (x[ai] + MOVE).min(1.0);
+                let cand = self.x[ai] * b.sqrt();
+                let lo = (self.x[ai] - MOVE).max(X_MIN);
+                let hi = (self.x[ai] + MOVE).min(1.0);
                 let xn = cand.clamp(lo, hi);
                 xnew[ai] = xn;
                 vol += xn;
@@ -115,31 +168,51 @@ pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -
             }
         }
 
-        let change = x
+        let change = self
+            .x
             .iter()
             .zip(&xnew)
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f64, f64::max);
-        x.copy_from_slice(&xnew);
+        self.x.copy_from_slice(&xnew);
 
         if change < spec.tolerance {
-            converged = true;
-            break;
+            self.converged = true;
+            self.done = true;
+        } else if self.iterations >= spec.max_iterations {
+            self.done = true;
+        }
+        SimpStepStatus {
+            done: self.done,
+            iteration: self.iterations,
+            compliance,
+            change,
         }
     }
 
-    // Expand to full grid indexing.
-    let mut densities = vec![0.0f64; domain.num_elements()];
-    for (ai, &e) in sys.active_elems.iter().enumerate() {
-        densities[e as usize] = x[ai];
+    /// Expand the converged density field to full grid indexing and package
+    /// the diagnostics.
+    pub fn finish(self, domain: &Domain, sys: &FeSystem) -> SimpResult {
+        let mut densities = vec![0.0f64; domain.num_elements()];
+        for (ai, &e) in sys.active_elems.iter().enumerate() {
+            densities[e as usize] = self.x[ai];
+        }
+        SimpResult {
+            densities,
+            compliance_history: self.history,
+            iterations: self.iterations,
+            converged: self.converged,
+        }
     }
+}
 
-    SimpResult {
-        densities,
-        compliance_history: history,
-        iterations,
-        converged,
-    }
+/// Run the SIMP loop on a prepared FE system (the one-shot form of
+/// [`SimpState`]; kept as the reference driver for parity tests).
+#[cfg_attr(not(test), allow(dead_code))]
+pub fn optimize_densities(domain: &Domain, sys: &FeSystem, spec: &TopoOptSpec) -> SimpResult {
+    let mut state = SimpState::new(domain, sys, spec);
+    while !state.step(domain, sys, spec).done {}
+    state.finish(domain, sys)
 }
 
 /// Classic sensitivity filter: weighted average of `x·dc` over neighbors

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -769,6 +769,105 @@ pub fn topology_optimize_mesh(
     topopt_response(result)
 }
 
+/// Stepwise SIMP topology optimization: the same pipeline as
+/// `topologyOptimizeBox` / `topologyOptimizeMesh`, split so a host can run one
+/// SIMP iteration per call and emit progress (compliance, density change)
+/// between iterations. Bit-identical to the one-shot calls — they are
+/// implemented on the same run type.
+///
+/// Usage: `TopoOptRun.beginBox(...)` or `.beginMesh(...)` → `step()` until
+/// `{done: true}` → `finish()` for the `WasmTopoOptResult`.
+#[wasm_bindgen(js_name = TopoOptRun)]
+pub struct WasmTopoOptRun {
+    run: Option<vcad_kernel::vcad_kernel_topopt::TopoOptRun>,
+}
+
+#[wasm_bindgen(js_class = TopoOptRun)]
+impl WasmTopoOptRun {
+    /// Begin inside an axis-aligned box design domain.
+    #[wasm_bindgen(js_name = beginBox)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn begin_box(
+        spec_json: &str,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Result<WasmTopoOptRun, JsError> {
+        let spec: vcad_kernel::vcad_kernel_topopt::TopoOptSpec =
+            serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+        let run = vcad_kernel::vcad_kernel_topopt::TopoOptRun::begin_box(
+            [min_x, min_y, min_z],
+            [max_x, max_y, max_z],
+            spec,
+        )
+        .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmTopoOptRun { run: Some(run) })
+    }
+
+    /// Begin inside an existing (closed) evaluated mesh.
+    #[wasm_bindgen(js_name = beginMesh)]
+    pub fn begin_mesh(
+        spec_json: &str,
+        positions: &[f32],
+        indices: &[u32],
+    ) -> Result<WasmTopoOptRun, JsError> {
+        let spec: vcad_kernel::vcad_kernel_topopt::TopoOptSpec =
+            serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+        let mut mesh = vcad_kernel_tessellate::TriangleMesh::new();
+        mesh.vertices = positions.to_vec();
+        mesh.indices = indices.to_vec();
+        let run = vcad_kernel::vcad_kernel_topopt::TopoOptRun::begin_mesh(&mesh, spec)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmTopoOptRun { run: Some(run) })
+    }
+
+    /// Total SIMP iterations this run may execute.
+    #[wasm_bindgen(js_name = maxIterations)]
+    pub fn max_iterations(&self) -> Result<u32, JsError> {
+        let run = self
+            .run
+            .as_ref()
+            .ok_or_else(|| JsError::new("TopoOptRun already finished"))?;
+        Ok(run.max_iterations() as u32)
+    }
+
+    /// One SIMP iteration. Returns `{ done, iteration, compliance, change }`.
+    pub fn step(&mut self) -> Result<JsValue, JsError> {
+        let run = self
+            .run
+            .as_mut()
+            .ok_or_else(|| JsError::new("TopoOptRun already finished"))?;
+        let s = run.step();
+        #[derive(Serialize)]
+        struct Status {
+            done: bool,
+            iteration: u32,
+            compliance: f64,
+            change: f64,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: s.done,
+            iteration: s.iteration as u32,
+            compliance: s.compliance,
+            change: s.change,
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Extract the optimized mesh; returns a `WasmTopoOptResult`. The run is
+    /// consumed; further calls error.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        let run = self
+            .run
+            .take()
+            .ok_or_else(|| JsError::new("TopoOptRun already finished"))?;
+        topopt_response(run.finish())
+    }
+}
+
 /// Result of a static structural analysis solve (see
 /// `vcad_kernel_topopt::analyze`). Two-tier contract: at coarse resolution
 /// this is the fast `predicted` path; the same solver at fine resolution is
@@ -6098,6 +6197,87 @@ mod ecad_wasm {
         .map_err(|e| JsError::new(&e.to_string()))
     }
 
+    /// Stepwise fab-prep driver: the same pipeline as `ecadFabPrep`, split so a
+    /// host can pump the strip-and-re-route loop one round at a time and emit
+    /// progress between rounds. The construct-round-finish sequence is
+    /// bit-identical to the one-shot call (`run_fab_prep` is implemented on the
+    /// same session type).
+    ///
+    /// Usage: `new FabPrepRun(pcbJson, optsJson)` → `round()` until
+    /// `{done: true}` → `finish()` for `{ report, pcb }`.
+    #[wasm_bindgen]
+    pub struct FabPrepRun {
+        pcb: Pcb,
+        session: Option<vcad_ecad_fabprep::FabPrepSession>,
+        /// Set when `begin` refused the run (bad waiver name): `round()` is a
+        /// no-op and `finish()` returns this outcome, matching the one-shot.
+        refusal: Option<vcad_ecad_fabprep::FabPrepOutcome>,
+    }
+
+    #[wasm_bindgen]
+    impl FabPrepRun {
+        /// Start a run: waiver validation, opt-in calibration, the stripped
+        /// baseline DRC, and the up-front verdict pass all happen here.
+        #[wasm_bindgen(constructor)]
+        pub fn new(pcb_json: &str, options_json: Option<String>) -> Result<FabPrepRun, JsError> {
+            let mut pcb: Pcb =
+                serde_json::from_str(pcb_json).map_err(|e| JsError::new(&e.to_string()))?;
+            let opts: vcad_ecad_fabprep::FabPrepOptions = match options_json.as_deref() {
+                None | Some("") | Some("null") => Default::default(),
+                Some(json) => {
+                    serde_json::from_str(json).map_err(|e| JsError::new(&e.to_string()))?
+                }
+            };
+            let (session, refusal) = match vcad_ecad_fabprep::FabPrepSession::begin(&mut pcb, &opts)
+            {
+                Ok(s) => (Some(s), None),
+                Err(outcome) => (None, Some(*outcome)),
+            };
+            Ok(FabPrepRun {
+                pcb,
+                session,
+                refusal,
+            })
+        }
+
+        /// Run one strip-and-re-route round. Returns
+        /// `{ done, round, attributable, max_rounds }`.
+        pub fn round(&mut self) -> Result<JsValue, JsError> {
+            let status = match &mut self.session {
+                Some(s) => s.round(&mut self.pcb),
+                None => vcad_ecad_fabprep::RoundStatus {
+                    done: true,
+                    round: 0,
+                    attributable: 0,
+                    max_rounds: 0,
+                },
+            };
+            serde_wasm_bindgen::to_value(&status).map_err(|e| JsError::new(&e.to_string()))
+        }
+
+        /// Prune, final DRC, receipt. Returns `{ report, pcb }` — the same
+        /// shape as `ecadFabPrep`. The run is consumed; further calls error.
+        pub fn finish(&mut self) -> Result<JsValue, JsError> {
+            let outcome = match (self.session.take(), self.refusal.take()) {
+                (Some(s), _) => s.finish(&mut self.pcb),
+                (None, Some(r)) => r,
+                (None, None) => {
+                    return Err(JsError::new("FabPrepRun already finished"));
+                }
+            };
+            #[derive(serde::Serialize)]
+            struct Out<'a> {
+                report: &'a vcad_ecad_fabprep::FabPrepReport,
+                pcb: &'a Pcb,
+            }
+            serde_wasm_bindgen::to_value(&Out {
+                report: &outcome.report,
+                pcb: &self.pcb,
+            })
+            .map_err(|e| JsError::new(&e.to_string()))
+        }
+    }
+
     /// Audit one net's routing without mutating anything: length, via/layer
     /// count, the closest approach to other-net copper (via the router oracle),
     /// and any clearance/short/unconnected DRC issues it's involved in. The
@@ -8033,12 +8213,21 @@ struct WasmParticleSim {
 /// (fail-closed: unbound names error), `options_json` a
 /// [`ParticleSimOptions`]. Returns stats + `vcad.particle-claims/1` set +
 /// unified-receipt claims (basis `predicted` — Provisional by contract).
-#[wasm_bindgen(js_name = particleSimulate)]
-pub fn particle_simulate(
+/// Shared setup for the one-shot and stepwise particle simulations:
+/// parse, resolve, solve the fields, and derive the trace options.
+struct ParticleSimSetup {
+    device: vcad_kernel::vcad_kernel_particle::device::Device,
+    sol: vcad_kernel::vcad_kernel_particle::poisson::Solution,
+    sol_tol: f64,
+    topts: vcad_kernel::vcad_kernel_particle::trace::TraceOptions,
+    opts: ParticleSimOptions,
+}
+
+fn particle_sim_setup(
     spec_json: &str,
     params_json: &str,
     options_json: &str,
-) -> Result<JsValue, JsError> {
+) -> Result<ParticleSimSetup, JsError> {
     use vcad_kernel::vcad_kernel_particle as pk;
     let spec: pk::spec::DeviceSpec =
         serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
@@ -8059,7 +8248,6 @@ pub fn particle_simulate(
     let sopts = pk::poisson::SolveOptions::default();
     let sol = pk::poisson::solve(&device, opts.nr, opts.nz, &sopts)
         .map_err(|e| JsError::new(&e.to_string()))?;
-    let fields = pk::field::FieldMap::new(&device, &sol);
     let mut topts = pk::trace::TraceOptions {
         max_passes: opts.max_passes,
         ..Default::default()
@@ -8073,19 +8261,34 @@ pub fn particle_simulate(
             ),
         });
     }
-    let tracer = pk::trace::Tracer::new(&device, &fields, &sol, topts);
-    let stats = pk::fom::stats(&tracer.launch_ensemble(pk::trace::DEUTERON, opts.particles));
+    Ok(ParticleSimSetup {
+        device,
+        sol,
+        sol_tol: sopts.tol,
+        topts,
+        opts,
+    })
+}
+
+/// Assemble the `particleSimulate` payload from a traced ensemble —
+/// shared by the one-shot and stepwise paths.
+fn particle_sim_readout(
+    setup: &ParticleSimSetup,
+    outcomes: &[vcad_kernel::vcad_kernel_particle::trace::TraceOutcome],
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_particle as pk;
+    let stats = pk::fom::stats(outcomes);
     let op = pk::receipt::OperatingPoint {
-        ion_current_a: opts.ion_current_a,
-        d2_pressure_mtorr: opts.d2_pressure_mtorr,
-        temperature_k: opts.temperature_k,
+        ion_current_a: setup.opts.ion_current_a,
+        d2_pressure_mtorr: setup.opts.d2_pressure_mtorr,
+        temperature_k: setup.opts.temperature_k,
     };
     let claim_set = pk::receipt::predicted_claims(
         &stats,
-        &sol,
-        &topts,
-        sopts.tol,
-        device.max_potential_drop_v(),
+        &setup.sol,
+        &setup.topts,
+        setup.sol_tol,
+        setup.device.max_potential_drop_v(),
         &op,
     );
     let receipt_claims = pk::receipt::design_claims(&claim_set);
@@ -8093,12 +8296,113 @@ pub fn particle_simulate(
         stats,
         claim_set,
         receipt_claims,
-        geometric_transparency: pk::fom::geometric_transparency(&device),
+        geometric_transparency: pk::fom::geometric_transparency(&setup.device),
     };
     // json_compatible: maps serialize as plain objects (a JS `Map` would
     // vanish under JSON.stringify on the TS side).
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen(js_name = particleSimulate)]
+pub fn particle_simulate(
+    spec_json: &str,
+    params_json: &str,
+    options_json: &str,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_particle as pk;
+    let setup = particle_sim_setup(spec_json, params_json, options_json)?;
+    let fields = pk::field::FieldMap::new(&setup.device, &setup.sol);
+    let tracer = pk::trace::Tracer::new(&setup.device, &fields, &setup.sol, setup.topts);
+    let outcomes = tracer.launch_ensemble(pk::trace::DEUTERON, setup.opts.particles);
+    particle_sim_readout(&setup, &outcomes)
+}
+
+/// Stepwise charged-particle simulation: the field solve happens in the
+/// constructor, then the deterministic launch-grid ensemble is traced in
+/// budgeted particle chunks so a host can stream progress. Each particle
+/// depends only on its index, so the result is bit-identical to
+/// `particleSimulate`.
+///
+/// Usage: `new ParticleRun(specJson, paramsJson, optionsJson)` →
+/// `advance(budget)` (particles) until `{done: true}` → `finish()`.
+#[wasm_bindgen(js_name = ParticleRun)]
+pub struct WasmParticleRun {
+    setup: Option<ParticleSimSetup>,
+    outcomes: Vec<vcad_kernel::vcad_kernel_particle::trace::TraceOutcome>,
+    total: usize,
+}
+
+#[wasm_bindgen(js_class = ParticleRun)]
+impl WasmParticleRun {
+    /// Parse, resolve, and solve the device's fields.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        spec_json: &str,
+        params_json: &str,
+        options_json: &str,
+    ) -> Result<WasmParticleRun, JsError> {
+        let setup = particle_sim_setup(spec_json, params_json, options_json)?;
+        // launch_ensemble clamps to >= 2 particles; mirror it here so the
+        // chunked grid is the same grid.
+        let total = setup.opts.particles.max(2);
+        Ok(WasmParticleRun {
+            setup: Some(setup),
+            outcomes: Vec::with_capacity(total),
+            total,
+        })
+    }
+
+    /// Trace up to `budget` particles. Returns `{ done, steps, total }`
+    /// (steps = particles traced).
+    pub fn advance(&mut self, budget: u32) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_particle as pk;
+        let setup = self
+            .setup
+            .as_ref()
+            .ok_or_else(|| JsError::new("ParticleRun already finished"))?;
+        let start = self.outcomes.len();
+        if start < self.total {
+            let end = (start + budget.max(1) as usize).min(self.total);
+            let fields = pk::field::FieldMap::new(&setup.device, &setup.sol);
+            let tracer = pk::trace::Tracer::new(&setup.device, &fields, &setup.sol, setup.topts);
+            self.outcomes.extend(tracer.launch_ensemble_range(
+                pk::trace::DEUTERON,
+                self.total,
+                start,
+                end,
+            ));
+        }
+        #[derive(serde::Serialize)]
+        struct Status {
+            done: bool,
+            steps: usize,
+            total: usize,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: self.outcomes.len() >= self.total,
+            steps: self.outcomes.len(),
+            total: self.total,
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Assemble the same payload `particleSimulate` returns. Errors
+    /// unless the whole ensemble was traced. The run is consumed.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        if self.outcomes.len() < self.total {
+            return Err(JsError::new(&format!(
+                "ParticleRun has only traced {} of {} particles — call advance() to completion first",
+                self.outcomes.len(),
+                self.total
+            )));
+        }
+        let setup = self
+            .setup
+            .take()
+            .ok_or_else(|| JsError::new("ParticleRun already finished"))?;
+        particle_sim_readout(&setup, &self.outcomes)
+    }
 }
 
 #[derive(serde::Deserialize)]
@@ -8220,6 +8524,19 @@ pub fn particle_optimize(
             .mean_ddn_sigma_v_m3
     };
 
+    let plan = particle_opt_plan(&oopts, lo, hi);
+    let (starts, best_idx) = pk::optimize::multi_start_maximize(&mut objective, plan);
+    particle_opt_readout(&names, &starts, best_idx, evals_total)
+}
+
+/// The multi-start plan for `particleOptimize` — shared by the one-shot
+/// and stepwise paths so both search the same seed grid.
+fn particle_opt_plan(
+    oopts: &ParticleOptOptions,
+    lo: Vec<f64>,
+    hi: Vec<f64>,
+) -> vcad_kernel::vcad_kernel_particle::optimize::MultiStart {
+    use vcad_kernel::vcad_kernel_particle as pk;
     let seed_fractions: Vec<f64> = if oopts.multi_start {
         vec![0.2, 0.5, 0.8]
     } else {
@@ -8230,39 +8547,180 @@ pub fn particle_optimize(
         .iter()
         .map(|v| v.start)
         .collect::<Option<Vec<f64>>>();
-
-    let fd = pk::optimize::FdOptions {
-        max_iters: oopts.max_iters,
-        ..pk::optimize::FdOptions::default()
-    };
-    let mut best: Option<pk::optimize::FdResult> = None;
-    let mut starts = Vec::new();
-    for (k, f) in seed_fractions.iter().enumerate() {
-        let x0: Vec<f64> = if k == 0 && explicit.is_some() {
-            explicit.clone().unwrap()
-        } else {
-            lo.iter().zip(&hi).map(|(a, b)| a + f * (b - a)).collect()
-        };
-        let r = pk::optimize::maximize(&mut objective, &x0, &lo, &hi, &fd);
-        starts.push(WasmParticleOptStart {
-            params: names.iter().cloned().zip(r.x.iter().copied()).collect(),
-            value: r.value,
-        });
-        let better = best.as_ref().map(|b| r.value > b.value).unwrap_or(true);
-        if better {
-            best = Some(r);
-        }
+    pk::optimize::MultiStart {
+        lo,
+        hi,
+        explicit_start: explicit,
+        seed_fractions,
+        opts: pk::optimize::FdOptions {
+            max_iters: oopts.max_iters,
+            ..pk::optimize::FdOptions::default()
+        },
     }
-    let best = best.expect("at least one start");
+}
+
+/// Assemble the `particleOptimize` payload — shared by the one-shot and
+/// stepwise paths.
+fn particle_opt_readout(
+    names: &[String],
+    starts: &[vcad_kernel::vcad_kernel_particle::optimize::FdResult],
+    best_idx: usize,
+    evals_total: usize,
+) -> Result<JsValue, JsError> {
+    let best = &starts[best_idx];
     let out = WasmParticleOpt {
         best_params: names.iter().cloned().zip(best.x.iter().copied()).collect(),
         best_sigma_v_m3: best.value,
         evals: evals_total,
-        history: best.history,
-        starts,
+        history: best.history.clone(),
+        starts: starts
+            .iter()
+            .map(|r| WasmParticleOptStart {
+                params: names.iter().cloned().zip(r.x.iter().copied()).collect(),
+                value: r.value,
+            })
+            .collect(),
     };
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Stepwise electrode optimization: each `advance()` call runs exactly
+/// one complete FD-ascent start, so a host can stream per-start progress
+/// (which start, its objective value). Deterministic — identical to
+/// `particleOptimize` by construction (both drive the kernel's
+/// multi-start runner over the same plan).
+///
+/// Usage: `new ParticleOptimizeRun(specJson, paramsJson, optimizeJson)`
+/// → `advance()` until `{done: true}` → `finish()`.
+#[wasm_bindgen(js_name = ParticleOptimizeRun)]
+pub struct WasmParticleOptimizeRun {
+    spec: vcad_kernel::vcad_kernel_particle::spec::DeviceSpec,
+    base: std::collections::BTreeMap<String, f64>,
+    names: Vec<String>,
+    nr: usize,
+    nz: usize,
+    particles: usize,
+    max_passes: u32,
+    run: Option<vcad_kernel::vcad_kernel_particle::optimize::MultiStartRun>,
+    evals_total: usize,
+}
+
+#[wasm_bindgen(js_class = ParticleOptimizeRun)]
+impl WasmParticleOptimizeRun {
+    /// Parse the spec/params/plan and set up the search.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        spec_json: &str,
+        params_json: &str,
+        optimize_json: &str,
+    ) -> Result<WasmParticleOptimizeRun, JsError> {
+        use vcad_kernel::vcad_kernel_particle as pk;
+        let spec: pk::spec::DeviceSpec =
+            serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+        let base: std::collections::BTreeMap<String, f64> = if params_json.trim().is_empty() {
+            Default::default()
+        } else {
+            serde_json::from_str(params_json)
+                .map_err(|e| JsError::new(&format!("bad params: {e}")))?
+        };
+        let oopts: ParticleOptOptions = serde_json::from_str(optimize_json)
+            .map_err(|e| JsError::new(&format!("bad optimize options: {e}")))?;
+        if oopts.variables.is_empty() {
+            return Err(JsError::new("optimize requires at least one variable"));
+        }
+        let lo: Vec<f64> = oopts.variables.iter().map(|v| v.lo).collect();
+        let hi: Vec<f64> = oopts.variables.iter().map(|v| v.hi).collect();
+        let names: Vec<String> = oopts.variables.iter().map(|v| v.name.clone()).collect();
+        let plan = particle_opt_plan(&oopts, lo, hi);
+        Ok(WasmParticleOptimizeRun {
+            spec,
+            base,
+            names,
+            nr: oopts.nr,
+            nz: oopts.nz,
+            particles: oopts.particles,
+            max_passes: oopts.max_passes,
+            run: Some(pk::optimize::MultiStartRun::new(plan)),
+            evals_total: 0,
+        })
+    }
+
+    /// Run the next complete FD-ascent start. Returns
+    /// `{ done, steps, total, value }` — `value` is the just-finished
+    /// start's best objective (D-D sigma-v, m^3/s), absent once done.
+    pub fn advance(&mut self) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_particle as pk;
+        let run = self
+            .run
+            .as_mut()
+            .ok_or_else(|| JsError::new("ParticleOptimizeRun already finished"))?;
+        let (spec, base, names) = (&self.spec, &self.base, &self.names);
+        let (nr, nz, particles, max_passes) = (self.nr, self.nz, self.particles, self.max_passes);
+        let evals_total = &mut self.evals_total;
+        let mut objective = |x: &[f64]| -> f64 {
+            let mut p = base.clone();
+            for (name, value) in names.iter().zip(x) {
+                p.insert(name.clone(), *value);
+            }
+            *evals_total += 1;
+            let Ok(device) = spec.resolve(&p) else {
+                return 0.0;
+            };
+            let Ok(sol) =
+                pk::poisson::solve(&device, nr, nz, &pk::poisson::SolveOptions::default())
+            else {
+                return 0.0;
+            };
+            let fields = pk::field::FieldMap::new(&device, &sol);
+            let topts = pk::trace::TraceOptions {
+                max_passes,
+                ..Default::default()
+            };
+            let tracer = pk::trace::Tracer::new(&device, &fields, &sol, topts);
+            pk::fom::stats(&tracer.launch_ensemble(pk::trace::DEUTERON, particles))
+                .mean_ddn_sigma_v_m3
+        };
+        let value = run.advance_one(&mut objective).map(|r| r.value);
+        #[derive(serde::Serialize)]
+        struct Status {
+            done: bool,
+            steps: usize,
+            total: usize,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            value: Option<f64>,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: run.starts_done() >= run.total_starts(),
+            steps: run.starts_done(),
+            total: run.total_starts(),
+            value,
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Assemble the same payload `particleOptimize` returns. Errors
+    /// unless every start ran. The run is consumed.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        let run = self
+            .run
+            .take()
+            .ok_or_else(|| JsError::new("ParticleOptimizeRun already finished"))?;
+        if run.starts_done() < run.total_starts() {
+            return Err(JsError::new(&format!(
+                "ParticleOptimizeRun has only run {} of {} starts — call advance() to completion first",
+                run.starts_done(),
+                run.total_starts()
+            )));
+        }
+        let best = run.best().expect("at least one start ran").clone();
+        let starts = run.starts().to_vec();
+        let best_idx = starts
+            .iter()
+            .position(|r| r == &best)
+            .expect("best came from starts");
+        particle_opt_readout(&self.names, &starts, best_idx, self.evals_total)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -8666,6 +9124,129 @@ pub fn simulate_flow(
     };
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Stepwise steady-flow solve: the same solve as `simulateFlow`, split so a
+/// host can pump the LBM timestep loop in chunks and emit progress (steps,
+/// residual) between chunks. Bit-identical to the one-shot call — chunk
+/// boundaries cannot change the result because steadiness checks key off the
+/// absolute step count.
+///
+/// Usage: `new FlowRun(specJson, optionsJson, includeFields)` →
+/// `advance(budget)` until `{converged: true}` → `finish()` for the same
+/// payload `simulateFlow` returns.
+#[wasm_bindgen]
+pub struct FlowRun {
+    model: vcad_kernel::vcad_kernel_flow::model::FlowModel,
+    opts: vcad_kernel::vcad_kernel_flow::solve::SolveOptions,
+    stepper: Option<vcad_kernel::vcad_kernel_flow::solve::FlowStepper>,
+    include_fields: bool,
+}
+
+#[wasm_bindgen]
+impl FlowRun {
+    /// Parse and resolve the spec, derive the scaling, initialize the lattice.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        spec_json: &str,
+        options_json: &str,
+        include_fields: bool,
+    ) -> Result<FlowRun, JsError> {
+        use vcad_kernel::vcad_kernel_flow as fl;
+        let spec: fl::spec::FlowSpec =
+            serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
+        let opts: fl::solve::SolveOptions =
+            if options_json.trim().is_empty() || options_json.trim() == "{}" {
+                Default::default()
+            } else {
+                serde_json::from_str(options_json)
+                    .map_err(|e| JsError::new(&format!("bad options: {e}")))?
+            };
+        let model = spec.resolve().map_err(|e| JsError::new(&e.to_string()))?;
+        let n_voxels: usize = model.divisions.iter().product();
+        if n_voxels > 2_000_000 {
+            return Err(JsError::new(&format!(
+                "grid too large for the MCP tier: {n_voxels} voxels (cap 2,000,000) — lower `divisions`"
+            )));
+        }
+        let stepper =
+            fl::solve::FlowStepper::new(&model, &opts).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(FlowRun {
+            model,
+            opts,
+            stepper: Some(stepper),
+            include_fields,
+        })
+    }
+
+    /// Run up to `budget` timesteps. Returns
+    /// `{ converged, steps, max_steps, residual }`; errors exactly as the
+    /// one-shot solve does (divergence, budget exhausted without steadiness).
+    pub fn advance(&mut self, budget: u32) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_flow::solve::FlowProgress;
+        let stepper = self
+            .stepper
+            .as_mut()
+            .ok_or_else(|| JsError::new("FlowRun already finished"))?;
+        let progress = stepper
+            .advance(budget.max(1) as usize)
+            .map_err(|e| JsError::new(&e.to_string()))?;
+        #[derive(serde::Serialize)]
+        struct Status {
+            converged: bool,
+            steps: usize,
+            max_steps: usize,
+            residual: f64,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            converged: matches!(progress, FlowProgress::Converged),
+            steps: stepper.steps(),
+            max_steps: stepper.max_steps(),
+            residual: stepper.residual(),
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Assemble the same payload `simulateFlow` returns. Errors unless a prior
+    /// `advance` reported convergence. The run is consumed; further calls error.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_flow as fl;
+        let stepper = self
+            .stepper
+            .take()
+            .ok_or_else(|| JsError::new("FlowRun already finished"))?;
+        let sol = stepper
+            .into_solution()
+            .ok_or_else(|| JsError::new("FlowRun has not converged — call advance() first"))?;
+        let model = &self.model;
+        let claim_set = fl::receipt::predicted_claims(model, &sol, &self.opts, None);
+        let receipt_claims = fl::receipt::design_claims(&claim_set);
+        let fields = self.include_fields.then(|| WasmFlowFields {
+            velocity_m_s: sol.velocity_m_s.clone(),
+            gauge_pressure_pa: sol.gauge_pressure_pa.clone(),
+            temperature_c: sol.temperature_c.clone(),
+        });
+        let out = WasmFlowSolve {
+            divisions: model.divisions,
+            voxel_mm: model.voxel_mm(),
+            scaling: sol.scaling,
+            steps: sol.steps,
+            steady_residual: sol.steady_residual,
+            pressure_drop_pa: sol.pressure_drop_pa,
+            inlet_flow_m3_s: sol.inlet_flow_m3_s,
+            outlet_flow_m3_s: sol.outlet_flow_m3_s,
+            mass_balance_residual: sol.mass_balance_residual,
+            max_speed_m_s: sol.max_speed_m_s,
+            outlet_temp_c: sol.outlet_temp_c,
+            heat_pickup_w: sol.heat_pickup_w,
+            wall_heat_w: sol.wall_heat_w,
+            claim_set,
+            receipt_claims,
+            fields,
+        };
+        let ser = serde_wasm_bindgen::Serializer::json_compatible();
+        serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -9787,12 +10368,27 @@ struct WasmPhotonicsSim {
     receipt_claims: Vec<vcad_receipt::ReceiptClaim>,
 }
 
-/// Forward 2D TM FDTD run of a rect-composed photonic device: slab-mode
-/// line source, input + output flux monitors, transmission spectrum, and
-/// predicted claims (the splitter claim family; a single-output device
-/// reads arm B as zero).
-#[wasm_bindgen(js_name = photonicsSimulate)]
-pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue, JsError> {
+/// Everything a forward photonics run needs between setup and the flux
+/// readout: the built simulation, its monitors, and the readout inputs.
+/// Shared by the one-shot `photonicsSimulate` and the stepwise
+/// `PhotonicsRun`, so the two paths are identical by construction.
+struct PhotonicsSetup {
+    sim: vcad_kernel::vcad_kernel_photonics::Simulation,
+    f_in: vcad_kernel::vcad_kernel_photonics::FluxId,
+    f_outs: Vec<vcad_kernel::vcad_kernel_photonics::FluxId>,
+    freqs: Vec<f64>,
+    f0: f64,
+    n_eff: f64,
+    delta: f64,
+    nx: usize,
+    ny: usize,
+    wavelength_um: f64,
+    n_core: f64,
+    steps: usize,
+}
+
+/// Validate the spec/options and assemble the simulation (no timesteps run).
+fn photonics_setup(spec_json: &str, options_json: &str) -> Result<PhotonicsSetup, JsError> {
     use vcad_kernel::vcad_kernel_photonics as ph;
     let spec: WasmPhotonicsSpec =
         serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
@@ -9936,8 +10532,39 @@ pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue
             freqs: freqs.clone(),
         }));
     }
-    sim.run(opts.steps);
+    Ok(PhotonicsSetup {
+        sim,
+        f_in,
+        f_outs,
+        freqs,
+        f0,
+        n_eff: mode.n_eff,
+        delta,
+        nx,
+        ny,
+        wavelength_um: spec.wavelength_um,
+        n_core: spec.n_core,
+        steps: opts.steps,
+    })
+}
 
+/// Read the monitors and price the claims (after all timesteps have run).
+fn photonics_finish(setup: PhotonicsSetup) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_photonics as ph;
+    let PhotonicsSetup {
+        sim,
+        f_in,
+        f_outs,
+        freqs,
+        f0,
+        n_eff,
+        delta,
+        nx,
+        ny,
+        wavelength_um,
+        n_core,
+        steps,
+    } = setup;
     let p_in = sim.flux_power(f_in);
     let p_a = sim.flux_power(f_outs[0]);
     let p_b = f_outs.get(1).map(|id| sim.flux_power(*id));
@@ -9949,21 +10576,98 @@ pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue
             p_arm_b: p_b.as_ref().map(|p| p[i].1).unwrap_or(0.0),
         })
         .collect();
-    let provenance =
-        ph::receipt::SolverProvenance::from_sim(&sim, spec.wavelength_um, spec.n_core, opts.steps);
+    let provenance = ph::receipt::SolverProvenance::from_sim(&sim, wavelength_um, n_core, steps);
     let claim_set = ph::receipt::splitter_claims(&meas, f0, provenance, None)
         .map_err(|e| JsError::new(&e.to_string()))?;
     let receipt_claims = ph::receipt::design_claims(&claim_set);
     let out = WasmPhotonicsSim {
         grid: [nx, ny],
         delta_um: delta,
-        n_eff: mode.n_eff,
+        n_eff,
         freqs,
         claim_set,
         receipt_claims,
     };
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+/// Forward 2D TM FDTD run of a rect-composed photonic device: slab-mode
+/// line source, input + output flux monitors, transmission spectrum, and
+/// predicted claims (the splitter claim family; a single-output device
+/// reads arm B as zero).
+#[wasm_bindgen(js_name = photonicsSimulate)]
+pub fn photonics_simulate(spec_json: &str, options_json: &str) -> Result<JsValue, JsError> {
+    let mut setup = photonics_setup(spec_json, options_json)?;
+    let steps = setup.steps;
+    setup.sim.run(steps);
+    photonics_finish(setup)
+}
+
+/// Stepwise forward FDTD run: the same simulation as `photonicsSimulate`,
+/// split so a host can pump the timestep loop in chunks and emit progress
+/// between chunks. `run(a)` then `run(b)` is exactly `run(a+b)`, so the
+/// chunked result is bit-identical to the one-shot call.
+///
+/// Usage: `new PhotonicsRun(specJson, optionsJson)` → `advance(budget)` until
+/// `{done: true}` → `finish()` for the same payload `photonicsSimulate`
+/// returns.
+#[wasm_bindgen]
+pub struct PhotonicsRun {
+    setup: Option<PhotonicsSetup>,
+    steps_done: usize,
+}
+
+#[wasm_bindgen]
+impl PhotonicsRun {
+    /// Validate and assemble the simulation (no timesteps run yet).
+    #[wasm_bindgen(constructor)]
+    pub fn new(spec_json: &str, options_json: &str) -> Result<PhotonicsRun, JsError> {
+        Ok(PhotonicsRun {
+            setup: Some(photonics_setup(spec_json, options_json)?),
+            steps_done: 0,
+        })
+    }
+
+    /// Run up to `budget` FDTD timesteps. Returns `{ done, steps, total }`.
+    pub fn advance(&mut self, budget: u32) -> Result<JsValue, JsError> {
+        let setup = self
+            .setup
+            .as_mut()
+            .ok_or_else(|| JsError::new("PhotonicsRun already finished"))?;
+        let total = setup.steps;
+        let n = (budget.max(1) as usize).min(total - self.steps_done.min(total));
+        setup.sim.run(n);
+        self.steps_done += n;
+        #[derive(serde::Serialize)]
+        struct Status {
+            done: bool,
+            steps: usize,
+            total: usize,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: self.steps_done >= total,
+            steps: self.steps_done,
+            total,
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Read the monitors and price the claims. Errors unless every timestep
+    /// has run. The run is consumed; further calls error.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        let setup = self
+            .setup
+            .take()
+            .ok_or_else(|| JsError::new("PhotonicsRun already finished"))?;
+        if self.steps_done < setup.steps {
+            return Err(JsError::new(&format!(
+                "PhotonicsRun has only run {} of {} steps — call advance() to completion first",
+                self.steps_done, setup.steps
+            )));
+        }
+        photonics_finish(setup)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -10002,8 +10706,19 @@ struct WasmNeutronicsSim {
 /// `spec_json` is a `vcad_kernel_neutronics::spec::ShieldSpec` (named
 /// parameters allowed; histories/batches/seed ride inside its `run`
 /// block), `params_json` a `{name: value}` map binding them.
-#[wasm_bindgen(js_name = neutronicsSimulate)]
-pub fn neutronics_simulate(spec_json: &str, params_json: &str) -> Result<JsValue, JsError> {
+/// Parse the spec/params and apply the MCP-tier history cap — shared by
+/// the one-shot and stepwise paths so they gate identically.
+#[allow(clippy::type_complexity)]
+fn neutronics_setup(
+    spec_json: &str,
+    params_json: &str,
+) -> Result<
+    (
+        vcad_kernel::vcad_kernel_neutronics::spec::ShieldSpec,
+        std::collections::BTreeMap<String, f64>,
+    ),
+    JsError,
+> {
     use vcad_kernel::vcad_kernel_neutronics as nk;
     let spec: nk::spec::ShieldSpec =
         serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
@@ -10021,14 +10736,21 @@ pub fn neutronics_simulate(spec_json: &str, params_json: &str) -> Result<JsValue
             "too many histories for the MCP tier: {total_requested} (cap 5,000,000) — error bars scale as 1/sqrt(N)"
         )));
     }
-    let (doses, result) =
-        nk::spec::evaluate(&spec, &params).map_err(|e| JsError::new(&e.to_string()))?;
-    let resolved = spec
-        .resolve(&params)
+    Ok((spec, params))
+}
+
+/// Assemble the `neutronicsSimulate` payload — shared by the one-shot
+/// and stepwise paths.
+fn neutronics_readout(
+    spec: &vcad_kernel::vcad_kernel_neutronics::spec::ShieldSpec,
+    params: &std::collections::BTreeMap<String, f64>,
+    detector_regions: &[(String, usize)],
+    doses: &[vcad_kernel::vcad_kernel_neutronics::spec::DetectorDose],
+    result: &vcad_kernel::vcad_kernel_neutronics::transport::RunResult,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_neutronics as nk;
+    let claim_set = nk::receipt::claims_from_run(spec, detector_regions, doses, result, params)
         .map_err(|e| JsError::new(&e.to_string()))?;
-    let claim_set =
-        nk::receipt::claims_from_run(&spec, &resolved.detector_regions, &doses, &result, &params)
-            .map_err(|e| JsError::new(&e.to_string()))?;
     let receipt_claims = nk::receipt::design_claims(&claim_set);
     let out = WasmNeutronicsSim {
         detectors: doses
@@ -10054,6 +10776,88 @@ pub fn neutronics_simulate(spec_json: &str, params_json: &str) -> Result<JsValue
     };
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen(js_name = neutronicsSimulate)]
+pub fn neutronics_simulate(spec_json: &str, params_json: &str) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_neutronics as nk;
+    let (spec, params) = neutronics_setup(spec_json, params_json)?;
+    let (doses, result) =
+        nk::spec::evaluate(&spec, &params).map_err(|e| JsError::new(&e.to_string()))?;
+    let resolved = spec
+        .resolve(&params)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+    neutronics_readout(&spec, &params, &resolved.detector_regions, &doses, &result)
+}
+
+/// Stepwise Monte Carlo neutron shielding run: the batch loop in budgeted
+/// chunks so a host can stream progress. Each batch owns an independent
+/// RNG stream, so the result is bit-identical to `neutronicsSimulate`.
+///
+/// Usage: `new NeutronicsRun(specJson, paramsJson)` → `advance(budget)`
+/// (batches) until `{done: true}` → `finish()` for the one-shot payload.
+#[wasm_bindgen(js_name = NeutronicsRun)]
+pub struct WasmNeutronicsRun {
+    spec: vcad_kernel::vcad_kernel_neutronics::spec::ShieldSpec,
+    params: std::collections::BTreeMap<String, f64>,
+    run: Option<vcad_kernel::vcad_kernel_neutronics::spec::EvaluateRun>,
+}
+
+#[wasm_bindgen(js_class = NeutronicsRun)]
+impl WasmNeutronicsRun {
+    /// Parse and gate the spec, resolve it, set up the tallies.
+    #[wasm_bindgen(constructor)]
+    pub fn new(spec_json: &str, params_json: &str) -> Result<WasmNeutronicsRun, JsError> {
+        use vcad_kernel::vcad_kernel_neutronics as nk;
+        let (spec, params) = neutronics_setup(spec_json, params_json)?;
+        let run =
+            nk::spec::EvaluateRun::new(&spec, &params).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmNeutronicsRun {
+            spec,
+            params,
+            run: Some(run),
+        })
+    }
+
+    /// Transport up to `budget` whole batches. Returns
+    /// `{ done, steps, total }` (steps = batches transported).
+    pub fn advance(&mut self, budget: u32) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_neutronics::transport::TransportProgress;
+        let run = self
+            .run
+            .as_mut()
+            .ok_or_else(|| JsError::new("NeutronicsRun already finished"))?;
+        let progress = run.advance(budget.max(1) as usize);
+        #[derive(serde::Serialize)]
+        struct Status {
+            done: bool,
+            steps: usize,
+            total: usize,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: matches!(progress, TransportProgress::Done),
+            steps: run.batches_done(),
+            total: run.total_batches(),
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Assemble the same payload `neutronicsSimulate` returns (advance to
+    /// completion first). The run is consumed.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        let run = self
+            .run
+            .take()
+            .ok_or_else(|| JsError::new("NeutronicsRun already finished"))?;
+        let (doses, result, resolved) = run.finish();
+        neutronics_readout(
+            &self.spec,
+            &self.params,
+            &resolved.detector_regions,
+            &doses,
+            &result,
+        )
+    }
 }
 
 // =============================================================================
@@ -10118,8 +10922,11 @@ struct WasmLatticeGaugeOut {
 /// binned-jackknife mean ± error, deterministic per seed.
 ///
 /// `spec_json` is a `vcad_kernel_qcd::spec::SimSpec`.
-#[wasm_bindgen(js_name = latticeGaugeSimulate)]
-pub fn lattice_gauge_simulate(spec_json: &str) -> Result<JsValue, JsError> {
+/// Parse the spec and apply the MCP-tier cost gate — shared by the
+/// one-shot and stepwise paths so they gate identically.
+fn lattice_gauge_setup(
+    spec_json: &str,
+) -> Result<vcad_kernel::vcad_kernel_qcd::spec::SimSpec, JsError> {
     use vcad_kernel::vcad_kernel_qcd as qcd;
     let spec: qcd::spec::SimSpec =
         serde_json::from_str(spec_json).map_err(|e| JsError::new(&format!("bad spec: {e}")))?;
@@ -10153,7 +10960,15 @@ pub fn lattice_gauge_simulate(spec_json: &str) -> Result<JsValue, JsError> {
              so a smaller honest run beats a truncated big one."
         )));
     }
-    let result = qcd::spec::run(&spec).map_err(|e| JsError::new(&e.to_string()))?;
+    Ok(spec)
+}
+
+/// Assemble the `latticeGaugeSimulate` payload from a finished run —
+/// shared by the one-shot and stepwise paths.
+fn lattice_gauge_readout(
+    result: vcad_kernel::vcad_kernel_qcd::spec::SimResult,
+) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_qcd as qcd;
     let creutz_ratios = qcd::analysis::creutz_ratios(&result.wilson_loops);
     let static_potential = qcd::analysis::static_potential(&result.temporal_loops);
     let cornell_fit = qcd::analysis::fit_cornell(&static_potential);
@@ -10171,4 +10986,70 @@ pub fn lattice_gauge_simulate(spec_json: &str) -> Result<JsValue, JsError> {
     };
     let ser = serde_wasm_bindgen::Serializer::json_compatible();
     serde::Serialize::serialize(&out, &ser).map_err(|e| JsError::new(&e.to_string()))
+}
+
+#[wasm_bindgen(js_name = latticeGaugeSimulate)]
+pub fn lattice_gauge_simulate(spec_json: &str) -> Result<JsValue, JsError> {
+    use vcad_kernel::vcad_kernel_qcd as qcd;
+    let spec = lattice_gauge_setup(spec_json)?;
+    let result = qcd::spec::run(&spec).map_err(|e| JsError::new(&e.to_string()))?;
+    lattice_gauge_readout(result)
+}
+
+/// Stepwise lattice gauge run: the Monte Carlo sweep loop in budgeted
+/// chunks so a host can stream progress between kernel calls. RNG state
+/// lives in the run, so the result is bit-identical to
+/// `latticeGaugeSimulate`.
+///
+/// Usage: `new LatticeGaugeRun(specJson)` → `advance(budget)` (sweeps)
+/// until `{done: true}` → `finish()` for the one-shot payload.
+#[wasm_bindgen(js_name = LatticeGaugeRun)]
+pub struct WasmLatticeGaugeRun {
+    run: Option<vcad_kernel::vcad_kernel_qcd::spec::SimRun>,
+}
+
+#[wasm_bindgen(js_class = LatticeGaugeRun)]
+impl WasmLatticeGaugeRun {
+    /// Parse and gate the spec, initialize the lattice and RNG.
+    #[wasm_bindgen(constructor)]
+    pub fn new(spec_json: &str) -> Result<WasmLatticeGaugeRun, JsError> {
+        use vcad_kernel::vcad_kernel_qcd as qcd;
+        let spec = lattice_gauge_setup(spec_json)?;
+        let run = qcd::spec::SimRun::new(&spec).map_err(|e| JsError::new(&e.to_string()))?;
+        Ok(WasmLatticeGaugeRun { run: Some(run) })
+    }
+
+    /// Perform up to `budget` compound sweeps. Returns
+    /// `{ done, steps, total }` (steps = sweeps completed).
+    pub fn advance(&mut self, budget: u32) -> Result<JsValue, JsError> {
+        use vcad_kernel::vcad_kernel_qcd::spec::RunProgress;
+        let run = self
+            .run
+            .as_mut()
+            .ok_or_else(|| JsError::new("LatticeGaugeRun already finished"))?;
+        let progress = run.advance(budget.max(1) as usize);
+        #[derive(serde::Serialize)]
+        struct Status {
+            done: bool,
+            steps: usize,
+            total: usize,
+        }
+        serde_wasm_bindgen::to_value(&Status {
+            done: matches!(progress, RunProgress::Done),
+            steps: run.sweeps_done(),
+            total: run.total_sweeps(),
+        })
+        .map_err(|e| JsError::new(&e.to_string()))
+    }
+
+    /// Assemble the same payload `latticeGaugeSimulate` returns. Errors
+    /// unless `advance` reported done. The run is consumed.
+    pub fn finish(&mut self) -> Result<JsValue, JsError> {
+        let run = self
+            .run
+            .take()
+            .ok_or_else(|| JsError::new("LatticeGaugeRun already finished"))?;
+        let result = run.finish().map_err(|e| JsError::new(&e.to_string()))?;
+        lattice_gauge_readout(result)
+    }
 }

--- a/packages/engine/src/atoms.ts
+++ b/packages/engine/src/atoms.ts
@@ -116,6 +116,11 @@ interface WasmMdSim {
   moleculeJson(): string;
   free(): void;
 }
+interface WasmAtomsMinimizeRun {
+  advance(budget: number): string;
+  finish(): string;
+  free(): void;
+}
 interface AtomsWasm {
   atoms_parse_xyz(text: string): string;
   atoms_write_xyz(json: string): string;
@@ -124,6 +129,22 @@ interface AtomsWasm {
   atoms_homogenize(molJson: string, cfgJson: string): string;
   atoms_build_receipt(m: string, ff: string, run: string, p: string, o: string): string;
   MdSim: new (moleculeJson: string, configJson: string) => WasmMdSim;
+  /** Stepwise minimizer; absent on older kernel builds. */
+  AtomsMinimizeRun?: new (
+    molJson: string,
+    cfgJson: string,
+    maxIters: number,
+    forceTol: number,
+  ) => WasmAtomsMinimizeRun;
+}
+
+/** Per-chunk status from the stepwise energy minimization. */
+export interface MinimizeChunkStatus {
+  done: boolean;
+  steps: number;
+  total: number;
+  energy: number;
+  maxForce: number;
 }
 
 /** Resolve the kernel WASM module through the shared singleton. */
@@ -170,6 +191,39 @@ export async function minimizeEnergy(
   const wasm = await ensureWasm();
   const out = wasm.atoms_minimize(JSON.stringify(mol), JSON.stringify(config), maxIters, forceTol);
   return JSON.parse(out) as { result: MinimizeResult; molecule: MoleculeSystem };
+}
+
+/**
+ * Chunked form of {@link minimizeEnergy}: runs the FIRE iteration loop in
+ * budgeted chunks, invoking `onChunk` between kernel calls so a host can
+ * stream progress. All FIRE state lives in the kernel run, so the result
+ * is bit-identical to the one-shot. Falls back to the one-shot on an
+ * older kernel.
+ */
+export async function minimizeEnergyChunked(
+  mol: MoleculeSystem,
+  config: MdConfig = {},
+  maxIters = 2000,
+  forceTol = 1e-4,
+  onChunk?: (status: MinimizeChunkStatus) => void,
+  chunkIters = 100,
+): Promise<{ result: MinimizeResult; molecule: MoleculeSystem }> {
+  const wasm = await ensureWasm();
+  const Runner = wasm.AtomsMinimizeRun;
+  if (typeof Runner !== "function") {
+    return minimizeEnergy(mol, config, maxIters, forceTol);
+  }
+  const run = new Runner(JSON.stringify(mol), JSON.stringify(config), maxIters, forceTol);
+  try {
+    for (;;) {
+      const status = JSON.parse(run.advance(chunkIters)) as MinimizeChunkStatus;
+      onChunk?.(status);
+      if (status.done) break;
+    }
+    return JSON.parse(run.finish()) as { result: MinimizeResult; molecule: MoleculeSystem };
+  } finally {
+    run.free?.();
+  }
 }
 
 /**

--- a/packages/engine/src/ecad.ts
+++ b/packages/engine/src/ecad.ts
@@ -429,6 +429,60 @@ export async function runFabPrep(
   }
 }
 
+/** Per-round status from the stepwise fab-prep driver. */
+export interface FabPrepRoundStatus {
+  done: boolean;
+  round: number;
+  attributable: number;
+  max_rounds: number;
+}
+
+/**
+ * Chunked form of {@link runFabPrep}: drives the kernel's stepwise
+ * `FabPrepRun` session one strip-and-re-route round at a time, invoking
+ * `onRound` between kernel calls so a host can stream progress while the
+ * Node event loop is unblocked. Bit-identical outcome to the one-shot call —
+ * `run_fab_prep` is implemented on the same kernel session type. Falls back
+ * to the one-shot path on a kernel that predates `FabPrepRun`.
+ */
+export async function runFabPrepChunked(
+  pcb: Pcb,
+  options?: FabPrepOptions,
+  onRound?: (status: FabPrepRoundStatus) => void | Promise<void>,
+): Promise<EcadProbe<{ report: FabPrepReport; pcb: Pcb }>> {
+  const wasm = await loadEcadWasm();
+  if (!wasm) {
+    return { ok: false, reason: "unavailable", message: "ECAD kernel WASM not loaded" };
+  }
+  const Runner = (wasm as { FabPrepRun?: new (pcb: string, opts?: string) => FabPrepRunHandle })
+    .FabPrepRun;
+  if (typeof Runner !== "function") {
+    return runFabPrep(pcb, options);
+  }
+  try {
+    const run = new Runner(JSON.stringify(pcb), options ? JSON.stringify(options) : undefined);
+    try {
+      for (;;) {
+        const status = run.round() as FabPrepRoundStatus;
+        await onRound?.(status);
+        if (status.done) break;
+      }
+      const out = run.finish() as { report: FabPrepReport; pcb: Pcb };
+      return { ok: true, value: out };
+    } finally {
+      run.free?.();
+    }
+  } catch (e) {
+    return { ok: false, reason: "error", message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+interface FabPrepRunHandle {
+  round(): unknown;
+  finish(): unknown;
+  free?(): void;
+}
+
 // ---------------------------------------------------------------------------
 // PCB Design-for-Manufacturing (fab-profile capability checks)
 // ---------------------------------------------------------------------------

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -189,6 +189,7 @@ export {
   getPcbDfmPack,
   tryRunDrc,
   runFabPrep,
+  runFabPrepChunked,
   critiqueRoute,
   netContinuity,
   runErc,
@@ -330,6 +331,7 @@ export {
   writeXyz,
   inspectMolecule,
   minimizeEnergy,
+  minimizeEnergyChunked,
   homogenizeMaterial,
   buildReceipt as buildMoleculeReceipt,
 } from "./atoms.js";
@@ -337,6 +339,7 @@ export type {
   MoleculeReport,
   MdObservation,
   MinimizeResult as AtomsMinimizeResult,
+  MinimizeChunkStatus,
   MdConfig,
   MaterialCard,
 } from "./atoms.js";
@@ -594,6 +597,19 @@ export interface KernelModule {
     positions: Float32Array,
     indices: Uint32Array,
   ) => unknown;
+  /** Stepwise SIMP topology optimization (one iteration per step() call). */
+  TopoOptRun?: {
+    beginBox(
+      specJson: string,
+      minX: number,
+      minY: number,
+      minZ: number,
+      maxX: number,
+      maxY: number,
+      maxZ: number,
+    ): TopoOptRunHandle;
+    beginMesh(specJson: string, positions: Float32Array, indices: Uint32Array): TopoOptRunHandle;
+  };
   /** Charged-particle optics simulation (DeviceSpec/params/options JSON). */
   particleSimulate?: (
     specJson: string,
@@ -606,6 +622,18 @@ export interface KernelModule {
     paramsJson: string,
     optimizeJson: string,
   ) => unknown;
+  /** Stepwise charged-particle simulation (chunked particle-trace loop). */
+  ParticleRun?: new (
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+  ) => ChunkedRunHandle<SimChunkStatus>;
+  /** Stepwise electrode optimization (one FD-ascent start per advance). */
+  ParticleOptimizeRun?: new (
+    specJson: string,
+    paramsJson: string,
+    optimizeJson: string,
+  ) => StartRunHandle<ParticleOptChunkStatus>;
   /** Tolerance stackup analysis (StackupSpec/params/options JSON). */
   toleranceAnalyze?: (
     specJson: string,
@@ -631,6 +659,14 @@ export interface KernelModule {
     optionsJson: string,
     includeFields: boolean,
   ) => unknown;
+  /** Stepwise LBM flow solve (chunked timestep loop). */
+  FlowRun?: new (
+    specJson: string,
+    optionsJson: string,
+    includeFields: boolean,
+  ) => ChunkedRunHandle<FlowChunkStatus>;
+  /** Stepwise FDTD photonics run (chunked timestep loop). */
+  PhotonicsRun?: new (specJson: string, optionsJson: string) => ChunkedRunHandle<SimChunkStatus>;
   /** Semantic entity-level diff of two `.vcad` documents (JSON strings). */
   documentDiff?: (oldJson: string, newJson: string) => unknown;
   /** Apply a `DocumentDiff` to a document, returning the patched document. */
@@ -691,8 +727,15 @@ export interface KernelModule {
   photonicsSimulate?: (specJson: string, optionsJson: string) => unknown;
   /** Monte Carlo neutron shielding run (ShieldSpec/params JSON). */
   neutronicsSimulate?: (specJson: string, paramsJson: string) => unknown;
+  /** Stepwise neutron shielding run (chunked batch loop). */
+  NeutronicsRun?: new (
+    specJson: string,
+    paramsJson: string,
+  ) => ChunkedRunHandle<SimChunkStatus>;
   /** Lattice gauge theory Monte Carlo run (SimSpec JSON). */
   latticeGaugeSimulate?: (specJson: string) => unknown;
+  /** Stepwise lattice gauge run (chunked Monte Carlo sweep loop). */
+  LatticeGaugeRun?: new (specJson: string) => ChunkedRunHandle<SimChunkStatus>;
   /** Static structural analysis of a box solid. */
   analyzeStaticsBox?: (
     specJson: string,
@@ -816,6 +859,77 @@ export interface TopoOptResult {
   grid: [number, number, number];
   /** Voxel edge length in mm. */
   voxelSize: number;
+}
+
+/** Generic handle on a kernel stepwise-run class (advance/finish/free). */
+export interface ChunkedRunHandle<S> {
+  advance(budget: number): S;
+  finish(): unknown;
+  free?(): void;
+}
+
+/** Per-chunk status from the stepwise LBM flow solve. */
+export interface FlowChunkStatus {
+  converged: boolean;
+  steps: number;
+  max_steps: number;
+  residual: number;
+}
+
+/** Per-chunk status from a fixed-step stepwise simulation run. */
+export interface SimChunkStatus {
+  done: boolean;
+  steps: number;
+  total: number;
+}
+
+/** Per-start status from the stepwise electrode optimization. */
+export interface ParticleOptChunkStatus {
+  done: boolean;
+  steps: number;
+  total: number;
+  /** The just-finished start's best objective (absent once done). */
+  value?: number;
+}
+
+/** Handle on a kernel stepwise-run class that advances one unit per call. */
+export interface StartRunHandle<S> {
+  advance(): S;
+  finish(): unknown;
+  free?(): void;
+}
+
+/** Per-iteration status from the stepwise topology-opt run. */
+export interface TopoOptStepStatus {
+  done: boolean;
+  iteration: number;
+  compliance: number;
+  change: number;
+}
+
+/** Handle on the kernel's stepwise `TopoOptRun` class. */
+export interface TopoOptRunHandle {
+  maxIterations(): number;
+  step(): TopoOptStepStatus;
+  finish(): unknown;
+  free?(): void;
+}
+
+/** Pump a stepwise topo-opt run to completion, narrating between kernel calls. */
+function driveTopoOptRun(
+  run: TopoOptRunHandle,
+  onStep?: (status: TopoOptStepStatus) => void,
+): TopoOptResult {
+  try {
+    for (;;) {
+      const status = run.step();
+      onStep?.(status);
+      if (status.done) break;
+    }
+    return run.finish() as TopoOptResult;
+  } finally {
+    run.free?.();
+  }
 }
 
 /**
@@ -1076,8 +1190,11 @@ export class Engine {
       mesh_clearance: (wasmModule as Record<string, unknown>).mesh_clearance as KernelModule["mesh_clearance"],
       topologyOptimizeBox: (wasmModule as Record<string, unknown>).topologyOptimizeBox as KernelModule["topologyOptimizeBox"],
       topologyOptimizeMesh: (wasmModule as Record<string, unknown>).topologyOptimizeMesh as KernelModule["topologyOptimizeMesh"],
+      TopoOptRun: (wasmModule as Record<string, unknown>).TopoOptRun as KernelModule["TopoOptRun"],
       particleSimulate: (wasmModule as Record<string, unknown>).particleSimulate as KernelModule["particleSimulate"],
       particleOptimize: (wasmModule as Record<string, unknown>).particleOptimize as KernelModule["particleOptimize"],
+      ParticleRun: (wasmModule as Record<string, unknown>).ParticleRun as KernelModule["ParticleRun"],
+      ParticleOptimizeRun: (wasmModule as Record<string, unknown>).ParticleOptimizeRun as KernelModule["ParticleOptimizeRun"],
       toleranceAnalyze: (wasmModule as Record<string, unknown>).toleranceAnalyze as KernelModule["toleranceAnalyze"],
       thermalSolve: (wasmModule as Record<string, unknown>).thermalSolve as KernelModule["thermalSolve"],
       thermalSolveTransient: (wasmModule as Record<string, unknown>).thermalSolveTransient as KernelModule["thermalSolveTransient"],
@@ -1096,8 +1213,12 @@ export class Engine {
       emSimulate: (wasmModule as Record<string, unknown>).emSimulate as KernelModule["emSimulate"],
       antennaAnalyze: (wasmModule as Record<string, unknown>).antennaAnalyze as KernelModule["antennaAnalyze"],
       photonicsSimulate: (wasmModule as Record<string, unknown>).photonicsSimulate as KernelModule["photonicsSimulate"],
+      FlowRun: (wasmModule as Record<string, unknown>).FlowRun as KernelModule["FlowRun"],
+      PhotonicsRun: (wasmModule as Record<string, unknown>).PhotonicsRun as KernelModule["PhotonicsRun"],
       neutronicsSimulate: (wasmModule as Record<string, unknown>).neutronicsSimulate as KernelModule["neutronicsSimulate"],
+      NeutronicsRun: (wasmModule as Record<string, unknown>).NeutronicsRun as KernelModule["NeutronicsRun"],
       latticeGaugeSimulate: (wasmModule as Record<string, unknown>).latticeGaugeSimulate as KernelModule["latticeGaugeSimulate"],
+      LatticeGaugeRun: (wasmModule as Record<string, unknown>).LatticeGaugeRun as KernelModule["LatticeGaugeRun"],
       analyzeStaticsBox: (wasmModule as Record<string, unknown>).analyzeStaticsBox as KernelModule["analyzeStaticsBox"],
       analyzeStaticsMesh: (wasmModule as Record<string, unknown>).analyzeStaticsMesh as KernelModule["analyzeStaticsMesh"],
     }, compiledWasmModule);
@@ -1383,6 +1504,68 @@ export class Engine {
   }
 
   /**
+   * Chunked form of {@link particleSimulate}: the field solve happens up
+   * front, then the deterministic launch-grid ensemble is traced in
+   * budgeted particle chunks, invoking `onChunk` between kernel calls so
+   * a host can stream progress. Each particle depends only on its index,
+   * so the result is bit-identical to the one-shot. Falls back to the
+   * one-shot on an older kernel.
+   */
+  particleSimulateChunked(
+    specJson: string,
+    paramsJson: string,
+    optionsJson: string,
+    onChunk?: (status: SimChunkStatus) => void,
+    chunkParticles = 8,
+  ): unknown {
+    const Runner = this.kernel.ParticleRun;
+    if (typeof Runner !== "function") {
+      return this.particleSimulate(specJson, paramsJson, optionsJson);
+    }
+    const run = new Runner(specJson, paramsJson, optionsJson);
+    try {
+      for (;;) {
+        const status = run.advance(chunkParticles) as SimChunkStatus;
+        onChunk?.(status);
+        if (status.done) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
+  }
+
+  /**
+   * Chunked form of {@link particleOptimize}: each chunk runs one
+   * complete FD-ascent start, invoking `onChunk` between kernel calls so
+   * a host can stream per-start progress (which start, its objective).
+   * Deterministic — identical to the one-shot by construction. Falls
+   * back to the one-shot on an older kernel.
+   */
+  particleOptimizeChunked(
+    specJson: string,
+    paramsJson: string,
+    optimizeJson: string,
+    onChunk?: (status: ParticleOptChunkStatus) => void,
+  ): unknown {
+    const Runner = this.kernel.ParticleOptimizeRun;
+    if (typeof Runner !== "function") {
+      return this.particleOptimize(specJson, paramsJson, optimizeJson);
+    }
+    const run = new Runner(specJson, paramsJson, optimizeJson);
+    try {
+      for (;;) {
+        const status = run.advance() as ParticleOptChunkStatus;
+        onChunk?.(status);
+        if (status.done) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
+  }
+
+  /**
    * Tolerance stackup analysis: worst-case, RSS, seeded Monte Carlo, and
    * exact sensitivities over a linear assembly chain, plus predicted
    * receipt claims. Inputs are JSON strings (StackupSpec, named parameter
@@ -1462,6 +1645,64 @@ export class Engine {
       );
     }
     return fn(specJson, optionsJson, includeFields);
+  }
+
+  /**
+   * Chunked form of {@link simulateFlow}: runs the LBM timestep loop in
+   * budgeted chunks, invoking `onChunk` between kernel calls so a host can
+   * stream progress. Bit-identical result (steadiness checks key off the
+   * absolute step count). Falls back to the one-shot on an older kernel.
+   */
+  simulateFlowChunked(
+    specJson: string,
+    optionsJson: string,
+    includeFields: boolean,
+    onChunk?: (status: FlowChunkStatus) => void,
+    chunkSteps = 2000,
+  ): unknown {
+    const Runner = this.kernel.FlowRun;
+    if (typeof Runner !== "function") {
+      return this.simulateFlow(specJson, optionsJson, includeFields);
+    }
+    const run = new Runner(specJson, optionsJson, includeFields);
+    try {
+      for (;;) {
+        const status = run.advance(chunkSteps) as FlowChunkStatus;
+        onChunk?.(status);
+        if (status.converged) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
+  }
+
+  /**
+   * Chunked form of {@link photonicsSimulate}; see {@link simulateFlowChunked}.
+   * FDTD stepping is sequential-stateful, so `run(a)` then `run(b)` is exactly
+   * `run(a+b)` — chunking exists only to surface progress between slices.
+   */
+  photonicsSimulateChunked(
+    specJson: string,
+    optionsJson: string,
+    onChunk?: (status: SimChunkStatus) => void,
+    chunkSteps = 500,
+  ): unknown {
+    const Runner = this.kernel.PhotonicsRun;
+    if (typeof Runner !== "function") {
+      return this.photonicsSimulate(specJson, optionsJson);
+    }
+    const run = new Runner(specJson, optionsJson);
+    try {
+      for (;;) {
+        const status = run.advance(chunkSteps) as SimChunkStatus;
+        onChunk?.(status);
+        if (status.done) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
   }
 
   private circuitFn<K extends keyof KernelModule>(name: K): NonNullable<KernelModule[K]> {
@@ -1633,6 +1874,36 @@ export class Engine {
   }
 
   /**
+   * Chunked form of {@link neutronicsSimulate}: transports the Monte
+   * Carlo batch loop in budgeted chunks, invoking `onChunk` between
+   * kernel calls so a host can stream progress. Each batch owns an
+   * independent RNG stream, so the result is bit-identical to the
+   * one-shot. Falls back to the one-shot on an older kernel.
+   */
+  neutronicsSimulateChunked(
+    specJson: string,
+    paramsJson: string,
+    onChunk?: (status: SimChunkStatus) => void,
+    chunkBatches = 2,
+  ): unknown {
+    const Runner = this.kernel.NeutronicsRun;
+    if (typeof Runner !== "function") {
+      return this.neutronicsSimulate(specJson, paramsJson);
+    }
+    const run = new Runner(specJson, paramsJson);
+    try {
+      for (;;) {
+        const status = run.advance(chunkBatches) as SimChunkStatus;
+        onChunk?.(status);
+        if (status.done) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
+  }
+
+  /**
    * Lattice gauge theory Monte Carlo (quenched SU(2)/SU(3) Wilson
    * action): plaquette, Wilson loops, string tension, Polyakov order
    * parameter, flux-tube profile, field snapshots — jackknife errors
@@ -1646,6 +1917,35 @@ export class Engine {
       );
     }
     return fn(specJson);
+  }
+
+  /**
+   * Chunked form of {@link latticeGaugeSimulate}: runs the Monte Carlo
+   * sweep loop in budgeted chunks, invoking `onChunk` between kernel
+   * calls so a host can stream progress. RNG state lives in the kernel
+   * run, so the result is bit-identical to the one-shot. Falls back to
+   * the one-shot on an older kernel.
+   */
+  latticeGaugeSimulateChunked(
+    specJson: string,
+    onChunk?: (status: SimChunkStatus) => void,
+    chunkSweeps = 10,
+  ): unknown {
+    const Runner = this.kernel.LatticeGaugeRun;
+    if (typeof Runner !== "function") {
+      return this.latticeGaugeSimulate(specJson);
+    }
+    const run = new Runner(specJson);
+    try {
+      for (;;) {
+        const status = run.advance(chunkSweeps) as SimChunkStatus;
+        onChunk?.(status);
+        if (status.done) break;
+      }
+      return run.finish();
+    } finally {
+      run.free?.();
+    }
   }
 
   topologyOptimizeBox(
@@ -1668,6 +1968,48 @@ export class Engine {
       max[1],
       max[2],
     ) as TopoOptResult;
+  }
+
+  /**
+   * Chunked form of {@link topologyOptimizeBox}: one SIMP iteration per kernel
+   * call, invoking `onStep` between calls so a host can stream convergence
+   * progress. Bit-identical result — the kernel one-shot is implemented on the
+   * same run type. Falls back to the one-shot on an older kernel.
+   */
+  topologyOptimizeBoxChunked(
+    min: [number, number, number],
+    max: [number, number, number],
+    spec: TopoOptSpec,
+    onStep?: (status: TopoOptStepStatus) => void,
+  ): TopoOptResult {
+    const Runner = this.kernel.TopoOptRun;
+    if (!Runner || typeof Runner.beginBox !== "function") {
+      return this.topologyOptimizeBox(min, max, spec);
+    }
+    const run = Runner.beginBox(
+      JSON.stringify(spec),
+      min[0],
+      min[1],
+      min[2],
+      max[0],
+      max[1],
+      max[2],
+    );
+    return driveTopoOptRun(run, onStep);
+  }
+
+  /** Chunked form of {@link topologyOptimizeMesh}; see {@link topologyOptimizeBoxChunked}. */
+  topologyOptimizeMeshChunked(
+    mesh: TriangleMesh,
+    spec: TopoOptSpec,
+    onStep?: (status: TopoOptStepStatus) => void,
+  ): TopoOptResult {
+    const Runner = this.kernel.TopoOptRun;
+    if (!Runner || typeof Runner.beginMesh !== "function") {
+      return this.topologyOptimizeMesh(mesh, spec);
+    }
+    const run = Runner.beginMesh(JSON.stringify(spec), mesh.positions, mesh.indices);
+    return driveTopoOptRun(run, onStep);
   }
 
   /**

--- a/packages/mcp/src/tools/atoms.ts
+++ b/packages/mcp/src/tools/atoms.ts
@@ -13,7 +13,7 @@ import type { MoleculeSystem } from "@vcad/ir";
 import {
   parseXyz,
   inspectMolecule,
-  minimizeEnergy,
+  minimizeEnergyChunked,
   homogenizeMaterial,
   buildMoleculeReceipt,
   MdEnv,
@@ -198,7 +198,10 @@ export async function inspectMoleculeTool(input: unknown): Promise<ToolResult> {
 }
 
 /** Relax a structure to a local energy minimum. */
-export async function minimizeEnergyTool(input: unknown): Promise<ToolResult> {
+export async function minimizeEnergyTool(
+  input: unknown,
+  toolCtx?: ToolContext,
+): Promise<ToolResult> {
   try {
     const args = input as {
       molecule: MoleculeSystem;
@@ -206,11 +209,24 @@ export async function minimizeEnergyTool(input: unknown): Promise<ToolResult> {
       max_iters?: number;
       force_tol?: number;
     };
-    const { result, molecule } = await minimizeEnergy(
+    // The kernel loop is chunked (a budget of FIRE iterations per call),
+    // so progress notifications flush between chunks instead of bursting
+    // at the end. Bit-identical to the one-shot path.
+    const { result, molecule } = await minimizeEnergyChunked(
       args.molecule,
       args.config ?? {},
       args.max_iters ?? 2000,
       args.force_tol ?? 1e-4,
+      toolCtx?.progress
+        ? (s) =>
+            toolCtx.progress?.(
+              s.steps,
+              s.total,
+              s.done
+                ? `FIRE finished at iteration ${s.steps} (max force ${s.maxForce.toExponential(2)} eV/A)`
+                : `FIRE iteration ${s.steps}/${s.total}, max force ${s.maxForce.toExponential(2)} eV/A`,
+            )
+        : undefined,
     );
     const receipt = await buildMoleculeReceipt(
       args.molecule,
@@ -590,7 +606,7 @@ export const toolDefs: ToolDef[] = [
     description:
       "Relax a structure to a local energy minimum with FIRE. Force field via config (Lennard-Jones default, harmonic bonds, Coulomb, or the ML-potential stub). Returns the relaxed molecule, a result summary (energy, max force, convergence), and a reproducibility receipt.",
     inputSchema: minimizeEnergySchema,
-    handler: (a) => minimizeEnergyTool(a),
+    handler: (a, ctx) => minimizeEnergyTool(a, ctx),
     behavior: behavior({}),
   },
   {

--- a/packages/mcp/src/tools/ecad.ts
+++ b/packages/mcp/src/tools/ecad.ts
@@ -61,7 +61,7 @@ import {
   exportKicadSch,
   tryExportFabFiles,
   tryRunDrc,
-  runFabPrep as kernelRunFabPrep,
+  runFabPrepChunked as kernelRunFabPrep,
   tryPcbPreviewMeshes,
   resolveFootprint,
   generateNetlist,
@@ -5643,7 +5643,8 @@ function detectUnsupportedFeatures(pcb: Pcb): UnsupportedFeature[] {
  * offenders named, and `export_gerber`'s clean-DRC gate still stands: this is the
  * supported way to GET clean, never a way around the gate.
  */
-export async function fabPrep(args: Record<string, unknown>) {
+export async function fabPrep(args: Record<string, unknown>, toolCtx?: ToolContext) {
+  const progress = toolCtx?.progress;
   const ctx = resolveDocInput(args);
   const pcb = getDocPcb(ctx.doc);
   if (!pcb) {
@@ -5673,7 +5674,18 @@ export async function fabPrep(args: Record<string, unknown>) {
     },
   };
 
-  const out = await kernelRunFabPrep(pcb, options);
+  // The kernel loop is stepwise (one strip-and-re-route round per call), so
+  // progress notifications flush between rounds instead of bursting at the
+  // end. Bit-identical to the one-shot path — same kernel session type.
+  const out = await kernelRunFabPrep(pcb, options, (status) => {
+    progress?.(
+      Math.min(status.round, status.max_rounds + 1),
+      status.max_rounds + 1,
+      status.done
+        ? `fab_prep: fix loop finished after ${status.round} check(s)`
+        : `fab_prep round ${status.round}/${status.max_rounds}: ${status.attributable} route-attributable violation(s)`,
+    );
+  });
   if (!out.ok) {
     return ecadError(`fab_prep could not run: ${out.message}`);
   }
@@ -14677,7 +14689,7 @@ export const toolDefs: ToolDef[] = [
       "otherwise, and `export_gerber`'s clean-DRC gate still stands — this is " +
       "the supported way to GET clean, not a way around it.",
     inputSchema: fabPrepSchema,
-    handler: (a) => fabPrep(a) as ToolResult | Promise<ToolResult>,
+    handler: (a, c) => fabPrep(a, c) as ToolResult | Promise<ToolResult>,
     behavior: behavior({ writesDoc: true, geometry: true, mount: true }),
   },
   {

--- a/packages/mcp/src/tools/flow.ts
+++ b/packages/mcp/src/tools/flow.ts
@@ -234,10 +234,25 @@ export const toolDefs: ToolDef[] = [
     },
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.simulateFlow(
+      // The kernel loop is chunked (a budget of LBM timesteps per call), so
+      // progress notifications flush between chunks instead of bursting at
+      // the end. Bit-identical to the one-shot path.
+      const out = ctx.engine.simulateFlowChunked(
         JSON.stringify(a.spec),
         JSON.stringify(a.options ?? {}),
         !!a.include_fields,
+        ctx.progress
+          ? (s) =>
+              ctx.progress?.(
+                Math.min(s.steps, s.max_steps),
+                s.max_steps,
+                s.converged
+                  ? `LBM steady after ${s.steps} steps (residual ${s.residual.toExponential(2)})`
+                  : `LBM step ${s.steps}/${s.max_steps}, residual ${
+                      Number.isFinite(s.residual) ? s.residual.toExponential(2) : "—"
+                    }`,
+              )
+          : undefined,
       );
       return textResult(out);
     },

--- a/packages/mcp/src/tools/neutronics.ts
+++ b/packages/mcp/src/tools/neutronics.ts
@@ -135,9 +135,23 @@ export const toolDefs: ToolDef[] = [
     },
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.neutronicsSimulate(
+      // The kernel loop is chunked (a budget of MC batches per call), so
+      // progress notifications flush between chunks instead of bursting at
+      // the end. Each batch owns an independent RNG stream — bit-identical
+      // to the one-shot path.
+      const out = ctx.engine.neutronicsSimulateChunked(
         JSON.stringify(a.spec),
         JSON.stringify(a.parameters ?? {}),
+        ctx.progress
+          ? (s) =>
+              ctx.progress?.(
+                s.steps,
+                s.total,
+                s.done
+                  ? `transport done: ${s.total} batches`
+                  : `transport batch ${s.steps}/${s.total}`,
+              )
+          : undefined,
       );
       return textResult(out);
     },

--- a/packages/mcp/src/tools/particle.ts
+++ b/packages/mcp/src/tools/particle.ts
@@ -196,10 +196,23 @@ export const toolDefs: ToolDef[] = [
     inputSchema: simulateChargedParticlesSchema,
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.particleSimulate(
+      // The kernel loop is chunked (a budget of traced particles per
+      // call), so progress notifications flush between chunks instead of
+      // bursting at the end. Bit-identical to the one-shot path.
+      const out = ctx.engine.particleSimulateChunked(
         JSON.stringify(a.spec),
         JSON.stringify(a.parameters ?? {}),
         JSON.stringify(a.options ?? {}),
+        ctx.progress
+          ? (s) =>
+              ctx.progress?.(
+                s.steps,
+                s.total,
+                s.done
+                  ? `traced ${s.total} particles`
+                  : `tracing particle ${s.steps}/${s.total}`,
+              )
+          : undefined,
       );
       return textResult(out);
     },
@@ -220,13 +233,29 @@ export const toolDefs: ToolDef[] = [
     inputSchema: optimizeElectrodesSchema,
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.particleOptimize(
+      // One complete FD-ascent start per kernel call, so progress (which
+      // start, its objective) flushes between starts. Identical to the
+      // one-shot path by construction.
+      const out = ctx.engine.particleOptimizeChunked(
         JSON.stringify(a.spec),
         JSON.stringify(a.parameters ?? {}),
         JSON.stringify({
           variables: a.variables,
           ...(a.options as Json | undefined),
         }),
+        ctx.progress
+          ? (s) =>
+              ctx.progress?.(
+                s.steps,
+                s.total,
+                s.done
+                  ? `search done: ${s.total} starts`
+                  : `start ${s.steps}/${s.total} finished` +
+                    (typeof s.value === "number"
+                      ? ` (sigma-v ${s.value.toExponential(2)} m^3/s)`
+                      : ""),
+              )
+          : undefined,
       );
       return textResult(out);
     },

--- a/packages/mcp/src/tools/photonics.ts
+++ b/packages/mcp/src/tools/photonics.ts
@@ -175,9 +175,15 @@ export const toolDefs: ToolDef[] = [
     },
     handler: (args, ctx) => {
       const a = args as Json;
-      const out = ctx.engine.photonicsSimulate(
+      // The kernel loop is chunked (a budget of FDTD timesteps per call), so
+      // progress notifications flush between chunks instead of bursting at
+      // the end. Bit-identical to the one-shot path.
+      const out = ctx.engine.photonicsSimulateChunked(
         JSON.stringify(a.spec),
         JSON.stringify(a.options ?? {}),
+        ctx.progress
+          ? (s) => ctx.progress?.(s.steps, s.total, `FDTD step ${s.steps}/${s.total}`)
+          : undefined,
       );
       return textResult(out);
     },

--- a/packages/mcp/src/tools/qcd.ts
+++ b/packages/mcp/src/tools/qcd.ts
@@ -175,7 +175,23 @@ export const toolDefs: ToolDef[] = [
     },
     handler: (args, ctx) => {
       const a = args as Record<string, unknown>;
-      const out = ctx.engine.latticeGaugeSimulate(JSON.stringify(a.spec));
+      // The kernel loop is chunked (a budget of compound sweeps per call),
+      // so progress notifications flush between chunks instead of bursting
+      // at the end. RNG state lives in the kernel run — bit-identical to
+      // the one-shot path.
+      const out = ctx.engine.latticeGaugeSimulateChunked(
+        JSON.stringify(a.spec),
+        ctx.progress
+          ? (s) =>
+              ctx.progress?.(
+                s.steps,
+                s.total,
+                s.done
+                  ? `Monte Carlo done: ${s.total} sweeps`
+                  : `Monte Carlo sweep ${s.steps}/${s.total}`,
+              )
+          : undefined,
+      );
       return textResult(out);
     },
     behavior: behavior({}),

--- a/packages/mcp/src/tools/topopt.ts
+++ b/packages/mcp/src/tools/topopt.ts
@@ -197,6 +197,7 @@ const round5 = (v: number) => Number(v.toPrecision(5));
 export function topologyOptimizeTool(
   args: Record<string, unknown>,
   engine: Engine,
+  progress?: (current: number, total?: number, message?: string) => void,
 ): { content: Array<{ type: "text"; text: string }> } {
   const a = args as TopoArgs;
 
@@ -239,15 +240,31 @@ export function topologyOptimizeTool(
   let sourceName: string | undefined;
   let sourceMaterial: string | undefined;
   let sourceRootIndex = -1;
+  // The kernel loop is stepwise (one SIMP iteration per call), so progress
+  // notifications flush between iterations instead of bursting at the end.
+  const totalIters = a.max_iterations ?? 40;
+  const onStep = progress
+    ? (s: { done: boolean; iteration: number; compliance: number; change: number }) => {
+        if (s.iteration > 0) {
+          progress(
+            s.iteration,
+            totalIters,
+            `SIMP iteration ${s.iteration}/${totalIters}: compliance ${Number(
+              s.compliance.toPrecision(5),
+            )}, change ${Number(s.change.toPrecision(3))}`,
+          );
+        }
+      }
+    : undefined;
   if (a.part) {
     const resolved = resolvePartMesh(doc, engine, a.part);
     sourceName = resolved.name;
     sourceMaterial = resolved.material;
     sourceRootIndex = resolved.rootIndex;
-    result = engine.topologyOptimizeMesh(resolved.mesh, spec);
+    result = engine.topologyOptimizeMeshChunked(resolved.mesh, spec, onStep);
   } else {
     const box = a.domain_box!;
-    result = engine.topologyOptimizeBox(box.min, box.max, spec);
+    result = engine.topologyOptimizeBoxChunked(box.min, box.max, spec, onStep);
   }
 
   const triangles = result.mesh.indices.length / 3;
@@ -335,7 +352,7 @@ export const toolDefs: ToolDef[] = [
       "history and achieved volume fraction are reported. Deterministic for a given spec. " +
       "Cost scales with resolution³ — start at the default 48 and refine.",
     inputSchema: topologyOptimizeSchema,
-    handler: (args, ctx) => topologyOptimizeTool(args, ctx.engine),
+    handler: (args, ctx) => topologyOptimizeTool(args, ctx.engine, ctx.progress),
     behavior: behavior({ writesDoc: true, geometry: true, mount: true }),
   },
 ];


### PR DESCRIPTION
Stacked on #746 — base that branch, so this diff is the single commit `edc83381`. Merge #746 first.

## The problem

#746 gave `notifications/progress` to every tool whose iteration loop lives in TypeScript. The rest were each **one synchronous kernel WASM call** whose loop runs in Rust — `fab_prep`, `topology_optimize`, and the `simulate_*` family. They go silent for minutes, then report everything at once.

A `js_sys::Function` callback invoked from inside that synchronous call **cannot** fix this. The Node event loop is blocked for the whole call, so every queued notification bursts out only after completion — fake streaming.

## The fix

Chunked kernel APIs: an env/handle created once, plus a `step`/`advance` method the TS layer calls in a loop, emitting `ctx.progress` between calls while the event loop is actually free. This is the seam `MdEnv.run` already proved out.

Each tool gets the same four layers — a stepwise driver in its own kernel crate, a wasm run class, an `@vcad/engine` wrapper that **falls back to the one-shot call on an older kernel**, and `ctx.progress` wiring in the handler.

| Tool | Progress granularity |
|---|---|
| `fab_prep` | per strip-and-re-route round |
| `topology_optimize` | per SIMP iteration (carries compliance + density change) |
| `simulate_flow` | per chunk of LBM timesteps (carries steadiness residual) |
| `simulate_photonics` | per chunk of FDTD timesteps |
| `simulate_charged_particles` | per chunk of traced particles |
| `optimize_electrodes` | per multi-start FD evaluation |
| `simulate_neutron_shield` | per batch of histories |
| `simulate_lattice_gauge` | per chunk of MC sweeps |
| `minimize_energy` | per chunk of FIRE iterations |

## Why the numbers can't drift

Chunked results are bit-identical to the one-shot path **by construction**: wherever possible the one-shot entry point is reimplemented on top of the stepwise driver (`run_fab_prep`, `solve_steady`, `optimize`), so there is no second code path to drift out of sync. RNG state lives in the env, so the Monte Carlo tools chunk without perturbing their stream. `FlowStepper`'s steadiness checks key off the **absolute** step count, so chunk boundaries can't change when it converges.

Every crate carries a parity test asserting one-shot == chunked on the same input:

```
vcad-ecad-fabprep     stepwise_session_matches_the_one_shot_run
vcad-kernel-topopt    stepwise_run_matches_the_one_shot_optimize
vcad-kernel-flow      chunked_stepper_matches_the_one_shot_solve
vcad-kernel-photonics chunked_run_matches_one_shot_run          (bit-level, .to_bits())
vcad-kernel-particle  chunked_ensemble_ranges_match_the_one_shot
                      stepwise_multi_start_matches_the_one_shot
vcad-kernel-neutronics chunked_run_matches_the_one_shot
vcad-kernel-qcd       chunked_run_matches_the_one_shot
vcad-kernel-atoms     stepwise_fire_matches_phyz_fire
```

## Reviewer notes

- **`vcad-kernel-flow/src/solve.rs` is the big diff** and the one worth real attention. `solve_steady`'s ~500-line loop became `FlowStepper::{new, advance, into_solution}`; the body is unchanged apart from field access through `&mut self`. `solve_steady` is now `advance(usize::MAX)`.
- The engine wrappers degrade gracefully: a kernel WASM predating a run class silently takes the one-shot path, so this does not hard-require a kernel refresh.
- No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts touched — `wasm-refresh.yml` still owns them.

## Not included

`simulate_em` and `homogenize_material` still take the one-shot path. Same pattern applies; left for a follow-up rather than shipped half-wired.

## Verification

- `cargo clippy -D warnings` clean across all nine touched crates + `vcad-kernel-wasm` (fixed 3 pre-existing `needless_range_loop` in neutronics)
- `cargo test` green on all touched crates, including `vcad-kernel-flow` (35 passed, 347s)
- `packages/mcp`: `tsc --noEmit` clean, `vitest run` 1078 passed / 3 skipped across 97 files
- `cargo fmt` applied per-crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)