### PR TITLE
fix(sketch): report pending, not solved, when the kernel isn't loaded

### DIFF
--- a/changelog/entries/2026-07-30-sketch-solve-pending-status.json
+++ b/changelog/entries/2026-07-30-sketch-solve-pending-status.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-30-sketch-solve-pending-status",
+  "version": "0.9.4",
+  "date": "2026-07-30",
+  "category": "fix",
+  "title": "Honest sketch solve status before kernel loads",
+  "summary": "Solving a sketch before the kernel WASM finishes loading now shows a dimmed 'pending' badge and re-solves automatically once it loads, instead of falsely showing 'solved'.",
+  "features": ["sketch", "constraints"]
+}

--- a/packages/app/src/components/FeatureTree.tsx
+++ b/packages/app/src/components/FeatureTree.tsx
@@ -174,6 +174,7 @@ function SketchTreeSection() {
             constraintStatus === "error" && "text-red-400",
             constraintStatus === "over" && "text-orange-400",
             constraintStatus === "under" && "text-yellow-400/70",
+            constraintStatus === "pending" && "text-neutral-500",
           )}
           title={`${constraints.length} constraint${constraints.length === 1 ? "" : "s"} · ${constraintStatus}`}
         >

--- a/packages/app/src/components/StatusBar.tsx
+++ b/packages/app/src/components/StatusBar.tsx
@@ -192,6 +192,7 @@ export function StatusBar() {
                 sketchStatus === "error" && "text-red-400",
                 sketchStatus === "over" && "text-orange-400",
                 sketchStatus === "under" && "text-yellow-400",
+                sketchStatus === "pending" && "text-neutral-500",
               )}
             >
               [{sketchStatus}]

--- a/packages/core/src/stores/sketch-store.ts
+++ b/packages/core/src/stores/sketch-store.ts
@@ -577,10 +577,19 @@ export const useSketchStore = create<SketchStore>((set, get) => {
       getKernelWasm()
         .then(() => {
           const s = get();
-          if (s.active && s.constraintStatus === "pending") s.solveSketch();
+          if (!s.active || s.constraintStatus !== "pending") return;
+          try {
+            s.solveSketch();
+          } catch (err) {
+            // The retry itself blew up. Surface it rather than leaving the
+            // sketch parked in "pending" forever with no visible reason.
+            console.warn("[sketch] solver error after hydration:", err);
+            set({ solved: false, constraintStatus: "error" });
+          }
         })
         .catch(() => {
-          // Kernel never hydrated (headless/tests) — stay pending.
+          // Kernel never hydrated (headless/tests) — stay pending. Nothing
+          // was solved and nothing is coming, which "pending" says honestly.
         });
       return;
     }

--- a/packages/core/src/stores/sketch-store.ts
+++ b/packages/core/src/stores/sketch-store.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import type { Vec2, Vec3, SketchSegment2D, SketchConstraint } from "@vcad/ir";
 import type { SketchPlane, SketchState, ConstraintTool, ConstraintStatus, FaceInfo } from "../types.js";
 import { computePlaneFromFace, getSketchPlaneDirections } from "../types.js";
-import { getKernelWasmSync } from "../wasm-singleton.js";
+import { getKernelWasm, getKernelWasmSync } from "../wasm-singleton.js";
 import { buildRectangle, buildCircle } from "../sketch-math.js";
 
 /** A saved profile snapshot for loft operations */
@@ -570,10 +570,18 @@ export const useSketchStore = create<SketchStore>((set, get) => {
     } | null;
 
     if (!wasm || typeof wasm.solveSketchSegments !== "function") {
-      // WASM not hydrated yet (e.g. tests) — mark solved without touching
-      // segments. The UI will show "solved" feedback but won't apply any
-      // geometric updates.
-      set({ solved: true, constraintStatus: "solved" });
+      // WASM not hydrated yet (e.g. during boot, or in tests) — no solve
+      // actually ran, so report "pending" rather than lying with "solved",
+      // and re-run automatically once the kernel module is available.
+      set({ solved: false, constraintStatus: "pending" });
+      getKernelWasm()
+        .then(() => {
+          const s = get();
+          if (s.active && s.constraintStatus === "pending") s.solveSketch();
+        })
+        .catch(() => {
+          // Kernel never hydrated (headless/tests) — stay pending.
+        });
       return;
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -385,7 +385,7 @@ export type ConstraintTool =
   | "equal";
 
 /** Constraint status for visual feedback */
-export type ConstraintStatus = "under" | "solved" | "over" | "error";
+export type ConstraintStatus = "under" | "solved" | "over" | "error" | "pending";
 
 /** Sketch editing state */
 export interface SketchState {


### PR DESCRIPTION
## What

`solveSketch` in `packages/core/src/stores/sketch-store.ts` had a fallback for when `getKernelWasmSync()` returns `null` (or the module lacks `solveSketchSegments`) — i.e. the kernel WASM hasn't hydrated yet. That fallback set `solved: true` and `constraintStatus: "solved"` **without running the solver or touching any segments**. The badge told the user their sketch was fully constrained when in fact nothing had been solved.

This replaces the dishonest state with an honest one:

- New `"pending"` variant on `ConstraintStatus` (`packages/core/src/types.ts`).
- The fallback now sets `solved: false, constraintStatus: "pending"` and kicks off `getKernelWasm()`. When the kernel hydrates, it re-runs `solveSketch()` if the sketch is still active and still pending — so a solve requested during app boot completes for real on its own rather than being silently dropped. If the kernel never loads (headless, tests), the `catch` leaves it honestly pending.
- The two components that color the status badge — `FeatureTree.tsx` and `StatusBar.tsx` — render `pending` as dimmed neutral gray, clearly distinct from the emerald "solved" state.

## Why

A constraint status is a correctness claim about the user's geometry. Reporting "solved" for a solve that never ran is the kind of thing a user only discovers downstream, when the extrude comes out wrong.

## Notes for reviewers

- No existing tests depended on the old fallback path — the only `solveSketch` callers are `useAppCommands.ts` and `useToolDefinitions.tsx` in the app, neither of which asserts on status.
- The re-solve guard checks both `s.active` and `s.constraintStatus === "pending"` so a user who has since exited the sketch, or whose status has moved on, doesn't get a surprise geometry rewrite after hydration.
- `npm run build -w @vcad/core -w @vcad/app` passes; `npm test --workspaces --if-present` is green across all workspaces.
- Changelog entry added (`fix`) since the visible badge behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)