### PR TITLE
fix(step): STEP import reports skipped faces instead of silently dropping them

### DIFF
--- a/changelog/entries/2026-07-30-step-import-skipped-face-report.json
+++ b/changelog/entries/2026-07-30-step-import-skipped-face-report.json
@@ -1,0 +1,14 @@
+{
+  "id": "2026-07-30-step-import-skipped-face-report",
+  "version": "0.9.4",
+  "date": "2026-07-30",
+  "category": "fix",
+  "title": "STEP import reports skipped faces",
+  "summary": "STEP import now reports faces skipped for unsupported surface types (entity id + surface type) instead of silently dropping them — surfaced in the CLI, the app's import toast, and the import_step MCP tool.",
+  "features": [
+    "step-import"
+  ],
+  "mcpTools": [
+    "import_step"
+  ]
+}

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -810,7 +810,15 @@ fn import_step(input: &PathBuf, output: &PathBuf, name: Option<String>) -> Resul
     });
 
     // Import the STEP file
-    let solids = Solid::from_step_all(input)?;
+    let (solids, report) = Solid::from_step_all_with_report(input)?;
+
+    if let Some(summary) = report.summary() {
+        eprintln!(
+            "warning: STEP import skipped {} face(s) with unsupported surface types:",
+            report.total_skipped_faces()
+        );
+        eprintln!("{summary}");
+    }
 
     if solids.is_empty() {
         anyhow::bail!("No solids found in STEP file");

--- a/crates/vcad-kernel-step/src/lib.rs
+++ b/crates/vcad-kernel-step/src/lib.rs
@@ -60,7 +60,10 @@ pub use pmi::{
     read_step_pmi, read_step_pmi_from_buffer, DimensionKind, StepDatum, StepDimension, StepPmi,
     StepTolerance,
 };
-pub use reader::{read_step, read_step_from_buffer};
+pub use reader::{
+    read_step, read_step_from_buffer, read_step_from_buffer_with_report, read_step_with_report,
+    ReadResult, SkippedFace, SolidImportReport, StepImportReport,
+};
 pub use writer::{
     write_step, write_step_solids, write_step_solids_to_buffer, write_step_to_buffer,
 };

--- a/crates/vcad-kernel-step/src/reader.rs
+++ b/crates/vcad-kernel-step/src/reader.rs
@@ -69,6 +69,93 @@ fn point_angle_on_circle(
     y.atan2(x)
 }
 
+/// A face omitted during import because its surface could not be parsed.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SkippedFace {
+    /// STEP `ADVANCED_FACE` entity id of the omitted face.
+    pub face_id: u64,
+    /// STEP entity id of the surface the face referenced.
+    pub surface_id: u64,
+    /// Why parsing failed — typically the unsupported surface type name.
+    pub reason: String,
+}
+
+/// Per-solid record of silent degradations applied during import.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SolidImportReport {
+    /// STEP `MANIFOLD_SOLID_BREP` entity id of the solid.
+    pub solid_id: u64,
+    /// Total faces the solid's shell declared in the file.
+    pub total_faces: usize,
+    /// Faces omitted because their surface type is unsupported. A non-empty
+    /// list means the imported solid has holes where these faces were.
+    pub skipped_faces: Vec<SkippedFace>,
+    /// Non-fatal approximations that don't remove geometry (e.g. curved
+    /// edges subdivided into chords).
+    pub notes: Vec<String>,
+}
+
+impl SolidImportReport {
+    /// True when the solid imported without dropping any faces.
+    pub fn is_clean(&self) -> bool {
+        self.skipped_faces.is_empty()
+    }
+}
+
+/// Whole-file import report: one entry per imported solid.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct StepImportReport {
+    /// Per-solid reports, in the order the solids were returned.
+    pub solids: Vec<SolidImportReport>,
+}
+
+impl StepImportReport {
+    /// True when no solid dropped any faces.
+    pub fn is_clean(&self) -> bool {
+        self.solids.iter().all(|s| s.is_clean())
+    }
+
+    /// Total number of faces dropped across all solids.
+    pub fn total_skipped_faces(&self) -> usize {
+        self.solids.iter().map(|s| s.skipped_faces.len()).sum()
+    }
+
+    /// Human-readable warning summary, or `None` when the import is clean.
+    pub fn summary(&self) -> Option<String> {
+        if self.is_clean() {
+            return None;
+        }
+        let mut lines = Vec::new();
+        for s in &self.solids {
+            if s.skipped_faces.is_empty() {
+                continue;
+            }
+            lines.push(format!(
+                "solid #{}: skipped {} of {} faces (imported geometry has holes):",
+                s.solid_id,
+                s.skipped_faces.len(),
+                s.total_faces
+            ));
+            for f in &s.skipped_faces {
+                lines.push(format!(
+                    "  face #{} (surface #{}): {}",
+                    f.face_id, f.surface_id, f.reason
+                ));
+            }
+        }
+        Some(lines.join("\n"))
+    }
+}
+
+/// Result of a STEP read: the solids plus a report of any degradations.
+#[derive(Debug)]
+pub struct ReadResult {
+    /// The imported B-rep solids.
+    pub solids: Vec<BRepSolid>,
+    /// Per-solid import report (skipped faces, approximation notes).
+    pub report: StepImportReport,
+}
+
 /// Read STEP file from a path.
 ///
 /// # Arguments
@@ -77,10 +164,18 @@ fn point_angle_on_circle(
 ///
 /// # Returns
 ///
-/// A vector of B-rep solids found in the file.
+/// A vector of B-rep solids found in the file. Faces with unsupported
+/// surface types are silently omitted — use [`read_step_with_report`] to
+/// find out about them.
 pub fn read_step(path: impl AsRef<Path>) -> Result<Vec<BRepSolid>, StepError> {
+    read_step_with_report(path).map(|r| r.solids)
+}
+
+/// Read STEP file from a path, reporting skipped faces and other
+/// degradations alongside the solids.
+pub fn read_step_with_report(path: impl AsRef<Path>) -> Result<ReadResult, StepError> {
     let data = std::fs::read(path)?;
-    read_step_from_buffer(&data)
+    read_step_from_buffer_with_report(&data)
 }
 
 /// Read STEP file from a byte buffer.
@@ -91,8 +186,16 @@ pub fn read_step(path: impl AsRef<Path>) -> Result<Vec<BRepSolid>, StepError> {
 ///
 /// # Returns
 ///
-/// A vector of B-rep solids found in the file.
+/// A vector of B-rep solids found in the file. Faces with unsupported
+/// surface types are silently omitted — use
+/// [`read_step_from_buffer_with_report`] to find out about them.
 pub fn read_step_from_buffer(data: &[u8]) -> Result<Vec<BRepSolid>, StepError> {
+    read_step_from_buffer_with_report(data).map(|r| r.solids)
+}
+
+/// Read STEP file from a byte buffer, reporting skipped faces and other
+/// degradations alongside the solids.
+pub fn read_step_from_buffer_with_report(data: &[u8]) -> Result<ReadResult, StepError> {
     let step_file = Parser::parse(data)?;
     let mut reader = StepReader::new(&step_file);
     reader.read_all_solids()
@@ -103,7 +206,7 @@ pub fn read_step_from_buffer(data: &[u8]) -> Result<Vec<BRepSolid>, StepError> {
 /// Creates a fresh reader state so maps from other solids don't bleed in.
 pub(crate) fn read_solid_from_file(file: &StepFile, solid_id: u64) -> Result<BRepSolid, StepError> {
     let mut reader = StepReader::new(file);
-    reader.read_solid(solid_id)
+    reader.read_solid(solid_id).map(|(solid, _)| solid)
 }
 
 /// Context for reading STEP files and building B-rep solids.
@@ -175,7 +278,7 @@ impl<'a> StepReader<'a> {
         Some(ids)
     }
 
-    fn read_all_solids(&mut self) -> Result<Vec<BRepSolid>, StepError> {
+    fn read_all_solids(&mut self) -> Result<ReadResult, StepError> {
         let solid_ids: Vec<u64> = match self.anchored_solid_ids() {
             // Anchor present: read exactly what it references. Empty means the
             // product structure points at no solids — fail rather than rescue
@@ -198,6 +301,7 @@ impl<'a> StepReader<'a> {
         };
 
         let mut solids = Vec::new();
+        let mut report = StepImportReport::default();
         for entity_id in solid_ids {
             // Reset maps for each solid
             self.vertex_map.clear();
@@ -206,14 +310,18 @@ impl<'a> StepReader<'a> {
             self.surface_map.clear();
             self.subdivided_edges.clear();
 
-            let solid = self.read_solid(entity_id)?;
+            let (solid, solid_report) = self.read_solid(entity_id)?;
             solids.push(solid);
+            report.solids.push(solid_report);
         }
 
-        Ok(solids)
+        Ok(ReadResult { solids, report })
     }
 
-    pub(crate) fn read_solid(&mut self, solid_id: u64) -> Result<BRepSolid, StepError> {
+    pub(crate) fn read_solid(
+        &mut self,
+        solid_id: u64,
+    ) -> Result<(BRepSolid, SolidImportReport), StepError> {
         use std::collections::HashSet;
 
         let mut topo = Topology::new();
@@ -233,6 +341,11 @@ impl<'a> StepReader<'a> {
 
         // Track faces we skip due to unsupported surface types
         let mut skipped_faces: HashSet<u64> = HashSet::new();
+        let mut solid_report = SolidImportReport {
+            solid_id,
+            total_faces: step_shell.face_ids.len(),
+            ..Default::default()
+        };
 
         // First pass: collect all vertices and surfaces
         for &face_id in &step_shell.face_ids {
@@ -246,9 +359,15 @@ impl<'a> StepReader<'a> {
                         self.surface_map
                             .insert(step_face.surface_id, (idx, sense_flipped));
                     }
-                    Err(StepError::UnsupportedEntity(_)) => {
-                        // Skip this face - surface type not supported
+                    Err(StepError::UnsupportedEntity(reason)) => {
+                        // Skip this face — surface type not supported. Recorded
+                        // in the report so the omission is never silent.
                         skipped_faces.insert(face_id);
+                        solid_report.skipped_faces.push(SkippedFace {
+                            face_id,
+                            surface_id: step_face.surface_id,
+                            reason,
+                        });
                         continue;
                     }
                     Err(e) => return Err(e),
@@ -444,11 +563,24 @@ impl<'a> StepReader<'a> {
         let shell_id = topo.add_shell(vcad_face_ids, ShellType::Outer);
         let solid_id = topo.add_solid(shell_id);
 
-        Ok(BRepSolid {
-            topology: topo,
-            geometry: geom,
-            solid_id,
-        })
+        // Chord subdivision loses the analytic curve but not the geometry —
+        // note it once per solid rather than per face.
+        let subdivided = self.subdivided_edges.len() / 2;
+        if subdivided > 0 {
+            solid_report.notes.push(format!(
+                "{subdivided} curved edge{} approximated by chordal subdivision",
+                if subdivided == 1 { "" } else { "s" }
+            ));
+        }
+
+        Ok((
+            BRepSolid {
+                topology: topo,
+                geometry: geom,
+                solid_id,
+            },
+            solid_report,
+        ))
     }
 
     /// Subdivide a curved edge (circle, B-spline, or trimmed variant) into multiple

--- a/crates/vcad-kernel-step/tests/import_report.rs
+++ b/crates/vcad-kernel-step/tests/import_report.rs
@@ -1,0 +1,115 @@
+//! The import report: a face whose surface type is unsupported must be
+//! recorded — entity id and surface type name — instead of vanishing
+//! silently from the imported solid.
+
+use vcad_kernel_step::{read_step_from_buffer, read_step_from_buffer_with_report};
+
+/// A closed cylinder-shaped solid (r=10, h=20, axis Z) whose lateral face
+/// surface (#40) is substituted per test. Same shape as the
+/// extended_surfaces fixture.
+const CYLINDER_TEMPLATE: &str = r#"ISO-10303-21;
+HEADER;
+FILE_DESCRIPTION((''), '2;1');
+FILE_NAME('fixture.step', '2024-01-01', (''), (''), '', '', '');
+FILE_SCHEMA(('AUTOMOTIVE_DESIGN'));
+ENDSEC;
+DATA;
+#1 = CARTESIAN_POINT('', (10.0, 0.0, 0.0));
+#2 = CARTESIAN_POINT('', (10.0, 0.0, 20.0));
+#3 = VERTEX_POINT('', #1);
+#4 = VERTEX_POINT('', #2);
+#10 = CARTESIAN_POINT('', (0.0, 0.0, 0.0));
+#11 = DIRECTION('', (0.0, 0.0, 1.0));
+#12 = DIRECTION('', (1.0, 0.0, 0.0));
+#13 = AXIS2_PLACEMENT_3D('', #10, #11, #12);
+#14 = CIRCLE('', #13, 10.0);
+#15 = CARTESIAN_POINT('', (0.0, 0.0, 20.0));
+#16 = AXIS2_PLACEMENT_3D('', #15, #11, #12);
+#17 = CIRCLE('', #16, 10.0);
+#18 = VECTOR('', #11, 20.0);
+#19 = LINE('', #1, #18);
+#20 = EDGE_CURVE('', #3, #3, #14, .T.);
+#21 = EDGE_CURVE('', #4, #4, #17, .T.);
+#22 = EDGE_CURVE('', #3, #4, #19, .T.);
+#23 = ORIENTED_EDGE('', *, *, #20, .T.);
+#24 = ORIENTED_EDGE('', *, *, #22, .T.);
+#25 = ORIENTED_EDGE('', *, *, #21, .F.);
+#26 = ORIENTED_EDGE('', *, *, #22, .F.);
+#27 = EDGE_LOOP('', (#23, #24, #25, #26));
+#28 = FACE_OUTER_BOUND('', #27, .T.);
+#29 = ADVANCED_FACE('', (#28), #40, .T.);
+#30 = DIRECTION('', (0.0, 0.0, -1.0));
+#31 = AXIS2_PLACEMENT_3D('', #10, #30, #12);
+#32 = PLANE('', #31);
+#33 = ORIENTED_EDGE('', *, *, #20, .F.);
+#34 = EDGE_LOOP('', (#33));
+#35 = FACE_OUTER_BOUND('', #34, .T.);
+#36 = ADVANCED_FACE('', (#35), #32, .T.);
+#37 = AXIS2_PLACEMENT_3D('', #15, #11, #12);
+#38 = PLANE('', #37);
+#39 = ORIENTED_EDGE('', *, *, #21, .T.);
+#41 = EDGE_LOOP('', (#39));
+#42 = FACE_OUTER_BOUND('', #41, .T.);
+#43 = ADVANCED_FACE('', (#42), #38, .T.);
+<LATERAL>
+#44 = CLOSED_SHELL('', (#29, #36, #43));
+#45 = MANIFOLD_SOLID_BREP('part', #44);
+ENDSEC;
+END-ISO-10303-21;
+"#;
+
+fn build_fixture(lateral: &str) -> String {
+    CYLINDER_TEMPLATE.replace("<LATERAL>", lateral)
+}
+
+#[test]
+fn unsupported_surface_is_reported_not_silent() {
+    // DEGENERATE_TOROIDAL_SURFACE is a real AP214 entity the reader does not
+    // support — the lateral face must be skipped AND reported.
+    let step = build_fixture("#40 = DEGENERATE_TOROIDAL_SURFACE('', #13, 10.0, 10.0, .T.);");
+    let result =
+        read_step_from_buffer_with_report(step.as_bytes()).expect("import should still succeed");
+
+    assert_eq!(result.solids.len(), 1);
+    // Only the two planar caps survive.
+    assert_eq!(result.solids[0].topology.faces.len(), 2);
+
+    assert!(!result.report.is_clean());
+    assert_eq!(result.report.total_skipped_faces(), 1);
+
+    let solid_report = &result.report.solids[0];
+    assert_eq!(solid_report.solid_id, 45);
+    assert_eq!(solid_report.total_faces, 3);
+
+    let skipped = &solid_report.skipped_faces[0];
+    assert_eq!(skipped.face_id, 29);
+    assert_eq!(skipped.surface_id, 40);
+    assert!(
+        skipped.reason.contains("DEGENERATE_TOROIDAL_SURFACE"),
+        "reason should name the unsupported surface type, got: {}",
+        skipped.reason
+    );
+
+    let summary = result.report.summary().expect("dirty import has a summary");
+    assert!(summary.contains("DEGENERATE_TOROIDAL_SURFACE"));
+    assert!(summary.contains("#29"));
+}
+
+#[test]
+fn clean_import_has_clean_report() {
+    let step = build_fixture("#40 = CYLINDRICAL_SURFACE('', #13, 10.0);");
+    let result = read_step_from_buffer_with_report(step.as_bytes()).expect("import should succeed");
+
+    assert_eq!(result.solids[0].topology.faces.len(), 3);
+    assert!(result.report.is_clean());
+    assert_eq!(result.report.summary(), None);
+    // Curved rim edges are chord-subdivided — noted, not per-face.
+    assert!(!result.report.solids[0].notes.is_empty());
+}
+
+#[test]
+fn compat_wrapper_still_returns_bare_solids() {
+    let step = build_fixture("#40 = CYLINDRICAL_SURFACE('', #13, 10.0);");
+    let solids = read_step_from_buffer(step.as_bytes()).expect("import should succeed");
+    assert_eq!(solids.len(), 1);
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -3150,6 +3150,86 @@ pub fn import_step_buffer(data: &[u8]) -> Result<JsValue, JsError> {
     serde_wasm_bindgen::to_value(&meshes).map_err(|e| JsError::new(&e.to_string()))
 }
 
+#[derive(serde::Serialize)]
+struct WasmSkippedFace {
+    face_id: u64,
+    surface_id: u64,
+    reason: String,
+}
+
+#[derive(serde::Serialize)]
+struct WasmSolidImportReport {
+    solid_id: u64,
+    total_faces: usize,
+    skipped_faces: Vec<WasmSkippedFace>,
+    notes: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+struct WasmStepImportResult {
+    meshes: Vec<WasmMesh>,
+    report: Vec<WasmSolidImportReport>,
+    /// Human-readable warning summary; null when the import is clean.
+    summary: Option<String>,
+}
+
+/// Import solids from STEP file bytes, reporting skipped faces.
+///
+/// Like [`import_step_buffer`], but returns `{ meshes, report, summary }`
+/// where `report` lists, per solid, any faces omitted because their surface
+/// type is unsupported (the imported geometry has holes there), and
+/// `summary` is a ready-to-display warning string (null when clean).
+#[module("step")]
+#[wasm_bindgen(js_name = importStepBufferWithReport)]
+pub fn import_step_buffer_with_report(data: &[u8]) -> Result<JsValue, JsError> {
+    let (solids, report) = vcad_kernel::Solid::from_step_buffer_all_with_report(data)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    let meshes: Vec<WasmMesh> = solids
+        .iter()
+        .map(|s| {
+            let mesh = s.to_mesh(16);
+            let normals = if mesh.normals.len() == mesh.vertices.len() {
+                Some(mesh.normals)
+            } else {
+                None
+            };
+            WasmMesh {
+                positions: mesh.vertices,
+                indices: mesh.indices,
+                normals,
+                face_kinds: None,
+            }
+        })
+        .collect();
+
+    let summary = report.summary();
+    let result = WasmStepImportResult {
+        meshes,
+        report: report
+            .solids
+            .into_iter()
+            .map(|s| WasmSolidImportReport {
+                solid_id: s.solid_id,
+                total_faces: s.total_faces,
+                skipped_faces: s
+                    .skipped_faces
+                    .into_iter()
+                    .map(|f| WasmSkippedFace {
+                        face_id: f.face_id,
+                        surface_id: f.surface_id,
+                        reason: f.reason,
+                    })
+                    .collect(),
+                notes: s.notes,
+            })
+            .collect(),
+        summary,
+    };
+
+    serde_wasm_bindgen::to_value(&result).map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Import a URDF (Unified Robot Description Format) file and return a
 /// serialised vcad [`Document`].
 ///

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -1238,15 +1238,29 @@ impl Solid {
     ///
     /// Returns a `StepError` if the file cannot be read, parsed, or contains no solids.
     pub fn from_step_all(path: impl AsRef<Path>) -> Result<Vec<Self>, StepError> {
-        let solids = vcad_kernel_step::read_step(path)?;
-        Ok(solids
+        Self::from_step_all_with_report(path).map(|(solids, _)| solids)
+    }
+
+    /// Import all solids from a STEP file, together with an import report
+    /// describing any skipped faces or approximations.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StepError` if the file cannot be read, parsed, or contains no solids.
+    pub fn from_step_all_with_report(
+        path: impl AsRef<Path>,
+    ) -> Result<(Vec<Self>, vcad_kernel_step::StepImportReport), StepError> {
+        let result = vcad_kernel_step::read_step_with_report(path)?;
+        let solids = result
+            .solids
             .into_iter()
             .map(|brep| Self {
                 names: None,
                 repr: SolidRepr::BRep(Box::new(brep)),
                 segments: 32,
             })
-            .collect())
+            .collect();
+        Ok((solids, result.report))
     }
 
     /// Import the first solid from a STEP buffer.
@@ -1282,15 +1296,29 @@ impl Solid {
     ///
     /// Returns a `StepError` if the buffer cannot be parsed.
     pub fn from_step_buffer_all(data: &[u8]) -> Result<Vec<Self>, StepError> {
-        let solids = vcad_kernel_step::read_step_from_buffer(data)?;
-        Ok(solids
+        Self::from_step_buffer_all_with_report(data).map(|(solids, _)| solids)
+    }
+
+    /// Import all solids from a STEP buffer, together with an import report
+    /// describing any skipped faces or approximations.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `StepError` if the buffer cannot be parsed.
+    pub fn from_step_buffer_all_with_report(
+        data: &[u8],
+    ) -> Result<(Vec<Self>, vcad_kernel_step::StepImportReport), StepError> {
+        let result = vcad_kernel_step::read_step_from_buffer_with_report(data)?;
+        let solids = result
+            .solids
             .into_iter()
             .map(|brep| Self {
                 names: None,
                 repr: SolidRepr::BRep(Box::new(brep)),
                 segments: 32,
             })
-            .collect())
+            .collect();
+        Ok((solids, result.report))
     }
 
     /// Export this solid to a STEP file.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -509,14 +509,21 @@ export function App() {
         logger.info("step", `Buffer size: ${buffer.byteLength}`);
 
         logger.info("step", "Calling engine.importStepWithReport...");
-        const { meshes: rawMeshes, summary: importWarnings } = await runJob(
+        const {
+          meshes: rawMeshes,
+          report: importReport,
+          summary: importWarnings,
+        } = await runJob(
           { verb: `Importing ${file.name}` },
           () => engine.importStepWithReport(buffer),
         );
         logger.info("step", `Got meshes: ${rawMeshes.length}`);
-        if (importWarnings) {
-          logger.warn("step", importWarnings);
-          const skipped = importWarnings.match(/face #/g)?.length ?? 0;
+        const skipped = importReport.reduce(
+          (sum, s) => sum + s.skipped_faces.length,
+          0,
+        );
+        if (skipped > 0) {
+          logger.warn("step", importWarnings ?? `${skipped} face(s) skipped`);
           useNotificationStore.getState().addToast(
             `STEP import skipped ${skipped} face${skipped !== 1 ? "s" : ""} with unsupported surfaces — the geometry has holes there (see console)`,
             "warning",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -508,12 +508,20 @@ export function App() {
         const buffer = await file.arrayBuffer();
         logger.info("step", `Buffer size: ${buffer.byteLength}`);
 
-        logger.info("step", "Calling engine.importStep...");
-        const rawMeshes = await runJob(
+        logger.info("step", "Calling engine.importStepWithReport...");
+        const { meshes: rawMeshes, summary: importWarnings } = await runJob(
           { verb: `Importing ${file.name}` },
-          () => engine.importStep(buffer),
+          () => engine.importStepWithReport(buffer),
         );
         logger.info("step", `Got meshes: ${rawMeshes.length}`);
+        if (importWarnings) {
+          logger.warn("step", importWarnings);
+          const skipped = importWarnings.match(/face #/g)?.length ?? 0;
+          useNotificationStore.getState().addToast(
+            `STEP import skipped ${skipped} face${skipped !== 1 ? "s" : ""} with unsupported surfaces — the geometry has holes there (see console)`,
+            "warning",
+          );
+        }
 
         if (rawMeshes.length === 0) {
           useNotificationStore.getState().addToast("No geometry found in STEP file", "error");

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -484,12 +484,43 @@ export interface DrawingSheetSpec {
   bom?: BomRow[];
 }
 
+/** A face omitted during STEP import because its surface type is unsupported. */
+export interface StepSkippedFace {
+  face_id: number;
+  surface_id: number;
+  reason: string;
+}
+
+/** Per-solid STEP import degradation report. */
+export interface StepSolidImportReport {
+  solid_id: number;
+  total_faces: number;
+  skipped_faces: StepSkippedFace[];
+  notes: string[];
+}
+
+/** STEP import result with the degradation report alongside the meshes. */
+export interface StepImportResult {
+  meshes: TriangleMesh[];
+  /** Per-solid reports; empty when the kernel WASM predates the report API. */
+  report: StepSolidImportReport[];
+  /** Ready-to-display warning; null when the import dropped nothing. */
+  summary: string | null;
+}
+
 /** Type for the initialized kernel module */
 export interface KernelModule {
   Solid: typeof Solid;
   WasmAnnotationLayer: typeof WasmAnnotationLayer;
   projectMesh: (mesh: { positions: Float32Array; indices: Uint32Array }, viewDirection: string) => ProjectedView | null;
   importStepBuffer: (data: Uint8Array) => Array<{ positions: Float32Array; indices: Uint32Array }>;
+  /** Like importStepBuffer, but also reports faces skipped as unsupported.
+   * Optional: absent on kernel WASM builds older than the report API. */
+  importStepBufferWithReport?: (data: Uint8Array) => {
+    meshes: Array<{ positions: Float32Array; indices: Uint32Array }>;
+    report: StepSolidImportReport[];
+    summary: string | null;
+  };
   /** Export a document's scene roots to a STEP AP214 buffer (BRep-preserving). */
   documentToStepBuffer?: (docJson: string) => Uint8Array;
   /**
@@ -1046,6 +1077,7 @@ export class Engine {
       WasmAnnotationLayer: wasmModule.WasmAnnotationLayer,
       projectMesh: wasmModule.projectMesh,
       importStepBuffer: wasmModule.importStepBuffer,
+      importStepBufferWithReport: (wasmModule as Record<string, unknown>).importStepBufferWithReport as KernelModule["importStepBufferWithReport"],
       documentToStepBuffer: (wasmModule as Record<string, unknown>).documentToStepBuffer as KernelModule["documentToStepBuffer"],
       importUrdfBuffer: (wasmModule as Record<string, unknown>).importUrdfBuffer as KernelModule["importUrdfBuffer"],
       exportProjectedViewToDxf: wasmModule.exportProjectedViewToDxf,
@@ -1745,6 +1777,29 @@ export class Engine {
       positions: new Float32Array(m.positions),
       indices: new Uint32Array(m.indices),
     }));
+  }
+
+  /** Import solids from a STEP file buffer, reporting skipped faces.
+   *
+   * Faces whose surface type the kernel doesn't support are omitted from
+   * the meshes; the report identifies each one (STEP entity id + surface
+   * type). On kernel WASM builds that predate the report API, falls back
+   * to the bare import with an empty report.
+   */
+  importStepWithReport(data: ArrayBuffer): StepImportResult {
+    const bytes = new Uint8Array(data);
+    if (typeof this.kernel.importStepBufferWithReport !== "function") {
+      return { meshes: this.importStep(data), report: [], summary: null };
+    }
+    const result = this.kernel.importStepBufferWithReport(bytes);
+    return {
+      meshes: result.meshes.map((m) => ({
+        positions: new Float32Array(m.positions),
+        indices: new Uint32Array(m.indices),
+      })),
+      report: result.report,
+      summary: result.summary,
+    };
   }
 
   /**

--- a/packages/mcp/src/__tests__/artifact-store.test.ts
+++ b/packages/mcp/src/__tests__/artifact-store.test.ts
@@ -182,26 +182,65 @@ describe("handleArtifactRequest", () => {
 
 describe("import_step large-result offload", () => {
   const smallEngine = {
-    importStep: () => [
-      {
-        positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
-        indices: new Uint32Array([0, 1, 2]),
-        normals: undefined,
-      },
-    ],
+    importStepWithReport: () => ({
+      meshes: [
+        {
+          positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          indices: new Uint32Array([0, 1, 2]),
+          normals: undefined,
+        },
+      ],
+      report: [],
+      summary: null,
+    }),
   } as unknown as Engine;
 
   const bigEngine = {
-    importStep: () => [
-      {
-        positions: new Float32Array(40_000),
-        indices: new Uint32Array(40_000),
-        normals: undefined,
-      },
-    ],
+    importStepWithReport: () => ({
+      meshes: [
+        {
+          positions: new Float32Array(40_000),
+          indices: new Uint32Array(40_000),
+          normals: undefined,
+        },
+      ],
+      report: [],
+      summary: null,
+    }),
   } as unknown as Engine;
 
   const step64 = Buffer.from("x").toString("base64");
+
+  it("surfaces skipped faces from the import report", () => {
+    const dirtyEngine = {
+      importStepWithReport: () => ({
+        meshes: [
+          {
+            positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            indices: new Uint32Array([0, 1, 2]),
+            normals: undefined,
+          },
+        ],
+        report: [
+          {
+            solid_id: 45,
+            total_faces: 3,
+            skipped_faces: [
+              { face_id: 29, surface_id: 40, reason: "DEGENERATE_TOROIDAL_SURFACE" },
+            ],
+            notes: [],
+          },
+        ],
+        summary: "solid #45: skipped 1 of 3 faces",
+      }),
+    } as unknown as Engine;
+    const res = importStep({ content_base64: step64, name: "holey" }, dirtyEngine);
+    const out = JSON.parse(res.content[0].text);
+    expect(out.summary.warning).toContain("1 face(s) skipped");
+    expect(out.summary.skipped_faces).toEqual([
+      { solid_id: 45, face_id: 29, surface_id: 40, reason: "DEGENERATE_TOROIDAL_SURFACE" },
+    ]);
+  });
 
   it("keeps a small import inline", () => {
     const res = importStep({ content_base64: step64, name: "tiny" }, smallEngine);

--- a/packages/mcp/src/tools/import.ts
+++ b/packages/mcp/src/tools/import.ts
@@ -101,8 +101,11 @@ export function importStep(
   const arrayBuffer = new ArrayBuffer(fileBuffer.byteLength);
   new Uint8Array(arrayBuffer).set(fileBuffer);
 
-  // Import using the engine
-  const meshes = engine.importStep(arrayBuffer);
+  // Import using the engine — with the degradation report, so faces the
+  // kernel skipped (unsupported surface types) surface in the result
+  // instead of vanishing silently.
+  const { meshes, report, summary: importWarnings } =
+    engine.importStepWithReport(arrayBuffer);
 
   if (meshes.length === 0) {
     throw new Error("No geometry found in STEP file");
@@ -172,10 +175,24 @@ export function importStep(
     },
   };
 
+  const skippedFaces = report.reduce((sum, s) => sum + s.skipped_faces.length, 0);
   const summary = {
     bodies: meshes.length,
     total_triangles: meshes.reduce((sum, m) => sum + m.indices.length / 3, 0),
     total_vertices: meshes.reduce((sum, m) => sum + m.positions.length / 3, 0),
+    ...(skippedFaces > 0
+      ? {
+          warning: `${skippedFaces} face(s) skipped (unsupported surface types) — the imported geometry has holes where they were.\n${importWarnings ?? ""}`,
+          skipped_faces: report.flatMap((s) =>
+            s.skipped_faces.map((f) => ({
+              solid_id: s.solid_id,
+              face_id: f.face_id,
+              surface_id: f.surface_id,
+              reason: f.reason,
+            })),
+          ),
+        }
+      : {}),
   };
 
   // A real STEP import is megabytes of mesh JSON — far past the tool-output


### PR DESCRIPTION
## What

A STEP face whose surface fails `parse_surface_oriented` with `UnsupportedEntity` was added to `skipped_faces` in `read_solid` and omitted from the imported solid **with no signal at all** — the user got a solid with holes in it and no way to find out why, or which faces were lost.

Import now threads a report out of the reader and surfaces it at every consumer, matching the repo-wide fail-closed reporting convention (see `vcad-receipt`).

## The report

`SolidImportReport` carries, per solid: the shell's `total_faces`, and one `SkippedFace { face_id, surface_id, reason }` per omission — the STEP entity id of the face, the entity id of the surface it referenced, and the surface type name lifted from the parse error. `StepImportReport` wraps the per-solid records and offers `is_clean()`, `total_skipped_faces()`, and a ready-to-print `summary()`.

Chordal subdivision of curved edges lands in a per-solid `notes` list rather than per face — it approximates geometry but doesn't remove any, so it doesn't warrant a face-level entry.

## API

`read_step_with_report` / `read_step_from_buffer_with_report` return `ReadResult { solids, report }`. The existing `read_step` / `read_step_from_buffer` become thin wrappers over them, so **every existing caller keeps compiling unchanged**. `vcad-kernel` mirrors the pair with `Solid::from_step_all_with_report` / `from_step_buffer_all_with_report`.

## Consumers

- **`vcad-cli import-step`** — prints a stderr warning summary naming each skipped face and its surface type.
- **`import_step` (MCP)** — adds `summary.warning` plus a structured `summary.skipped_faces` array to the result text when anything was dropped.
- **App drag-drop** — raises a warning toast (`STEP import skipped N faces with unsupported surfaces — the geometry has holes there`) and logs the full per-face detail.
- **WASM** — new `importStepBufferWithReport` returning `{ meshes, report, summary }`.

## Reviewer notes

- **No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts are committed** — `wasm-refresh.yml` on main owns those. Because of that, the checked-in WASM predates the new binding, so `Engine.importStepWithReport` feature-detects `importStepBufferWithReport` and falls back to the bare import with an empty report. The app path degrades gracefully and lights up once CI refreshes the artifacts after merge.
- The two `artifact-store.test.ts` import_step fixtures were updated because their engine mocks stubbed `importStep`, which the tool no longer calls.

## Testing

- New `crates/vcad-kernel-step/tests/import_report.rs`: a hand-written STEP fixture whose lateral face uses `DEGENERATE_TOROIDAL_SURFACE` (a real AP214 entity the reader doesn't support) asserts the report names the face (`#29`), the surface (`#40`), and the type; plus a clean-import case and a compat-wrapper case.
- New MCP test asserting the report reaches the tool result.
- `cargo test --workspace` — exit 0.
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `npm test -w @vcad/mcp` — 97/97 files, 1079 passed.
- Builds green for `@vcad/engine`, `@vcad/mcp`, `@vcad/app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)