### PR TITLE
fix(render): jointed parts pivot at their anchor, not the world origin

### DIFF
--- a/changelog/entries/2026-07-29-fk-render-pivot.json
+++ b/changelog/entries/2026-07-29-fk-render-pivot.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-29-fk-render-pivot",
+  "version": "0.9.4",
+  "date": "2026-07-29",
+  "category": "fix",
+  "title": "Jointed parts pivot at their anchor when rendered",
+  "summary": "Kinematic playback rotated a jointed child about the world origin instead of its joint anchor; renders at nonzero joint angles are now correct.",
+  "features": ["assembly", "kinematics", "animation", "rendering"],
+  "mcpTools": ["export_video", "render_sequence", "animate", "render_view"]
+}

--- a/crates/vcad-eval/src/kinematics.rs
+++ b/crates/vcad-eval/src/kinematics.rs
@@ -373,6 +373,48 @@ mod tests {
         );
     }
 
+    /// Apply a solved world transform to a part-local point.
+    fn world_point(t: &Transform3D, p: Vec3) -> Vec3 {
+        vec3_add(&t.translation, &mat_vec3(&euler_to_matrix(&t.rotation), &p))
+    }
+
+    /// The defining invariant: the child's anchor point lands on the parent's
+    /// anchor point at *every* joint angle. A zero anchor cannot distinguish
+    /// "rotate about the anchor" from "rotate about the world origin", so
+    /// this pins a nonzero parent anchor and a nonzero child anchor together.
+    #[test]
+    fn anchor_points_stay_coincident_at_every_angle() {
+        for state in [0.0, -30.0, 45.0, 137.0] {
+            let mut doc = doc_with_instance_transform(state);
+            let child_anchor = Vec3::new(3.0, -2.0, 7.0);
+            doc.joints.as_mut().expect("joints")[0].child_anchor = child_anchor;
+            let expect = doc.joints.as_ref().unwrap()[0].parent_anchor; // parent is ground-identity
+            let world = solve_forward_kinematics(&doc);
+            let arm = world.get("arm").expect("arm solved");
+
+            let anchor = world_point(arm, child_anchor);
+            assert!(
+                (anchor.x - expect.x).abs() < 1e-9
+                    && (anchor.y - expect.y).abs() < 1e-9
+                    && (anchor.z - expect.z).abs() < 1e-9,
+                "state {state}: anchor at {anchor:?}, want {expect:?}"
+            );
+
+            // And the pivot really is the anchor, not the world origin: a
+            // material point keeps its distance to the anchor, not to (0,0,0).
+            let probe = world_point(arm, Vec3::new(0.0, 0.0, 0.0));
+            let d_anchor = ((probe.x - expect.x).powi(2)
+                + (probe.y - expect.y).powi(2)
+                + (probe.z - expect.z).powi(2))
+            .sqrt();
+            let want = (3.0f64.powi(2) + 2.0f64.powi(2) + 7.0f64.powi(2)).sqrt();
+            assert!(
+                (d_anchor - want).abs() < 1e-9,
+                "state {state}: |probe - anchor| = {d_anchor}, want {want}"
+            );
+        }
+    }
+
     #[test]
     fn root_instance_keeps_own_transform() {
         let mut doc = doc_with_instance_transform(0.0);

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -771,15 +771,18 @@ fn focus_mask(scene: &[SceneSolid], focus: &str) -> Result<Vec<bool>, String> {
 /// IR `Transform3D` → kernel `Transform`, matching the evaluator's
 /// convention: scale, then Rx·Ry·Rz (applied x-first), then translation.
 fn transform3d_to_kernel(t: &vcad_ir::Transform3D) -> Transform {
-    Transform::scale(t.scale.x, t.scale.y, t.scale.z)
-        .then(&Transform::rotation_x(t.rotation.x.to_radians()))
-        .then(&Transform::rotation_y(t.rotation.y.to_radians()))
+    // `Transform::then` composes self·other with column vectors, so `other`
+    // acts on the point FIRST. The intended world placement is
+    // T · Rz · Ry · Rx · S (scale first, translation last — matching the
+    // Rz·Ry·Rx euler convention `vcad_eval::kinematics` emits), so the chain
+    // reads outermost-first. Chaining the other way rotated the translation
+    // itself, which swung a jointed child about the world origin instead of
+    // about its parent anchor.
+    Transform::translation(t.translation.x, t.translation.y, t.translation.z)
         .then(&Transform::rotation_z(t.rotation.z.to_radians()))
-        .then(&Transform::translation(
-            t.translation.x,
-            t.translation.y,
-            t.translation.z,
-        ))
+        .then(&Transform::rotation_y(t.rotation.y.to_radians()))
+        .then(&Transform::rotation_x(t.rotation.x.to_radians()))
+        .then(&Transform::scale(t.scale.x, t.scale.y, t.scale.z))
 }
 
 // ─── canonicalized per-solid mesh ─────────────────────────────────────────
@@ -3982,6 +3985,42 @@ mod raytrace {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A world transform must rotate the geometry about the transform's own
+    /// origin and *then* translate — never rotate the translation itself.
+    ///
+    /// Regression: the chain was built scale→Rx→Ry→Rz→T, but
+    /// `Transform::then` composes `self·other` (other acts first), so the
+    /// translation was applied first and the rotation then swung it about
+    /// the world origin. A revolute child anchored at z=94 detached from its
+    /// parent and orbited the origin at radius 94 — invisible at state 0,
+    /// where the rotation is identity.
+    #[test]
+    fn world_transform_rotates_about_its_own_origin() {
+        let t = vcad_ir::Transform3D {
+            translation: vcad_ir::Vec3::new(0.0, 0.0, 94.0),
+            rotation: vcad_ir::Vec3::new(0.0, -30.0, 0.0),
+            scale: vcad_ir::Vec3::new(1.0, 1.0, 1.0),
+        };
+        let k = transform3d_to_kernel(&t);
+
+        // The transform's origin is the pivot: it maps to the translation.
+        let pivot = k.apply_point(&vcad_kernel::vcad_kernel_math::Point3::new(0.0, 0.0, 0.0));
+        assert!(
+            (pivot.x).abs() < 1e-9 && (pivot.z - 94.0).abs() < 1e-9,
+            "pivot moved: {pivot:?}"
+        );
+
+        // A point 58mm below the pivot swings to R·(0,0,-58) + (0,0,94).
+        let tip = k.apply_point(&vcad_kernel::vcad_kernel_math::Point3::new(0.0, 0.0, -58.0));
+        let (s, c) = (-30.0_f64).to_radians().sin_cos();
+        assert!((tip.x - (-58.0 * s)).abs() < 1e-9, "tip.x = {}", tip.x);
+        assert!(
+            (tip.z - (-58.0 * c + 94.0)).abs() < 1e-9,
+            "tip.z = {}",
+            tip.z
+        );
+    }
 
     /// Pins the handedness of every [`View`]'s screen basis.
     ///


### PR DESCRIPTION
## What

`vcad-render`'s `transform3d_to_kernel` composed a world transform in the wrong order, so any jointed child rendered at a nonzero joint angle rotated about the **world origin** instead of its joint anchor — detaching from its parent and swinging on a giant lever arm.

## Why

The FK solver was never the problem. `vcad_eval::solve_forward_kinematics` correctly returns `translation = parent_anchor − R·child_anchor`; I verified its output numerically on the reported repro at every angle before touching anything.

The bug was one function downstream. The chain was built as:

```rust
scale.then(Rx).then(Ry).then(Rz).then(T)
```

but `Transform::then` composes `self.matrix * other.matrix`, so with column vectors **`other` acts on the point first**. The translation was therefore applied *before* the rotation, and the rotation swung it about the origin. The correct chain reads outermost-first — `T.then(Rz).then(Ry).then(Rx).then(S)` — matching the Rz·Ry·Rx euler convention the FK solver emits, and the convention already documented in `vcad-kernel-tessellate/src/placement.rs`. A sweep of the workspace found vcad-render was the only violator; `vcad-eval`'s `collect_transform_chain` walks outer→inner and is correct.

## Reviewer notes

- **Blast radius is every render path.** `render_view`, `export_video`, `render_sequence`, and `animate` all route through wasm `render_svg` → vcad-render → this function. That's why it presented as an FK bug rather than a renderer bug.
- **`then` reads like "afterwards" and means the opposite.** Worth keeping in mind on review of any future `.then` chain; a comment now explains the ordering at the call site.
- **Two masking conditions hid this.** At joint state 0 the rotation is identity, so every static render was correct. And with a zero anchor the anchor coincides with the world origin, so the broken and correct implementations are indistinguishable — which is why the existing `fk_alignment` test passed on it.

## Verification

Reproduced the reported case (revolute joint, `parentAnchor (0,0,94)`, −30° about +Y) through the real render path, then re-rendered the same document after the fix: the arm now pivots at the beam, W 52mm / H 64.2mm — matching the analytic prediction exactly (tip at x=29, z=43.8). Before the fix the arm's top landed at radius 94 from the origin, as reported.

`cargo test -p vcad-render -p vcad-eval` green; `cargo clippy -p vcad-render -p vcad-eval -- -D warnings` clean. (There is a pre-existing `--all-targets` clippy failure in `vcad-eval`'s `torr_boolean_catalogue` test, unrelated and present on `main`; CI does not use `--all-targets`.)

## Tests added

- `world_transform_rotates_about_its_own_origin` (vcad-render) — pins the pivot directly: the transform's own origin maps to the translation, and a point 58mm below swings to `R·(0,0,−58)+(0,0,94)`. Fails on the old chain.
- `anchor_points_stay_coincident_at_every_angle` (vcad-eval kinematics) — the FK contract with a **nonzero parent anchor and nonzero child anchor** across states 0/−30/45/137: the child anchor stays coincident with the parent anchor, and distances are preserved to the *anchor*, not the origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)