### PR TITLE
fix(booleans): close the trim-overshoot defect family (torr A1/A2)

### DIFF
--- a/changelog/entries/2026-07-30-boolean-trim-overshoot-fix.json
+++ b/changelog/entries/2026-07-30-boolean-trim-overshoot-fix.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-30-boolean-trim-overshoot-fix",
+  "version": "0.9.4",
+  "date": "2026-07-30",
+  "category": "fix",
+  "title": "Boolean trim overshoot on curved trim boundaries",
+  "summary": "Booleans that trim parts against cylindrical boundaries (e.g. pattern blades cut to a radius) no longer over- or under-trim: split boundaries land on the true intersection and thin slivers classify reliably.",
+  "features": ["kernel", "booleans"],
+  "mcpTools": []
+}

--- a/crates/vcad-eval/tests/torr_boolean_catalogue.rs
+++ b/crates/vcad-eval/tests/torr_boolean_catalogue.rs
@@ -303,7 +303,6 @@ fn a1_pattern_child_boolean_gross() {
 /// to r45 via an annulus tool. Untrimmed total = 23 × 147.6975 = 3397.04;
 /// trimmed = 23 × 146.3205 = 3365.37.
 #[test]
-#[ignore = "known remaining: trim executes but overshoots ~1.1% (3329.8 vs 3365.4; field baseline returned the untrimmed 3397). Sliver-boundary placement on sampled ellipse curves."]
 fn a1_pattern_child_boolean_sliver() {
     let i = inspect(&format!(
         "[circular-pattern 0 0 0  0 0 1  23 360 \
@@ -324,7 +323,6 @@ fn a1_pattern_child_boolean_sliver() {
 /// ≈3365 expected), asymmetric bbox — some instances trimmed, some not,
 /// some corrupted.
 #[test]
-#[ignore = "known remaining: -5.8% (3171.7 vs 3365.4; field baseline -63%). Per-instance trim-boundary error accumulates across 23 rotated ellipse cuts."]
 fn a2_boolean_over_pattern_doc10() {
     let i = inspect(
         "[difference [translate 0 0 96.89 [difference [cylinder 45.0 14.05] \
@@ -358,7 +356,6 @@ fn a2_boolean_over_pattern_doc10() {
 /// must lose its outer half. Per-blade kept ≈ 51.35 (numeric, r30 clip of
 /// the flat blade = 53.41... computed for the FLAT blade below).
 #[test]
-#[ignore = "known remaining: +4.0% (444.5 vs 427.3). Analytic wall split positions vs tessellated-mesh classification disagree at the r30 trim boundary."]
 fn a2_boolean_over_pattern_gross() {
     // flat blade ∩ r<30: ∫ y∈[0,0.5] (√(900−y²) − 21.5) dy × 12.57 = 53.4138
     let per_blade = 53.4138;

--- a/crates/vcad-kernel-booleans/src/classify.rs
+++ b/crates/vcad-kernel-booleans/src/classify.rs
@@ -28,6 +28,19 @@ pub enum FaceClassification {
     OnOpposite,
 }
 
+/// How far a classification probe must sit from the other solid's boundary
+/// before its in/out verdict is trusted to veto (mm).
+///
+/// It has to clear every noise source that can put a probe on the wrong
+/// side of a boundary it should sit exactly ON: the classification mesh's
+/// chordal sag (~4.5e-3 mm at the 256-segment cap) and split-boundary
+/// placement error, whose worst case is the trim truncation wedge near a
+/// tangency (~0.05 mm, measured on the torr doc_10 blades). A genuinely
+/// straddling face — one the splitter missed entirely — overhangs by much
+/// more: 0.165 mm in the smallest observed case (torr's rotating-group
+/// bore wall). 0.1 mm separates the two regimes with ~2x margin either way.
+const CONFIDENT_CLEARANCE: f64 = 0.1;
+
 /// Closest point on segment (x1,y1)-(x2,y2) to (px,py).
 fn nearest_point_on_segment_2d(px: f64, py: f64, x1: f64, y1: f64, x2: f64, y2: f64) -> (f64, f64) {
     let dx = x2 - x1;
@@ -1168,7 +1181,6 @@ pub fn classify_face(
     // missed entirely — overhang by much more (0.165 mm in the smallest
     // observed case, torr's rotating-group bore wall), so 0.1 mm separates
     // the two regimes with ~2-3x margin on either side.
-    let confident = 0.1;
     let verdicts: Vec<(Point3, bool)> = probes
         .iter()
         .map(|p| {
@@ -1176,35 +1188,46 @@ pub fn classify_face(
             (inward, point_in_mesh(&inward, other_mesh))
         })
         .collect();
-    // Fast path: unanimous probes need no clearance computation at all —
-    // the confidence weighting only matters when the vote is split, and
-    // `dist_to_mesh` is an O(triangles) scan per probe.
+    // Fast path: unanimous probes need no clearance computation at all.
+    // The confidence weighting only changes the answer when the probes
+    // disagree, and clearance costs a mesh scan per probe — so on the
+    // overwhelming majority of faces this costs nothing beyond the
+    // point-in-mesh tests the old unanimity rule already did.
     let n_inside = verdicts.iter().filter(|(_, i)| *i).count();
     let inside = if n_inside == verdicts.len() {
         true
     } else if n_inside == 0 {
         false
     } else {
-        let mut best_clear = f64::NEG_INFINITY;
-        let mut best_inside = false;
-        let mut any_confident = false;
-        let mut confident_all_inside = true;
-        for (inward, inside) in &verdicts {
-            let clear = dist_to_mesh(inward, other_mesh);
-            if clear > best_clear {
-                best_clear = clear;
-                best_inside = *inside;
-            }
-            if clear > confident {
-                any_confident = true;
-                if !inside {
-                    confident_all_inside = false;
+        // Split vote. Which probes are far enough from the other boundary
+        // to be trusted? `clearance_exceeds` bails at the first triangle
+        // within the threshold, so a probe hugging the boundary — the
+        // common case here — costs a partial scan, not a full one.
+        let confident: Vec<bool> = verdicts
+            .iter()
+            .map(|(p, _)| clearance_exceeds(p, other_mesh, CONFIDENT_CLEARANCE))
+            .collect();
+        if confident.iter().any(|c| *c) {
+            // Unanimity among the confident probes: any confident Outside
+            // probe vetoes, which is what protects genuinely straddling
+            // faces.
+            verdicts
+                .iter()
+                .zip(&confident)
+                .all(|((_, inside), conf)| !conf || *inside)
+        } else {
+            // Every probe sits inside the ambiguity band. Fall back to the
+            // one with the most clearance — the least noise-prone verdict.
+            // Only this rare branch pays for exact distances.
+            let mut best_clear = f64::NEG_INFINITY;
+            let mut best_inside = false;
+            for (p, inside) in &verdicts {
+                let clear = dist_to_mesh(p, other_mesh);
+                if clear > best_clear {
+                    best_clear = clear;
+                    best_inside = *inside;
                 }
             }
-        }
-        if any_confident {
-            confident_all_inside
-        } else {
             best_inside
         }
     };
@@ -1216,18 +1239,89 @@ pub fn classify_face(
     }
 }
 
-/// Unsigned distance from a point to the closest triangle of a mesh.
-fn dist_to_mesh(p: &Point3, mesh: &TriangleMesh) -> f64 {
-    let verts = &mesh.vertices;
-    let mut best = f64::INFINITY;
-    for tri in mesh.indices.chunks(3) {
-        let v = |i: u32| {
-            let b = i as usize * 3;
-            Point3::new(verts[b] as f64, verts[b + 1] as f64, verts[b + 2] as f64)
+/// Squared distance from `p` to a triangle's axis-aligned bounding box —
+/// a cheap lower bound on the true point-triangle distance, used to skip
+/// the full barycentric computation for triangles that are obviously far.
+fn aabb_dist_sq(p: &Point3, a: &Point3, b: &Point3, c: &Point3) -> f64 {
+    let mut d2 = 0.0;
+    for (pv, av, bv, cv) in [
+        (p.x, a.x, b.x, c.x),
+        (p.y, a.y, b.y, c.y),
+        (p.z, a.z, b.z, c.z),
+    ] {
+        let lo = av.min(bv).min(cv);
+        let hi = av.max(bv).max(cv);
+        let d = if pv < lo {
+            lo - pv
+        } else if pv > hi {
+            pv - hi
+        } else {
+            0.0
         };
-        let d = point_triangle_dist(p, &v(tri[0]), &v(tri[1]), &v(tri[2]));
+        d2 += d * d;
+    }
+    d2
+}
+
+/// Read triangle `tri`'s three corners out of a mesh, promoted to `f64`.
+///
+/// The `f32` → `f64` promotion is deliberate, and matches what
+/// `point_in_mesh` and every other mesh consumer in the kernel does: the
+/// distances computed from these corners decide a 0.1 mm clearance
+/// threshold on millimetre-scale coordinates, which is well inside the
+/// range where `f32` rounding would flip the verdict. Do not "optimize"
+/// this to `f32` arithmetic.
+fn tri_points(mesh: &TriangleMesh, tri: &[u32]) -> (Point3, Point3, Point3) {
+    let v = |i: u32| {
+        let b = i as usize * 3;
+        Point3::new(
+            mesh.vertices[b] as f64,
+            mesh.vertices[b + 1] as f64,
+            mesh.vertices[b + 2] as f64,
+        )
+    };
+    (v(tri[0]), v(tri[1]), v(tri[2]))
+}
+
+/// Is `p` farther than `threshold` from every triangle of `mesh`?
+///
+/// Answers the threshold question without computing the actual minimum:
+/// it returns `false` the instant one triangle is found within
+/// `threshold`. Probes that hug a boundary — the common case when the
+/// classification vote is split — therefore cost a partial scan rather
+/// than a full one, and far-away triangles are rejected by their bounding
+/// box before the barycentric branch chain runs.
+fn clearance_exceeds(p: &Point3, mesh: &TriangleMesh, threshold: f64) -> bool {
+    let thr_sq = threshold * threshold;
+    for tri in mesh.indices.chunks(3) {
+        let (a, b, c) = tri_points(mesh, tri);
+        if aabb_dist_sq(p, &a, &b, &c) >= thr_sq {
+            continue;
+        }
+        if point_triangle_dist(p, &a, &b, &c) < threshold {
+            return false;
+        }
+    }
+    true
+}
+
+/// Unsigned distance from a point to the closest triangle of a mesh.
+///
+/// Only reached when no probe cleared `CONFIDENT_CLEARANCE`, so this full
+/// scan is rare; the bounding-box reject against the running best still
+/// skips the barycentric work for most triangles.
+fn dist_to_mesh(p: &Point3, mesh: &TriangleMesh) -> f64 {
+    let mut best = f64::INFINITY;
+    let mut best_sq = f64::INFINITY;
+    for tri in mesh.indices.chunks(3) {
+        let (a, b, c) = tri_points(mesh, tri);
+        if aabb_dist_sq(p, &a, &b, &c) >= best_sq {
+            continue;
+        }
+        let d = point_triangle_dist(p, &a, &b, &c);
         if d < best {
             best = d;
+            best_sq = d * d;
         }
     }
     best

--- a/crates/vcad-kernel-booleans/src/classify.rs
+++ b/crates/vcad-kernel-booleans/src/classify.rs
@@ -1145,17 +1145,137 @@ pub fn classify_face(
         return c;
     }
 
-    // Test every probe: classify `Inside` only when *every* probe's
-    // interior-side offset lies inside the other solid; any `Outside` probe
-    // implies the face has material on the result's boundary.
+    // Confidence-weighted vote. The old rule was strict unanimity — any
+    // Outside probe forced `Outside` — which keeps genuinely-straddling
+    // faces (a split the pipeline missed) on the result boundary. But it
+    // also turned boundary-hugging slivers into coin flips: sub-faces
+    // produced by a trim split have probes sitting within the other
+    // tessellation's chordal error of the analytic surface, and a single
+    // such ambiguous probe then vetoed an entire correctly-kept sliver
+    // (the torr A1/A2 trim-overshoot family). So: only probes with real
+    // clearance from the other solid's boundary may veto. Among confident
+    // probes the unanimity rule stands (any confident Outside probe wins,
+    // preserving the straddling-face safety); when NO probe is confident
+    // the face lives entirely inside the ambiguity band and the probe with
+    // the most clearance — the least noise-prone verdict — decides.
     let eps = 1e-4;
-    for p in &probes {
-        let inward = *p - eps * oriented_normal;
-        if !point_in_mesh(&inward, other_mesh) {
-            return FaceClassification::Outside;
+    // A probe may veto only when its clearance exceeds every noise source
+    // that puts probes on the wrong side of a boundary they should sit ON:
+    // classification-mesh chordal sag (~4.5e-3 mm at the 256-segment cap),
+    // and split-boundary placement error, whose worst case is the trim
+    // truncation wedge near a tangency (~0.05 mm measured on the torr
+    // doc_10 blades). Genuine straddling faces — a split the pipeline
+    // missed entirely — overhang by much more (0.165 mm in the smallest
+    // observed case, torr's rotating-group bore wall), so 0.1 mm separates
+    // the two regimes with ~2-3x margin on either side.
+    let confident = 0.1;
+    let verdicts: Vec<(Point3, bool)> = probes
+        .iter()
+        .map(|p| {
+            let inward = *p - eps * oriented_normal;
+            (inward, point_in_mesh(&inward, other_mesh))
+        })
+        .collect();
+    // Fast path: unanimous probes need no clearance computation at all —
+    // the confidence weighting only matters when the vote is split, and
+    // `dist_to_mesh` is an O(triangles) scan per probe.
+    let n_inside = verdicts.iter().filter(|(_, i)| *i).count();
+    let inside = if n_inside == verdicts.len() {
+        true
+    } else if n_inside == 0 {
+        false
+    } else {
+        let mut best_clear = f64::NEG_INFINITY;
+        let mut best_inside = false;
+        let mut any_confident = false;
+        let mut confident_all_inside = true;
+        for (inward, inside) in &verdicts {
+            let clear = dist_to_mesh(inward, other_mesh);
+            if clear > best_clear {
+                best_clear = clear;
+                best_inside = *inside;
+            }
+            if clear > confident {
+                any_confident = true;
+                if !inside {
+                    confident_all_inside = false;
+                }
+            }
+        }
+        if any_confident {
+            confident_all_inside
+        } else {
+            best_inside
+        }
+    };
+
+    if inside {
+        FaceClassification::Inside
+    } else {
+        FaceClassification::Outside
+    }
+}
+
+/// Unsigned distance from a point to the closest triangle of a mesh.
+fn dist_to_mesh(p: &Point3, mesh: &TriangleMesh) -> f64 {
+    let verts = &mesh.vertices;
+    let mut best = f64::INFINITY;
+    for tri in mesh.indices.chunks(3) {
+        let v = |i: u32| {
+            let b = i as usize * 3;
+            Point3::new(verts[b] as f64, verts[b + 1] as f64, verts[b + 2] as f64)
+        };
+        let d = point_triangle_dist(p, &v(tri[0]), &v(tri[1]), &v(tri[2]));
+        if d < best {
+            best = d;
         }
     }
-    FaceClassification::Inside
+    best
+}
+
+/// Unsigned distance from point `p` to triangle `abc`.
+fn point_triangle_dist(p: &Point3, a: &Point3, b: &Point3, c: &Point3) -> f64 {
+    // Project onto the triangle plane and clamp to the triangle via
+    // barycentric regions (Ericson, Real-Time Collision Detection).
+    let ab = *b - *a;
+    let ac = *c - *a;
+    let ap = *p - *a;
+    let d1 = ab.dot(ap);
+    let d2 = ac.dot(ap);
+    if d1 <= 0.0 && d2 <= 0.0 {
+        return ap.norm();
+    }
+    let bp = *p - *b;
+    let d3 = ab.dot(bp);
+    let d4 = ac.dot(bp);
+    if d3 >= 0.0 && d4 <= d3 {
+        return bp.norm();
+    }
+    let vc = d1 * d4 - d3 * d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {
+        let t = d1 / (d1 - d3);
+        return (ap - t * ab).norm();
+    }
+    let cp = *p - *c;
+    let d5 = ab.dot(cp);
+    let d6 = ac.dot(cp);
+    if d6 >= 0.0 && d5 <= d6 {
+        return cp.norm();
+    }
+    let vb = d5 * d2 - d1 * d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {
+        let t = d2 / (d2 - d6);
+        return (ap - t * ac).norm();
+    }
+    let va = d3 * d6 - d5 * d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {
+        let t = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return (bp - t * (*c - *b)).norm();
+    }
+    let denom = 1.0 / (va + vb + vc);
+    let v = vb * denom;
+    let w = vc * denom;
+    (ap - (v * ab + w * ac)).norm()
 }
 
 /// Classify all faces of a solid relative to another solid.

--- a/crates/vcad-kernel-booleans/src/pipeline.rs
+++ b/crates/vcad-kernel-booleans/src/pipeline.rs
@@ -39,6 +39,23 @@ macro_rules! debug_bool {
     ($($arg:tt)*) => {};
 }
 
+/// Largest curved-surface radius in a solid's geometry (0.0 when the solid
+/// is all-planar). Drives the classification tessellation density.
+fn max_curved_radius(brep: &BRepSolid) -> f64 {
+    let mut r = 0.0f64;
+    for s in &brep.geometry.surfaces {
+        let any = s.as_any();
+        if let Some(c) = any.downcast_ref::<vcad_kernel_geom::CylinderSurface>() {
+            r = r.max(c.radius.abs());
+        } else if let Some(sp) = any.downcast_ref::<vcad_kernel_geom::SphereSurface>() {
+            r = r.max(sp.radius.abs());
+        } else if let Some(t) = any.downcast_ref::<vcad_kernel_geom::TorusSurface>() {
+            r = r.max(t.major_radius.abs() + t.minor_radius.abs());
+        }
+    }
+    r
+}
+
 /// Handle boolean operations on non-overlapping solids.
 pub(crate) fn non_overlapping_boolean(
     solid_a: &BRepSolid,
@@ -574,12 +591,84 @@ pub(crate) fn brep_boolean(
                     }
                     false
                 };
+                // Exact third chance: the circle properly CROSSES the planar
+                // face's boundary and carries a real interior arc. The seated
+                // probes above sample only 8 angles, so a genuine narrow
+                // crossing (a thin blade face crossing a big wall circle over
+                // ~1° of arc — torr A2's r30 trim) falls between probes and
+                // the wall never gets its circle split. Solving each boundary
+                // edge against the circle is exact for any arc width, and the
+                // interior-midpoint test still rejects the phantom graze
+                // regime the anchor gate exists for.
+                let crosses = |solid: &vcad_kernel_primitives::BRepSolid, fid: FaceId| -> bool {
+                    let verts: Vec<Point3> = solid
+                        .topology
+                        .loop_half_edges(solid.topology.faces[fid].outer_loop)
+                        .map(|he| {
+                            solid.topology.vertices[solid.topology.half_edges[he].origin].point
+                        })
+                        .collect();
+                    if verts.len() < 3 {
+                        return false;
+                    }
+                    let xd = circle.x_dir.into_inner();
+                    let yd = circle.y_dir.into_inner();
+                    let nd = circle.normal.into_inner();
+                    let mut angles: Vec<f64> = Vec::new();
+                    for i in 0..verts.len() {
+                        let p1 = verts[i] - circle.center;
+                        let p2 = verts[(i + 1) % verts.len()] - circle.center;
+                        // The face must be coplanar with the circle's plane.
+                        if p1.dot(nd).abs() > 1e-6 || p2.dot(nd).abs() > 1e-6 {
+                            return false;
+                        }
+                        let (x1, y1) = (p1.dot(xd), p1.dot(yd));
+                        let (x2, y2) = (p2.dot(xd), p2.dot(yd));
+                        let (dx, dy) = (x2 - x1, y2 - y1);
+                        let aa = dx * dx + dy * dy;
+                        if aa < 1e-18 {
+                            continue;
+                        }
+                        let bb = 2.0 * (x1 * dx + y1 * dy);
+                        let cc = x1 * x1 + y1 * y1 - circle.radius * circle.radius;
+                        let disc = bb * bb - 4.0 * aa * cc;
+                        if disc <= 0.0 {
+                            continue;
+                        }
+                        let sq = disc.sqrt();
+                        for t in [(-bb - sq) / (2.0 * aa), (-bb + sq) / (2.0 * aa)] {
+                            if (0.0..1.0).contains(&t) {
+                                angles.push((y1 + t * dy).atan2(x1 + t * dx));
+                            }
+                        }
+                    }
+                    if angles.len() < 2 {
+                        return false;
+                    }
+                    angles.sort_by(|p, q| p.partial_cmp(q).unwrap_or(std::cmp::Ordering::Equal));
+                    for i in 0..angles.len() {
+                        let (t0, t1) = (angles[i], angles[(i + 1) % angles.len()]);
+                        let mid = if i + 1 == angles.len() {
+                            // wrap arc
+                            0.5 * (t0 + t1 + 2.0 * std::f64::consts::PI)
+                        } else {
+                            0.5 * (t0 + t1)
+                        };
+                        let p = circle.center + circle.radius * (mid.cos() * xd + mid.sin() * yd);
+                        if trim::point_in_face(solid, fid, &p) {
+                            return true;
+                        }
+                    }
+                    false
+                };
                 let b_anchors_circle = !split::is_planar_face(&b, face_b)
                     || trim::point_in_face(&b, face_b, &circle.center)
-                    || seated(&b, face_b);
+                    || seated(&b, face_b)
+                    || crosses(&b, face_b);
                 let a_anchors_circle = !split::is_planar_face(&a, face_a)
                     || trim::point_in_face(&a, face_a, &circle.center)
-                    || seated(&a, face_a);
+                    || seated(&a, face_a)
+                    || crosses(&a, face_a);
 
                 // A circle that is already part of the planar face's sampled
                 // boundary (the cap of an arc-extruded body paired with the
@@ -868,9 +957,30 @@ pub(crate) fn brep_boolean(
     debug_bool!("Solid A has {} faces after splits", a.topology.faces.len());
     debug_bool!("Solid B has {} faces after splits", b.topology.faces.len());
 
-    // Tessellate each solid once and reuse for classification
-    let mesh_b = tessellate_brep(&b, segments);
-    let mesh_a = tessellate_brep(&a, segments);
+    // Tessellate each solid once and reuse for classification. Classification
+    // probes sit ~1e-4 off split boundaries that were placed on the ANALYTIC
+    // surfaces, so the point-in-mesh oracle needs far less chordal error than
+    // the display tessellation: at 64 segments a 45mm cylinder's mesh is
+    // ~0.05mm inside the true surface and boundary-adjacent slivers flip
+    // classification (torr A1/A2 trim overshoot). The count must be FLAT
+    // (one number for walls and caps alike — per-radius adaptivity leaves
+    // 64-gon caps butted against 256-gon walls and the classification mesh
+    // cracks along the shared circles), so pick it per boolean from the
+    // largest curved radius across both operands: a 45mm part classifies at
+    // the 256 cap (~4e-3mm sag) while a fillet-scale solid stays cheap.
+    let cls_segments = {
+        let max_r = max_curved_radius(&a).max(max_curved_radius(&b));
+        const SAG: f64 = 1.5e-3;
+        let needed = if max_r > SAG {
+            let arg = (1.0 - SAG / max_r).clamp(-1.0, 1.0);
+            (std::f64::consts::PI / arg.acos()).ceil() as u32
+        } else {
+            0
+        };
+        needed.min(256).max(segments)
+    };
+    let mesh_b = tessellate_brep(&b, cls_segments);
+    let mesh_a = tessellate_brep(&a, cls_segments);
     let classes_a = classify::classify_all_faces_with_mesh(&a, &b, &mesh_b);
     let classes_b = classify::classify_all_faces_with_mesh(&b, &a, &mesh_a);
 

--- a/crates/vcad-kernel-booleans/src/pipeline.rs
+++ b/crates/vcad-kernel-booleans/src/pipeline.rs
@@ -39,6 +39,16 @@ macro_rules! debug_bool {
     ($($arg:tt)*) => {};
 }
 
+/// Shortest interior arc (mm) that counts as a circle genuinely CROSSING a
+/// planar face rather than grazing it.
+///
+/// Sits three orders of magnitude above the sewing merge tolerance (1e-6),
+/// so an accepted crossing can never collapse to a degenerate face, and
+/// well below the smallest real crossing measured in the corpus (a 0.5mm
+/// arc where a torr blade crosses the r30 trim circle; the tangency graze
+/// it has to reject is 4e-7mm).
+const MIN_CROSSING_ARC: f64 = 1e-3;
+
 /// Largest curved-surface radius in a solid's geometry (0.0 when the solid
 /// is all-planar). Drives the classification tessellation density.
 fn max_curved_radius(brep: &BRepSolid) -> f64 {
@@ -654,6 +664,24 @@ pub(crate) fn brep_boolean(
                         } else {
                             0.5 * (t0 + t1)
                         };
+                        // The arc must be long enough to be real geometry, not
+                        // a touch. A circle that grazes a face at a single
+                        // point (a solid tangent to another's edge) produces
+                        // two crossings a hair apart, and splitting on it
+                        // emits a degenerate face — this is exactly the
+                        // phantom regime the anchor gate exists for, and the
+                        // `seated()` probe above rejects it by construction.
+                        // Measure it as arc LENGTH, not angle: the same
+                        // physical crossing subtends 23 degrees on an r=5
+                        // circle and under 1 degree on an r=30 one.
+                        let span = if i + 1 == angles.len() {
+                            t1 + 2.0 * std::f64::consts::PI - t0
+                        } else {
+                            t1 - t0
+                        };
+                        if span * circle.radius <= MIN_CROSSING_ARC {
+                            continue;
+                        }
                         let p = circle.center + circle.radius * (mid.cos() * xd + mid.sin() * yd);
                         if trim::point_in_face(solid, fid, &p) {
                             return true;

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -3060,7 +3060,47 @@ pub fn split_cylindrical_face(
                         sub_faces: vec![face_id],
                     });
             }
-            let result = split_cylindrical_face_by_circle(brep, face_id, circle);
+            // The legacy splitter reconstructs its sub-faces as degenerate
+            // seam loops spanning the FULL circumference — correct only when
+            // the input face is itself a full tube. A u-sector rectangle
+            // (from earlier axis-parallel line splits) routed through it
+            // would balloon into two overlapping full tubes. Gate it to
+            // loops whose vertices all sit on one seam angle.
+            let is_seam_loop = {
+                let face = &brep.topology.faces[face_id];
+                if let Some(cyl) = brep.geometry.surfaces[face.surface_index]
+                    .as_any()
+                    .downcast_ref::<vcad_kernel_geom::CylinderSurface>()
+                {
+                    let mut u0: Option<f64> = None;
+                    brep.topology.loop_half_edges(face.outer_loop).all(|he| {
+                        let p = brep.topology.vertices[brep.topology.half_edges[he].origin].point;
+                        let u = compute_cylinder_u(&p, cyl);
+                        match u0 {
+                            None => {
+                                u0 = Some(u);
+                                true
+                            }
+                            Some(base) => {
+                                let mut d = (u - base).rem_euclid(2.0 * std::f64::consts::PI);
+                                if d > std::f64::consts::PI {
+                                    d = 2.0 * std::f64::consts::PI - d;
+                                }
+                                d < 1e-6
+                            }
+                        }
+                    })
+                } else {
+                    false
+                }
+            };
+            let result = if is_seam_loop {
+                split_cylindrical_face_by_circle(brep, face_id, circle)
+            } else {
+                SplitResult {
+                    sub_faces: vec![face_id],
+                }
+            };
             if result.sub_faces.len() >= 2 {
                 return result;
             }

--- a/crates/vcad-kernel-booleans/src/ssi.rs
+++ b/crates/vcad-kernel-booleans/src/ssi.rs
@@ -310,6 +310,20 @@ fn plane_sphere(plane: &Plane, sphere: &SphereSurface) -> IntersectionCurve {
 // Plane-Cylinder intersection
 // =============================================================================
 
+/// Sample count for a sampled ellipse (oblique plane × cylinder) so the
+/// polyline's chordal sag stays under ~1e-3 mm on the cylinder of radius
+/// `r`. `n = π / acos(1 − sag/r)`, clamped to [64, 512].
+fn ellipse_samples(r: f64) -> usize {
+    const SAG: f64 = 1e-3;
+    let n = if r > SAG {
+        let arg = (1.0 - SAG / r).clamp(-1.0, 1.0);
+        (std::f64::consts::PI / arg.acos()).ceil() as usize
+    } else {
+        64
+    };
+    n.clamp(64, 512)
+}
+
 /// Intersection of a plane and a cylinder.
 ///
 /// Three cases:
@@ -420,9 +434,13 @@ fn plane_cylinder(plane: &Plane, cyl: &CylinderSurface) -> IntersectionCurve {
             normal: Dir3::new_normalize(circle_normal),
         })
     } else {
-        // General case — ellipse
-        // Sample the intersection curve
-        let n_samples = 64;
+        // General case — ellipse. Sample densely enough that the polyline's
+        // chordal sag stays below classification/probe tolerances: with a
+        // fixed 64 samples a 45mm-radius ellipse deviates ~0.07mm from the
+        // true curve, which places trim boundaries visibly inside the real
+        // intersection (the torr A1/A2 trim-overshoot family). Target the
+        // same sag the splitter's `arc_segments` uses.
+        let n_samples = ellipse_samples(cyl.radius);
         let mut points = Vec::with_capacity(n_samples);
 
         for i in 0..n_samples {

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -5028,6 +5028,15 @@ pub fn tessellate(brep: &BRepSolid, segments: u32) -> TriangleMesh {
 /// This is the primary tessellation function used by the facade crate.
 pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
     let params = TessellationParams::from_segments(segments);
+    tessellate_brep_with_params(brep, &params)
+}
+
+/// `tessellate_brep` with explicit [`TessellationParams`] — for callers that
+/// need sag-driven adaptive resolution (e.g. boolean classification meshes,
+/// which must track the analytic surfaces far more tightly than the display
+/// tessellation without paying flat-high segment counts on small radii).
+pub fn tessellate_brep_with_params(brep: &BRepSolid, params: &TessellationParams) -> TriangleMesh {
+    let params = *params;
     let solid = &brep.topology.solids[brep.solid_id];
     let shell = &brep.topology.shells[solid.outer_shell];
 


### PR DESCRIPTION
Closes the trim-overshoot family of boolean defects: the three `#[ignore]`d cases in `crates/vcad-eval/tests/torr_boolean_catalogue.rs` now pass and lose their ignores.

| Test | Before | Now |
|---|---|---|
| `a1_pattern_child_boolean_sliver` | 3329.8 vs 3365.4 (−1.1%) | passes |
| `a2_boolean_over_pattern_doc10` | 3171.7 vs 3365.4 (−5.8%) | passes |
| `a2_boolean_over_pattern_gross` | 444.5 vs 427.3 (+4.0%) | passes |

## What was wrong

Trimming a part against a cylindrical boundary (pattern blades cut to a radius, an annulus tool clipping a blade) placed the trim boundary off the true intersection, and then classified the resulting slivers unreliably. Four distinct causes, all needed together — each alone left one or more cases failing:

**Sampled ellipses were too coarse.** `plane × cylinder` at an oblique angle returns a sampled polyline, fixed at 64 points. At r45 that is ~0.07 mm of chordal sag, so every trim boundary derived from it sat visibly inside the real curve. Now sag-adaptive (target 1e-3 mm, clamped 64..512).

**The classification mesh was the display mesh.** Classification probes sit 1e-4 off boundaries placed on the *analytic* surfaces, but were tested against a 64-segment tessellation that runs ~0.05 mm inside the true surface at r45 — enough to flip any boundary-adjacent sliver. Classification now tessellates at a sag-driven count derived from the largest curved radius across both operands, capped at 256. The count is deliberately **flat** across walls and caps: per-radius adaptivity leaves 64-gon caps butted against 256-gon walls and the classification mesh cracks along the shared circles (this was tried, and `a2_boolean_over_pattern_doc10` failed reproducibly 5/5 until it was replaced).

**The probe vote was strict unanimity.** Any `Outside` probe forced `Outside`, so one probe sitting inside the tessellation's ambiguity band vetoed an entire correctly-kept sliver. Now only probes with real clearance may veto. The 0.1 mm threshold is measured, not guessed: trim-wedge noise near a tangency reaches ~0.05 mm (torr doc_10 blades), while a genuinely straddling face — a split the pipeline missed — overhangs by 0.165 mm in the smallest observed case (torr's rotating-group bore wall). Unanimity still governs among confident probes, preserving the straddling-face safety; the farthest-clearance probe decides only when no probe is confident. Clearances are computed lazily, so unanimous faces skip the O(triangles) distance scan entirely.

**Two splitter bugs.** The circle-anchor gate's `seated()` test samples 8 angles, so a thin blade face crossing a large wall circle over ~1° of arc fell between probes and the wall never got its circle split — added an exact edge-vs-circle crossing test (quadratic per boundary edge + interior-arc midpoint in-face). Separately, the legacy `split_cylindrical_face_by_circle` rebuilds its sub-faces as degenerate seam loops spanning the *full* circumference, correct only for a full tube; a u-sector rectangle routed through it ballooned into two overlapping tubes. It is now gated to seam-loop faces, with the band machinery handling the rest.

## Reviewer notes

- The classification-mesh resolution change is the one with the widest blast radius — it affects every boolean, not just trimming ones. `control_rotating_group_volume` in `torr_phantom_intersection` is the test that guards the straddling-face behavior the unanimity rule used to provide; it is green and was used to calibrate the 0.1 mm threshold.
- `tessellate_brep_with_params` is added to `vcad-kernel-tessellate` as a public entry point. It is not used by the final version of this change (the flat-count approach won), but it is a reasonable API to have and the refactor leaves `tessellate_brep` as a thin wrapper. Say the word if you would rather it come out.
- Distinct root cause from the seam-crack family (`f1_*`/`f2_*`, analytic-vs-frozen conformity) — those 6 ignores are untouched and still ignored.
- No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts touched.

## Verification

- `torr_boolean_catalogue`: 26 passed, 0 failed, 6 pre-existing ignores — run twice for stability
- `cargo test -p vcad-kernel-booleans`: all green (91 lib + 7 integration suites)
- All other `vcad-eval` suites green: `torr_phantom_intersection`, `loon_boolean_composition`, `mirror_symmetry`, `assembly_symmetry`, `clash_broadphase`, `document_gradient`, lib (33)
- `cargo test -p vcad-kernel --lib`: 68 passed
- `cargo clippy --workspace --exclude vcad-desktop -- -D warnings`: clean
- `cargo fmt --all --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)