### PR TITLE
feat(cli): wire GLB export in CLI and GLB/STEP export in the TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6951,6 +6951,7 @@ dependencies = [
  "vcad-kernel",
  "vcad-kernel-cam",
  "vcad-kernel-constraints",
+ "vcad-kernel-export",
  "vcad-kernel-physics",
  "vcad-kernel-raytrace",
  "vcad-kernel-sketch",

--- a/changelog/entries/2026-07-30-cli-tui-glb-step-export.json
+++ b/changelog/entries/2026-07-30-cli-tui-glb-step-export.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-30-cli-tui-glb-step-export",
+  "version": "0.9.4",
+  "date": "2026-07-30",
+  "category": "feat",
+  "title": "CLI and TUI GLB/STEP export",
+  "summary": "vcad export now writes .glb files, and the TUI's Export GLB/STEP menu actions work, sharing the CLI's kernel-backed writers.",
+  "features": ["cli", "tui", "export", "glb", "step"]
+}

--- a/crates/vcad-cli/Cargo.toml
+++ b/crates/vcad-cli/Cargo.toml
@@ -29,6 +29,7 @@ vcad-kernel-physics = { path = "../vcad-kernel-physics" }
 vcad-kernel-cam = { path = "../vcad-kernel-cam" }
 vcad-kernel-raytrace = { path = "../vcad-kernel-raytrace" }
 vcad-kernel-tessellate = { workspace = true }
+vcad-kernel-export = { workspace = true }
 vcad-ecad-fabprep = { workspace = true }
 # fab-prep runs for minutes on a dense board and narrates its rounds through
 # `log`; without a subscriber the terminal shows nothing until it finishes.

--- a/crates/vcad-cli/src/app.rs
+++ b/crates/vcad-cli/src/app.rs
@@ -915,6 +915,40 @@ impl App {
         Ok(())
     }
 
+    /// Default export target: the open file with a new extension, or
+    /// `untitled.<ext>` in the working directory when nothing is open.
+    fn default_export_path(&self, ext: &str) -> PathBuf {
+        match &self.file_path {
+            Some(p) => p.with_extension(ext),
+            None => PathBuf::from(format!("untitled.{ext}")),
+        }
+    }
+
+    /// Export to GLB via the shared CLI writer; outcome lands in the status line.
+    pub fn export_glb(&mut self, path: &PathBuf) {
+        match crate::write_glb(&self.document, path) {
+            Ok(count) => self.set_status(format!(
+                "Exported GLB ({count} mesh{}) to {}",
+                if count == 1 { "" } else { "es" },
+                path.display()
+            )),
+            Err(e) => self.set_status(format!("GLB export failed: {e}")),
+        }
+    }
+
+    /// Export to STEP via the shared CLI writer; mesh-only refusals and other
+    /// errors surface in the status line.
+    pub fn export_step(&mut self, path: &PathBuf) {
+        match crate::write_step(&self.document, path) {
+            Ok(count) => self.set_status(format!(
+                "Exported STEP ({count} solid{}) to {}",
+                if count == 1 { "" } else { "s" },
+                path.display()
+            )),
+            Err(e) => self.set_status(format!("STEP export failed: {e}")),
+        }
+    }
+
     /// Evaluate the document to get meshes.
     pub fn evaluate(&mut self) -> Result<()> {
         self.meshes = evaluate_document(&self.document)?;
@@ -1141,10 +1175,21 @@ impl App {
             "export" => {
                 if let Some(path) = parts.get(1) {
                     let path = PathBuf::from(path);
-                    self.export_stl(&path)?;
-                    self.set_status(format!("Exported to {}", path.display()));
+                    let ext = path
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .unwrap_or("")
+                        .to_lowercase();
+                    match ext.as_str() {
+                        "glb" => self.export_glb(&path),
+                        "step" | "stp" => self.export_step(&path),
+                        _ => {
+                            self.export_stl(&path)?;
+                            self.set_status(format!("Exported to {}", path.display()));
+                        }
+                    }
                 } else {
-                    self.set_status("Usage: export <path.stl>");
+                    self.set_status("Usage: export <path.stl|.glb|.step>");
                 }
             }
             "undo" => self.undo()?,
@@ -1166,8 +1211,20 @@ impl App {
                 self.set_status("New document");
             }
             "open" => self.set_status("Open: drag a .vcad file into the terminal"),
-            "export_glb" => self.set_status("Export GLB: not yet implemented in TUI"),
-            "export_step" => self.set_status("Export STEP: not yet implemented in TUI"),
+            "export_glb" => {
+                let path = parts
+                    .get(1)
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| self.default_export_path("glb"));
+                self.export_glb(&path);
+            }
+            "export_step" => {
+                let path = parts
+                    .get(1)
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| self.default_export_path("step"));
+                self.export_step(&path);
+            }
             "select_all" => {
                 let ids: Vec<_> = self.get_parts().into_iter().map(|(id, _)| id).collect();
                 self.selected = ids.into_iter().collect();

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -641,7 +641,12 @@ fn export_file(input: &PathBuf, output: &PathBuf) -> Result<()> {
             println!("Exported STL to {}", output.display());
         }
         "glb" => {
-            println!("GLB export not yet implemented in CLI");
+            let count = write_glb(&doc, output)?;
+            println!(
+                "Exported GLB ({count} mesh{}) to {}",
+                if count == 1 { "" } else { "es" },
+                output.display()
+            );
         }
         "step" | "stp" => {
             export_step(&doc, output)?;
@@ -734,7 +739,96 @@ fn export_stl_bytes(vertices: &[f32], indices: &[u32]) -> Result<Vec<u8>> {
     Ok(data)
 }
 
+/// Write the evaluated document to a binary GLB at `output`. Returns the
+/// number of meshes written. Print-free so the TUI can surface the result
+/// in its status line.
+fn write_glb(doc: &vcad_ir::Document, output: &PathBuf) -> Result<usize> {
+    use vcad_kernel_export::{build_glb, GlbMeshSpec, GlbSpec};
+
+    let opts = vcad_eval::EvalOptions {
+        skip_clash_detection: true,
+        ..Default::default()
+    };
+    let scene = vcad_eval::evaluate_document(doc, &opts).map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let mut f32_data: Vec<f32> = Vec::new();
+    let mut u32_data: Vec<u32> = Vec::new();
+    let mut meshes = Vec::new();
+    for (i, part) in scene.parts.iter().enumerate() {
+        if part.mesh.positions.is_empty() || part.mesh.indices.is_empty() {
+            continue;
+        }
+        let pos_off = f32_data.len();
+        f32_data.extend_from_slice(&part.mesh.positions);
+        let normals = part.mesh.normals.as_ref().map(|n| {
+            let off = f32_data.len();
+            f32_data.extend_from_slice(n);
+            [off, n.len()]
+        });
+        let idx_off = u32_data.len();
+        u32_data.extend_from_slice(&part.mesh.indices);
+        let name = doc
+            .roots
+            .get(i)
+            .and_then(|r| doc.nodes.get(&r.root))
+            .and_then(|n| n.name.clone())
+            .unwrap_or_else(|| format!("part_{}", i + 1));
+        meshes.push(GlbMeshSpec {
+            name,
+            positions: [pos_off, part.mesh.positions.len()],
+            indices: [idx_off, part.mesh.indices.len()],
+            normals,
+            color: [0.71, 0.71, 0.75],
+            metallic: 0.1,
+            roughness: 0.7,
+            emissive: None,
+            emissive_strength: None,
+            clearcoat: None,
+            clearcoat_roughness: None,
+            alpha: None,
+            transform: None,
+            mesh_key: None,
+        });
+    }
+    if meshes.is_empty() {
+        anyhow::bail!("Document has no geometry to export");
+    }
+
+    let count = meshes.len();
+    let scene_name = output
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("vcad")
+        .to_string();
+    let glb = build_glb(
+        &GlbSpec {
+            name: scene_name,
+            meshes,
+            animation: None,
+        },
+        &f32_data,
+        &u32_data,
+    )
+    .map_err(|e| anyhow::anyhow!("GLB build failed: {e}"))?;
+    std::fs::write(output, glb)?;
+    Ok(count)
+}
+
 fn export_step(doc: &vcad_ir::Document, output: &PathBuf) -> Result<()> {
+    let count = write_step(doc, output)?;
+    println!(
+        "Exported STEP ({} solid{}) to {}",
+        count,
+        if count == 1 { "" } else { "s" },
+        output.display()
+    );
+    Ok(())
+}
+
+/// Write the evaluated document to AP214 STEP at `output`. Returns the number
+/// of solids written. Mesh-only roots are refused by name (existing policy);
+/// print-free so the TUI can surface the error in its status line.
+fn write_step(doc: &vcad_ir::Document, output: &PathBuf) -> Result<usize> {
     use vcad_kernel::Solid;
 
     // Evaluate the document through the kernel: booleans, transforms,
@@ -787,13 +881,7 @@ fn export_step(doc: &vcad_ir::Document, output: &PathBuf) -> Result<()> {
     let refs: Vec<(&Solid, &str)> = named.iter().map(|(s, n)| (*s, n.as_str())).collect();
     let buffer = Solid::solids_to_step_buffer(&refs)?;
     std::fs::write(output, buffer)?;
-    println!(
-        "Exported STEP ({} solid{}) to {}",
-        roots.len(),
-        if roots.len() == 1 { "" } else { "s" },
-        output.display()
-    );
-    Ok(())
+    Ok(roots.len())
 }
 
 fn import_step(input: &PathBuf, output: &PathBuf, name: Option<String>) -> Result<()> {
@@ -1817,5 +1905,60 @@ fn parse_vec3(s: &str) -> Result<vcad_ir::Vec3> {
             Ok(vcad_ir::Vec3::new(x, y, z))
         }
         _ => anyhow::bail!("Expected 'x,y,z' or single value, got '{}'", s),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_ir::{CsgOp, Document, Node, SceneEntry, Vec3};
+
+    fn cube_doc() -> Document {
+        let mut doc = Document::new();
+        doc.nodes.insert(
+            1,
+            Node {
+                id: 1,
+                name: Some("Cube 1".to_string()),
+                op: CsgOp::Cube {
+                    size: Vec3::new(10.0, 10.0, 10.0),
+                },
+            },
+        );
+        doc.roots.push(SceneEntry {
+            root: 1,
+            material: "default".to_string(),
+            visible: None,
+        });
+        doc
+    }
+
+    #[test]
+    fn write_glb_produces_valid_glb() {
+        let doc = cube_doc();
+        let out = std::env::temp_dir().join("vcad_cli_test_export.glb");
+        let count = write_glb(&doc, &out).expect("GLB export failed");
+        assert_eq!(count, 1);
+        let bytes = std::fs::read(&out).unwrap();
+        std::fs::remove_file(&out).ok();
+        // GLB header: magic "glTF", version 2, total length == file length.
+        assert!(bytes.len() > 12);
+        assert_eq!(&bytes[0..4], b"glTF");
+        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 2);
+        assert_eq!(
+            u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize,
+            bytes.len()
+        );
+    }
+
+    #[test]
+    fn write_step_produces_ap214_file() {
+        let doc = cube_doc();
+        let out = std::env::temp_dir().join("vcad_cli_test_export.step");
+        let count = write_step(&doc, &out).expect("STEP export failed");
+        assert_eq!(count, 1);
+        let text = std::fs::read_to_string(&out).unwrap();
+        std::fs::remove_file(&out).ok();
+        assert!(text.starts_with("ISO-10303-21"));
     }
 }

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -881,7 +881,10 @@ fn write_step(doc: &vcad_ir::Document, output: &PathBuf) -> Result<usize> {
     let refs: Vec<(&Solid, &str)> = named.iter().map(|(s, n)| (*s, n.as_str())).collect();
     let buffer = Solid::solids_to_step_buffer(&refs)?;
     std::fs::write(output, buffer)?;
-    Ok(roots.len())
+    // Count what was actually serialized rather than what was evaluated, so
+    // the caller's message can't drift from the file if the guard above ever
+    // stops rejecting every solid-less root.
+    Ok(named.len())
 }
 
 fn import_step(input: &PathBuf, output: &PathBuf, name: Option<String>) -> Result<()> {


### PR DESCRIPTION
## What

`vcad export foo.vcad foo.glb` printed *"GLB export not yet implemented in CLI"*, and the TUI's **Export GLB** / **Export STEP** menu actions were status-line stubs — even though the writers already exist. `vcad-kernel-export` holds the consolidated GLB/STL writer (the 2026-07-24 consolidation), and `vcad-kernel-step` does multi-body STEP through `evaluate_root_solids`. This just wires the CLI and TUI to them.

- **`write_glb`** (new, in `main.rs`): evaluates the document via `vcad_eval` and serializes through `vcad_kernel_export::build_glb` — per-part normals when the tessellator produced them, root-node names for click-to-select, a neutral PBR material. The CLI's `.glb` branch now calls it.
- **STEP split**: the existing `export_step` becomes a print-free `write_step` returning the solid count, plus a thin printing CLI wrapper. The mesh-only-roots-refused-by-name policy is carried over verbatim, and the refusal message now reaches the TUI status line instead of being swallowed.
- **TUI**: `export_glb` / `export_step` actions call those same writers. Default output is the open file with the new extension, or `untitled.<ext>` when nothing is open — no file dialog exists in the TUI, and this matches how `save` behaves. The generic `export <path>` command now dispatches on extension too (`.glb`, `.step`/`.stp`, else STL).
- Adds `vcad-kernel-export` as a `vcad-cli` dependency (one-line `Cargo.lock` change).

## Not done

`toggle_wireframe` (app.rs:1190) stays a stub. The TUI renders through `termview`, which is a solid rasterizer with no edge-drawing or wireframe path at all — this needs a new render mode in that crate, not a wiring fix, so it was out of scope here.

## Tests

Two new tests in `main.rs`: GLB export asserts the `glTF` magic, version 2, and a header length field matching the actual file size; STEP export asserts an `ISO-10303-21` header. Both round-trip a one-cube document through the real writers.

- `cargo test -p vcad-cli` — 23 passed
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean
- `cargo fmt -p vcad-cli --check` — clean

## Reviewer notes

The GLB material is a fixed neutral grey rather than resolved from the document's `MaterialDef` table. The CLI has no material database wired up today (the STL path has the same gap), so this keeps the change scoped; per-part materials would be a natural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)