### PR TITLE
Mesh-based URDF robots render and export correctly (Booster K1 import)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7192,6 +7192,7 @@ version = "0.9.4"
 dependencies = [
  "serde",
  "serde_json",
+ "stl_io",
  "thiserror 2.0.18",
  "vcad-ecad-pcb",
  "vcad-ir",

--- a/changelog/entries/2026-07-30-urdf-mesh-robots-render.json
+++ b/changelog/entries/2026-07-30-urdf-mesh-robots-render.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-07-30-urdf-mesh-robots-render",
+  "version": "0.9.4",
+  "date": "2026-07-30",
+  "category": "fix",
+  "title": "Mesh-based URDF robots render and export correctly",
+  "summary": "URDF imports with STL meshes (Booster K1, Unitree G1) now render FK-placed instead of vanishing or piling at the origin; whitespace-padded URDF numbers parse.",
+  "features": ["urdf", "render", "assembly"]
+}

--- a/crates/vcad-app/src/registry.rs
+++ b/crates/vcad-app/src/registry.rs
@@ -169,7 +169,7 @@ impl KeybindingRegistry {
         .to_string()
     }
 
-    /// Load overrides previously saved with [`save_overrides`]. Unknown
+    /// Load overrides previously saved with [`Self::save_overrides`]. Unknown
     /// command ids and malformed chords are skipped — the caller shouldn't
     /// crash on a stale config file.
     pub fn load_overrides(&mut self, json: &str) -> Result<(), LoadError> {

--- a/crates/vcad-chat/src/lib.rs
+++ b/crates/vcad-chat/src/lib.rs
@@ -11,7 +11,7 @@
 //! - [`stream`]   — HTTP client + NDJSON stream parser
 //! - [`executor`] — `execute_crud`, port of `executeCrud`
 //! - [`auth`]     — token storage and refresh
-//! - [`state`]    — [`ChatSession`] and [`Message`] types
+//! - `state`    — `ChatSession` and `Message` types
 //!
 //! The TS reference lives in `packages/core/src/commands/registry.ts`,
 //! `packages/app/src/lib/chat-api.ts`, and `api/chat.ts`.

--- a/crates/vcad-design-constraints/src/lib.rs
+++ b/crates/vcad-design-constraints/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Lowers [`vcad_ir::constraints::DesignConstraint`]s — spanning PCB layout
 //! (footprints, board outline), sketches, and mechanical part anchors — into
-//! per-plane [`Sketch2D`] systems solved by the Levenberg-Marquardt solver in
+//! per-plane `Sketch2D` systems solved by the Levenberg-Marquardt solver in
 //! `vcad-kernel-constraints`, then writes the solved geometry back into the
 //! document.
 //!

--- a/crates/vcad-ecad-diff/src/codesign.rs
+++ b/crates/vcad-ecad-diff/src/codesign.rs
@@ -55,7 +55,7 @@ const MAGNET: AirGapSpec = AirGapSpec {
     teeth: None,
 };
 
-/// Air-gap flux density (T) used as the plant constant, computed from [`MAGNET`]
+/// Air-gap flux density (T) used as the plant constant, computed from `MAGNET`
 /// by the first-order reluctance-network model in `vcad_ecad_sim::airgap`.
 ///
 /// The flux is a *constant* with respect to the design variables (`outer_r`,

--- a/crates/vcad-ecad-package/src/lib.rs
+++ b/crates/vcad-ecad-package/src/lib.rs
@@ -1,7 +1,7 @@
 //! Parametric IPC-7351 package generator for vcad.
 //!
 //! A [`vcad_ir::ecad::PackageClass`] is the single source of truth for an
-//! electronic part's *physical* package. [`derive`] turns it — in one pass —
+//! electronic part's *physical* package. [`derive()`] turns it — in one pass —
 //! into a PCB land pattern, a schematic symbol, and a real 3D body, all sharing
 //! one pin numbering so they cannot disagree. This is the "generate, don't
 //! aggregate" core: standard packages get infinite coverage from parametric

--- a/crates/vcad-ecad-pcb/src/drc.rs
+++ b/crates/vcad-ecad-pcb/src/drc.rs
@@ -2644,7 +2644,7 @@ pub(crate) fn spur_copper_mask(pcb: &Pcb) -> (Vec<bool>, Vec<bool>) {
     (keep_trace, keep_via)
 }
 
-/// Remove spur copper board-wide — see [`spur_copper_mask`]. Returns
+/// Remove spur copper board-wide — see `spur_copper_mask`. Returns
 /// `(traces_removed, vias_removed)`.
 pub fn prune_spur_copper(pcb: &mut Pcb) -> (usize, usize) {
     let (keep_trace, keep_via) = spur_copper_mask(pcb);

--- a/crates/vcad-ecad-pcb/src/router/classes.rs
+++ b/crates/vcad-ecad-pcb/src/router/classes.rs
@@ -7,7 +7,7 @@
 //! *names*. This module recovers that intent:
 //!
 //! * [`classify_nets`] scans net names and produces a [`NetClassifier`]:
-//!   pair membership (via [`super::pair::pair_partner`] plus the USB
+//!   pair membership (via `pair_partner` plus the USB
 //!   `DP`/`DM` convention) and length-match groups (LPDDR4 CA/DQ buses per
 //!   channel, RGMII, and every pair intra-matched).
 //! * [`apply_classes`] realizes the classification as IR design rules — a

--- a/crates/vcad-ecad-pcb/src/router/mod.rs
+++ b/crates/vcad-ecad-pcb/src/router/mod.rs
@@ -583,7 +583,7 @@ fn meander_pair_skew(pcb: &mut Pcb, tolerance: f64) -> (usize, usize) {
 ///    to be re-routed before descending it is worth anything.
 /// 2. [`descend_board`] then drives residual intra-pair skew out of the
 ///    geometry that is already close.
-/// 3. [`meander_pair_skew`] meanders whatever skew survives — the breakout
+/// 3. `meander_pair_skew` meanders whatever skew survives — the breakout
 ///    mismatch descent structurally cannot reach.
 ///
 /// Every stage is strictly non-regressive and gated on the exact oracle: a

--- a/crates/vcad-ecad-pcb/src/router/si_claims.rs
+++ b/crates/vcad-ecad-pcb/src/router/si_claims.rs
@@ -3,7 +3,7 @@
 //! Measures the routed copper itself (no simulation): per-group length skew,
 //! intra-pair skew, differential coupled-length fraction, and SI-net via
 //! counts, each judged against explicit bounds. These are `basis: "verified"`
-//! claims in the [`vcad-receipt`] sense — the oracle (geometric measurement
+//! claims in the `vcad-receipt` sense — the oracle (geometric measurement
 //! over the actual board copper) ran for real. What they do NOT claim is
 //! spelled out per-claim: no impedance verification (analytic tables are
 //! `predicted`, emitted separately), no crosstalk, no eye simulation.
@@ -184,7 +184,7 @@ fn leg_copper_is_starved(pcb: &Pcb, net: &str) -> bool {
 /// Note the asymmetry, which matters when reading a high value: the denominator
 /// is P's own length, so a short P beside a long N scores near 1.0. Callers that
 /// need "these two legs run together" must also check the legs are comparable in
-/// length — [`si_claims`] gates on [`leg_copper_is_starved`] first for exactly
+/// length — [`si_claims`] gates on `leg_copper_is_starved` first for exactly
 /// this reason.
 ///
 /// Exposed as `router::pair_coupled_fraction` so reports can name the pairs
@@ -565,7 +565,7 @@ mod tests {
 }
 
 /// Bridge into the unified `vcad.receipt/1` schema: every SI claim becomes a
-/// [`ReceiptClaim`] with `basis: Measured` — the geometric oracle ran over
+/// `ReceiptClaim` with `basis: Measured` — the geometric oracle ran over
 /// the actual board copper — under the [`RECEIPT_DOMAIN`] domain. Broken
 /// bounds are `Fail` claims, not omissions: the receipt is fail-closed.
 pub fn to_receipt_claims(set: &SiClaimSet) -> Vec<vcad_receipt::ReceiptClaim> {

--- a/crates/vcad-ecad-pcb/src/session.rs
+++ b/crates/vcad-ecad-pcb/src/session.rs
@@ -8,7 +8,7 @@
 //!
 //! [`RouteSession`] wraps the same R-tree broadphase and the same exact
 //! [`CopperGeom::distance_to`] narrowphase the DRC clearance pass uses, plus the
-//! same [`NetTieGroups`] exemptions, behind three operations:
+//! same `NetTieGroups` exemptions, behind three operations:
 //!
 //! - [`RouteSession::probe`] — test a candidate geometry against existing copper
 //!   without mutating anything (the avoidance constraint).

--- a/crates/vcad-ecad-sim/src/circuit/ac.rs
+++ b/crates/vcad-ecad-sim/src/circuit/ac.rs
@@ -14,7 +14,7 @@
 //!
 //! Complex arithmetic is hand-rolled as an `(re, im)` pair — no external
 //! dependency, and the dense complex LU is a line-for-line sibling of the
-//! real one in [`super::linalg`].
+//! real one in `linalg`.
 
 use super::dc::{operating_point, DcError, DcSolution};
 use super::devices::VT;

--- a/crates/vcad-ecad-sim/src/circuit/transient_adjoint.rs
+++ b/crates/vcad-ecad-sim/src/circuit/transient_adjoint.rs
@@ -4,7 +4,7 @@
 //! This extends the transposed-network method (Director & Rohrer, "The
 //! generalized adjoint network and network sensitivities", IEEE Trans.
 //! Circuit Theory CT-16, 1969) from a single solve to the whole transient:
-//! the discrete adjoint of exactly the time-stepping scheme [`CircuitEnv`]
+//! the discrete adjoint of exactly the time-stepping scheme `CircuitEnv`
 //! runs, so the gradient is exact to machine precision **for the trajectory
 //! as discretized** — the standard discrete-adjoint (backpropagation-through-
 //! the-solver) framing, the same contract the particle crate's adjoint keeps.
@@ -54,7 +54,7 @@
 //!
 //! The forward pass here is the adjoint's own (linear devices only, one
 //! LU per step, first step always backward Euler exactly like
-//! [`CircuitEnv::step`]), storing the full trajectory `x_1..x_N`. Storage is
+//! `CircuitEnv::step`), storing the full trajectory `x_1..x_N`. Storage is
 //! O(N·m) — fine at lumped-circuit scale; checkpointing is a scale problem
 //! this module does not have.
 //!
@@ -138,7 +138,7 @@ struct History {
 /// dJ/d(every device primary) of the weighted least-squares tracking
 /// objective `J = Σ_k w_k·(v_out(t_k) − target_k)²` over an `N`-step
 /// transient from the power-on state (`t_k = k·dt`, k = 1..N — the same
-/// trajectory [`CircuitEnv`] produces with the same `dt` and integrator).
+/// trajectory `CircuitEnv` produces with the same `dt` and integrator).
 ///
 /// Linear devices only (R, L, C, V, I) at this milestone; see
 /// [`TransientAdjointError::Unsupported`].

--- a/crates/vcad-ecad-symbols/src/kicad_pcb.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_pcb.rs
@@ -1,7 +1,7 @@
 //! Parser for KiCad `.kicad_pcb` board files.
 //!
 //! Converts a `.kicad_pcb` S-expression file into a [`vcad_ir::ecad::Pcb`]
-//! struct.  Reuses the [`crate::sexpr`] S-expression parser.
+//! struct.  Reuses the `sexpr` S-expression parser.
 
 use std::collections::HashMap;
 

--- a/crates/vcad-ecad-symbols/src/kicad_sch.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_sch.rs
@@ -2,7 +2,7 @@
 //!
 //! Converts a `.kicad_sch` S-expression file (KiCad 9 format, `version
 //! 20250114` — the format [`crate::kicad_write::write_kicad_sch`] emits) into a
-//! [`vcad_ir::ecad::SchematicSheet`].  Reuses the [`crate::sexpr`]
+//! [`vcad_ir::ecad::SchematicSheet`].  Reuses the `sexpr`
 //! S-expression parser and, like [`crate::kicad_pcb`], tolerates unknown
 //! tokens by skipping them.
 //!

--- a/crates/vcad-ecad-symbols/src/kicad_write.rs
+++ b/crates/vcad-ecad-symbols/src/kicad_write.rs
@@ -917,7 +917,7 @@ fn arc_points(center: Vec2, radius: f64, start_deg: f64, end_deg: f64) -> (Vec2,
 /// point rather than a pixel-match of KiCad's built-in symbol artwork.
 ///
 /// Recognizable part classes (resistors, capacitors, diodes/LEDs,
-/// inductors, transistors — see [`symbol_artwork`]) get real schematic
+/// inductors, transistors — see `symbol_artwork`) get real schematic
 /// artwork; anything else keeps the generic rectangular body.
 ///
 /// When the stored component positions are degenerate (all at one point, or

--- a/crates/vcad-eval/Cargo.toml
+++ b/crates/vcad-eval/Cargo.toml
@@ -22,6 +22,9 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+stl_io = "0.8"
+
 [dev-dependencies]
 vcad-loon.workspace = true
 vcad-kernel-fillet.workspace = true

--- a/crates/vcad-eval/src/diff.rs
+++ b/crates/vcad-eval/src/diff.rs
@@ -10,7 +10,7 @@
 //! 1. A **named document parameter** (the `parameters` + `bindings` sidecar
 //!    the product's parametric documents already carry) is the θ.
 //! 2. The **build closure** clones the document, overwrites the parameter's
-//!    value, and runs [`evaluate_document`](crate::evaluate_document) — the
+//!    value, and runs [`evaluate_document`] — the
 //!    same resolve-and-walk every other consumer uses.
 //! 3. **Seeding synthesis** (M6) machine-derives how θ moves every surface;
 //!    the frozen-plan seam prices the mass-property derivatives exactly.

--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -1381,6 +1381,24 @@ fn find_imported_mesh(
                     scale,
                 });
             }
+            // Native only: a CLI-imported URDF references its STLs by
+            // absolute path (`MeshImport`). Load from disk here so render /
+            // export / info see real geometry; on wasm the browser flow has
+            // already rewritten these nodes to `ImportedMesh`, so this arm
+            // never fires there.
+            #[cfg(not(target_arch = "wasm32"))]
+            CsgOp::MeshImport { path, scale: urdf_scale } => {
+                let (positions, indices, normals) =
+                    load_mesh_import(path, urdf_scale.as_ref())?;
+                return Some(ImportedMeshData {
+                    positions,
+                    indices,
+                    normals,
+                    translate,
+                    rotate_deg,
+                    scale,
+                });
+            }
             CsgOp::Translate { child, offset } => {
                 translate = [offset.x, offset.y, offset.z];
                 current = *child;
@@ -1396,6 +1414,55 @@ fn find_imported_mesh(
             _ => return None,
         }
     }
+}
+
+/// Raw mesh buffers loaded from a `MeshImport` STL: positions, indices,
+/// optional per-vertex normals.
+#[cfg(not(target_arch = "wasm32"))]
+type LoadedMeshBuffers = (Vec<f64>, Vec<u32>, Option<Vec<f64>>);
+
+/// Load an STL referenced by a `MeshImport` node, converting URDF metres to
+/// millimetres and applying the URDF `<mesh scale>`. Returns `None` (logged
+/// to stderr) when the file is missing or unparseable so callers fall back
+/// to the no-geometry path rather than erroring the whole document.
+#[cfg(not(target_arch = "wasm32"))]
+fn load_mesh_import(
+    path: &str,
+    urdf_scale: Option<&vcad_ir::Vec3>,
+) -> Option<LoadedMeshBuffers> {
+    let file = std::fs::File::open(path)
+        .map_err(|e| eprintln!("MeshImport: cannot open {path}: {e}"))
+        .ok()?;
+    let mut reader = std::io::BufReader::new(file);
+    let stl = stl_io::read_stl(&mut reader)
+        .map_err(|e| eprintln!("MeshImport: cannot parse {path}: {e}"))
+        .ok()?;
+
+    let m_to_mm = 1000.0_f64;
+    let sx = urdf_scale.map(|s| s.x).unwrap_or(1.0) * m_to_mm;
+    let sy = urdf_scale.map(|s| s.y).unwrap_or(1.0) * m_to_mm;
+    let sz = urdf_scale.map(|s| s.z).unwrap_or(1.0) * m_to_mm;
+
+    let mut positions = Vec::with_capacity(stl.vertices.len() * 3);
+    for v in &stl.vertices {
+        positions.push(v[0] as f64 * sx);
+        positions.push(v[1] as f64 * sy);
+        positions.push(v[2] as f64 * sz);
+    }
+
+    let mut indices = Vec::with_capacity(stl.faces.len() * 3);
+    let mut normals = vec![0.0_f64; stl.vertices.len() * 3];
+    for tri in &stl.faces {
+        let [a, b, c] = tri.vertices;
+        indices.extend([a as u32, b as u32, c as u32]);
+        for &vi in &tri.vertices {
+            normals[vi * 3] = tri.normal[0] as f64;
+            normals[vi * 3 + 1] = tri.normal[1] as f64;
+            normals[vi * 3 + 2] = tri.normal[2] as f64;
+        }
+    }
+
+    Some((positions, indices, Some(normals)))
 }
 
 /// Apply transform to imported mesh positions and normals.

--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -1387,9 +1387,11 @@ fn find_imported_mesh(
             // already rewritten these nodes to `ImportedMesh`, so this arm
             // never fires there.
             #[cfg(not(target_arch = "wasm32"))]
-            CsgOp::MeshImport { path, scale: urdf_scale } => {
-                let (positions, indices, normals) =
-                    load_mesh_import(path, urdf_scale.as_ref())?;
+            CsgOp::MeshImport {
+                path,
+                scale: urdf_scale,
+            } => {
+                let (positions, indices, normals) = load_mesh_import(path, urdf_scale.as_ref())?;
                 return Some(ImportedMeshData {
                     positions,
                     indices,
@@ -1426,10 +1428,7 @@ type LoadedMeshBuffers = (Vec<f64>, Vec<u32>, Option<Vec<f64>>);
 /// to stderr) when the file is missing or unparseable so callers fall back
 /// to the no-geometry path rather than erroring the whole document.
 #[cfg(not(target_arch = "wasm32"))]
-fn load_mesh_import(
-    path: &str,
-    urdf_scale: Option<&vcad_ir::Vec3>,
-) -> Option<LoadedMeshBuffers> {
+fn load_mesh_import(path: &str, urdf_scale: Option<&vcad_ir::Vec3>) -> Option<LoadedMeshBuffers> {
     let file = std::fs::File::open(path)
         .map_err(|e| eprintln!("MeshImport: cannot open {path}: {e}"))
         .ok()?;
@@ -1450,11 +1449,20 @@ fn load_mesh_import(
         positions.push(v[2] as f64 * sz);
     }
 
+    let n_verts = stl.vertices.len();
     let mut indices = Vec::with_capacity(stl.faces.len() * 3);
-    let mut normals = vec![0.0_f64; stl.vertices.len() * 3];
+    let mut normals = vec![0.0_f64; n_verts * 3];
     for tri in &stl.faces {
         let [a, b, c] = tri.vertices;
+        // A malformed STL can reference vertices past the vertex table;
+        // drop such faces instead of panicking on the index below.
+        if a >= n_verts || b >= n_verts || c >= n_verts {
+            continue;
+        }
         indices.extend([a as u32, b as u32, c as u32]);
+        // Spread the face normal onto each vertex it touches; later faces
+        // overwrite earlier for shared vertices — flat-ish shading, same
+        // trade-off as the physics STL loader.
         for &vi in &tri.vertices {
             normals[vi * 3] = tri.normal[0] as f64;
             normals[vi * 3 + 1] = tri.normal[1] as f64;

--- a/crates/vcad-eval/src/pcb_preview.rs
+++ b/crates/vcad-eval/src/pcb_preview.rs
@@ -9,7 +9,7 @@
 //! meshes — green soldermask, mask-clad copper (green) with exposed gold pads,
 //! real 3D component bodies, and white silkscreen — for the inline GLB preview.
 //! It reuses the exact copper-mesh
-//! helpers the merged path uses ([`trace_to_mesh`](crate::evaluate::trace_to_mesh)
+//! helpers the merged path uses (`trace_to_mesh`
 //! et al.) so the two views never diverge, and pulls component bodies from
 //! [`vcad_ecad_pcb::component_mesh`] so the preview shows real packages
 //! (chips with metallic end caps, dark ICs, pin headers) instead of 1 mm boxes.

--- a/crates/vcad-i18n/src/bundle.rs
+++ b/crates/vcad-i18n/src/bundle.rs
@@ -14,7 +14,7 @@ impl TranslationBundle {
     /// Load translations for the given language code.
     ///
     /// English is always embedded at compile time. Other locales are loaded
-    /// from JSON files embedded via `include_str!` in [`load_locale`].
+    /// from JSON files embedded via `include_str!` in `load_locale`.
     pub fn load(language: &str) -> Self {
         let english: HashMap<String, String> =
             serde_json::from_str(EN_JSON).expect("en.json must be valid");

--- a/crates/vcad-ir/src/lib.rs
+++ b/crates/vcad-ir/src/lib.rs
@@ -1117,8 +1117,8 @@ pub enum CsgOp {
     ///
     /// Sheet-metal ops bypass the regular Solid pipeline — the engine
     /// detects a sheet-metal root and routes the whole chain to
-    /// [`vcad_kernel_wasm::sheet_metal::evaluate_sheet_metal_chain`], which
-    /// builds a [`vcad_kernel_sheet::SheetMetalModel`] and returns a
+    /// `vcad_kernel_wasm::sheet_metal::evaluate_sheet_metal_chain`, which
+    /// builds a `vcad_kernel_sheet::SheetMetalModel` and returns a
     /// tessellated mesh + flat pattern.
     SheetMetalBaseFlangeRect {
         /// Width (mm), extends in +X.
@@ -1178,7 +1178,7 @@ pub enum CsgOp {
         parent: NodeId,
         /// Panel id within the parent's model (0 = root).
         panel_id: usize,
-        /// Edge index in that panel's outline (0 = outline[0]→outline[1]).
+        /// Edge index in that panel's outline (0 = outline\[0\]→outline\[1\]).
         edge_index: usize,
         /// Flange length perpendicular to the hinge edge (mm).
         length: f64,

--- a/crates/vcad-ir/src/parameters.rs
+++ b/crates/vcad-ir/src/parameters.rs
@@ -4,7 +4,7 @@
 //! values are either literal numbers or expression strings. Operation fields
 //! can be bound to expressions via the [`Bindings`] sidecar — a map from
 //! (node id, field path) to [`Expr`]. At evaluation time, the
-//! [`resolve`](Bindings::resolve) pass evaluates every parameter and binding
+//! `resolve` pass evaluates every parameter and binding
 //! and returns concrete `f64` values.
 //!
 //! Why a sidecar? It keeps the kernel, mesh, and WASM pipelines oblivious

--- a/crates/vcad-kernel-atoms/src/lib.rs
+++ b/crates/vcad-kernel-atoms/src/lib.rs
@@ -14,7 +14,7 @@
 //! ## Layers
 //! - [`system::AtomSystem`] — the simulator's working state, built from the IR.
 //! - [`potential`] — composable force-field terms behind the [`potential::ForceField`] trait.
-//! - [`integrate`] / [`minimize`] — velocity-Verlet dynamics and FIRE relaxation.
+//! - [`integrate`] / [`minimize`](mod@minimize) — velocity-Verlet dynamics and FIRE relaxation.
 //! - [`fd`] — the finite-difference oracle every force term is validated against.
 //! - [`mlip`] — ML-potential adapter (the near-DFT force engine seam).
 //! - [`inverse`] — property-target inverse design.

--- a/crates/vcad-kernel-atoms/src/minimize.rs
+++ b/crates/vcad-kernel-atoms/src/minimize.rs
@@ -3,7 +3,7 @@
 //! FIRE is the workhorse for atomic relaxation: it's a damped-MD scheme that
 //! is robust, gradient-only, and converges quickly to a local energy minimum.
 //! Convergence is on the max force component (eV/Å). The FIRE numerics
-//! delegate to [`phyz_md::field::fire`]; this module binds them to
+//! delegate to [`phyz_md::field::fire()`]; this module binds them to
 //! [`AtomSystem`] and a [`ForceField`].
 
 use crate::potential::ForceField;

--- a/crates/vcad-kernel-booleans/src/trim.rs
+++ b/crates/vcad-kernel-booleans/src/trim.rs
@@ -27,7 +27,7 @@
 //! - t_range = 17.7 * 2 ≈ 35.5
 //! - Sampled t from -35.5 to +35.5
 //! - Points sampled: X from 35.5 to -35.5
-//! - MISSED the face entirely (X=[34,46] requires t≈-34 to -46)
+//! - MISSED the face entirely (X=\[34,46\] requires t≈-34 to -46)
 //!
 //! Fixed approach:
 //! - Use ray-AABB intersection to find t values where line enters/exits face bounds

--- a/crates/vcad-kernel-cam/src/lib.rs
+++ b/crates/vcad-kernel-cam/src/lib.rs
@@ -7,9 +7,9 @@
 //!
 //! # Operations
 //!
-//! - [`Face`](operation::Face) - Surface facing with raster pattern
-//! - [`Pocket2D`](operation::Pocket2D) - 2D pocket clearing with offset rings
-//! - [`Contour2D`](operation::Contour2D) - Profile machining with optional tabs
+//! - [`Face`] - Surface facing with raster pattern
+//! - [`Pocket2D`] - 2D pocket clearing with offset rings
+//! - [`Contour2D`] - Profile machining with optional tabs
 //!
 //! # Example
 //!

--- a/crates/vcad-kernel-constraints/src/jacobian.rs
+++ b/crates/vcad-kernel-constraints/src/jacobian.rs
@@ -1,7 +1,7 @@
 //! Jacobian matrix computation using finite differences.
 //!
 //! The Jacobian matrix J has dimensions (num_residuals × num_parameters),
-//! where J[i,j] = ∂r_i/∂p_j is the partial derivative of the i-th residual
+//! where J\[i,j\] = ∂r_i/∂p_j is the partial derivative of the i-th residual
 //! with respect to the j-th parameter.
 //!
 //! Note: the solver now uses symbolic Jacobians via [`crate::symbolic::CompiledSystem`].
@@ -21,7 +21,7 @@ const EPSILON: f64 = 1e-8;
 /// Compute the Jacobian matrix for all constraints using central finite differences.
 ///
 /// Central differences give better accuracy than forward differences:
-/// J[i,j] ≈ (r_i(p + h·e_j) - r_i(p - h·e_j)) / (2h)
+/// J\[i,j\] ≈ (r_i(p + h·e_j) - r_i(p - h·e_j)) / (2h)
 ///
 /// # Arguments
 ///

--- a/crates/vcad-kernel-constraints/src/solver.rs
+++ b/crates/vcad-kernel-constraints/src/solver.rs
@@ -143,7 +143,7 @@ pub trait LeastSquares {
 }
 
 /// Run Levenberg-Marquardt on any [`LeastSquares`] system, mutating `params`
-/// in place. This is the generic core extracted from [`solve`]; the constraint
+/// in place. This is the generic core extracted from `solve`; the constraint
 /// solver is now a thin wrapper around it, and differentiable design reuses it.
 pub fn levenberg_marquardt<Sys: LeastSquares>(
     system: &Sys,

--- a/crates/vcad-kernel-diff/src/adjoint.rs
+++ b/crates/vcad-kernel-diff/src/adjoint.rs
@@ -54,7 +54,7 @@ use vcad_kernel_geom::SurfaceKind;
 /// Every scalar shape parameter a surface kind exposes gets its **own**
 /// slot — the torus in particular has two independent radii, so overloading
 /// a single `radius` slot would price a major- and a minor-radius parameter
-/// against each other. The [`ScalarSlot`] enum names them; the translation
+/// against each other. The `ScalarSlot` enum names them; the translation
 /// slot (ℝ³) is shared by every kind.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct SurfaceCotangent {

--- a/crates/vcad-kernel-diff/src/implicit.rs
+++ b/crates/vcad-kernel-diff/src/implicit.rs
@@ -288,7 +288,7 @@ pub fn tangency_rows(
 ///   field-velocity-quadratic terms. For sphere/cylinder it is the closed
 ///   form `−2‖ẋ⊥ − v_c⊥‖² + 2ṙ²` of their *constant* Hessian (`∇²g` = `2I` /
 ///   `2P`, `P = I − aaᵀ`); cone and torus carry their non-constant curvature
-///   in closed form too (see [`velocity_curvature`]'s per-kind derivations).
+///   in closed form too (see `velocity_curvature`'s per-kind derivations).
 ///
 /// `x` is the vertex position, `xdot` its already-solved velocity (from
 /// [`solve_vertex_velocity`] on the first-order rows). Implemented for

--- a/crates/vcad-kernel-gpu/src/wavefront.rs
+++ b/crates/vcad-kernel-gpu/src/wavefront.rs
@@ -350,7 +350,7 @@ const ITERS_PER_READBACK: usize = 64;
 /// grid: a prep kernel converts the frontier counter into indirect
 /// dispatch args, and the relax kernel appends improved neighbors to the
 /// next frontier with epoch-stamped deduplication. The host only reads
-/// back the frontier length every [`ITERS_PER_READBACK`] iterations to
+/// back the frontier length every `ITERS_PER_READBACK` iterations to
 /// detect termination.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn distance_field_compacted(

--- a/crates/vcad-kernel-magnetostatic/src/iron.rs
+++ b/crates/vcad-kernel-magnetostatic/src/iron.rs
@@ -51,7 +51,7 @@ use crate::vec3::Vec3;
 ///
 /// One plane is a single mirror. Two planes form a cavity whose image series is
 /// infinite, exactly like facing mirrors; it is truncated at
-/// [`IronStack::max_reflections`] and the residual is reported by
+/// `IronStack::max_reflections` and the residual is reported by
 /// [`IronStack::tail_fraction`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct IronStack {
@@ -100,7 +100,7 @@ impl IronStack {
     ///
     /// Zero for an alternating-pole rotor, one for a lone magnet. The two-plane
     /// image series converges only near zero — see the module note. Values above
-    /// ~0.05 mean the result depends on [`IronStack::max_reflections`] and must
+    /// ~0.05 mean the result depends on `IronStack::max_reflections` and must
     /// not be quoted.
     pub fn balance_residual(sources: &[Filament]) -> f64 {
         let mut net = Vec3::ZERO;
@@ -191,7 +191,7 @@ impl IronStack {
     /// `probe`, for `source`.
     ///
     /// This is the truncation error of the image series: if it is not small, the
-    /// answer depends on [`IronStack::max_reflections`] and should not be quoted.
+    /// answer depends on `IronStack::max_reflections` and should not be quoted.
     pub fn tail_fraction(&self, source: &Filament, probe: Vec3) -> f64 {
         if self.planes_z.is_empty() {
             return 0.0;

--- a/crates/vcad-kernel-magnetostatic/src/lib.rs
+++ b/crates/vcad-kernel-magnetostatic/src/lib.rs
@@ -45,7 +45,7 @@
 //! - Self-inductance is filamentary, so it depends on the conductor radius used
 //!   to regularize the on-axis singularity. Rectangular PCB traces have no
 //!   single "radius"; we use the geometric-mean-distance equivalent, and the
-//!   residual error on `L` is larger than on `Kt` — see [`machine`].
+//!   residual error on `L` is larger than on `Kt` — see `machine`.
 //! - Temperature. `Kt` shifts with magnet remanence (≈ −0.2%/K for NdFeB,
 //!   ≈ −0.2%/K for ferrite) and `R` with copper resistivity (+0.39%/K).
 //!   Callers supply the operating temperature; nothing here guesses it.
@@ -57,7 +57,7 @@
 //! crate therefore returns zero cogging *by construction*, not as a computed
 //! result — do not read it as a validated prediction. What *is* computed is
 //! torque ripple under load, which for an air-core machine comes from winding
-//! and magnet-field harmonics alone; see [`kpi`].
+//! and magnet-field harmonics alone; see `kpi`.
 //!
 //! # Units
 //!

--- a/crates/vcad-kernel-math/src/lib.rs
+++ b/crates/vcad-kernel-math/src/lib.rs
@@ -99,7 +99,7 @@ impl Transform {
     /// Composed entirely from existing primitives:
     /// `T(p0) · R⁻¹ · Scale(1, 1, −1) · R · T(−p0)`, where `R` rotates
     /// `plane_normal` onto `+Z`. The determinant of the upper-left 3×3 is
-    /// −1, so callers like [`Solid::apply_transform`] will detect the
+    /// −1, so callers like `Solid::apply_transform` will detect the
     /// orientation flip and reverse face / triangle winding to preserve
     /// outward normals.
     pub fn reflection(plane_origin: Point3, plane_normal: Vec3) -> Self {

--- a/crates/vcad-kernel-naming/src/lib.rs
+++ b/crates/vcad-kernel-naming/src/lib.rs
@@ -245,7 +245,7 @@ fn surface_tag(surface: &dyn Surface) -> String {
 /// Every face the boolean keeps still lies on exactly one input surface (the
 /// splitter trims loops but reuses the carrying surfaces), so each result
 /// face is matched to the input faces whose surface is geometrically
-/// identical (within [`SURF_TOL`]). Fail-closed rules:
+/// identical (within `SURF_TOL`). Fail-closed rules:
 ///
 /// - candidates carrying more than one distinct input name (e.g. two flush
 ///   coplanar faces from A and B) → the result face stays anonymous;
@@ -310,7 +310,7 @@ pub fn propagate_boolean(
     map
 }
 
-/// Geometric identity of two surfaces within [`SURF_TOL`].
+/// Geometric identity of two surfaces within `SURF_TOL`.
 ///
 /// Kind-wise comparison of the analytic parameters that determine the point
 /// set (parameterization details like `ref_dir` are ignored; axis sign is

--- a/crates/vcad-kernel-neutronics/src/materials.rs
+++ b/crates/vcad-kernel-neutronics/src/materials.rs
@@ -15,7 +15,7 @@
 //! order-of-magnitude dose rates — exactly the design questions.
 //!
 //! Scattering model: isotropic-in-CM elastic scattering off free nuclei.
-//! Group-transfer matrices are derived in [`transfer_row`] from the exact
+//! Group-transfer matrices are derived in `transfer_row` from the exact
 //! single-collision energy kernel (E′ uniform on [αE, E], α=((A−1)/(A+1))²)
 //! averaged over a flat-in-lethargy flux across the source group — the
 //! standard multigroup construction, computed numerically at build time so

--- a/crates/vcad-kernel-particle/src/field.rs
+++ b/crates/vcad-kernel-particle/src/field.rs
@@ -86,7 +86,7 @@ struct BGrid {
 ///
 /// Coil B is precomputed on the Poisson grid once (analytic elliptic
 /// integrals at every node) and bilinearly sampled during tracing — except
-/// within [`B_NEAR_WIRE_FACTOR`] wire radii of a conductor, where the
+/// within `B_NEAR_WIRE_FACTOR` wire radii of a conductor, where the
 /// exact analytic sum is used so the shielding sheath keeps its 1/ρ
 /// structure. This removes the per-substep elliptic-integral cost that
 /// dominated high-current traces.

--- a/crates/vcad-kernel-particle/src/power.rs
+++ b/crates/vcad-kernel-particle/src/power.rs
@@ -15,7 +15,7 @@
 //! resulting Q is **conservative** (the honest direction).
 
 /// Inputs to the power ledger. Every field is a measured or supplied
-/// number with a stated origin — see [`PowerLedger::evaluate`].
+/// number with a stated origin — see `PowerLedger::evaluate`.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct LedgerInputs {
     /// D-D neutron rate of the machine, n/s (from the ion traces).

--- a/crates/vcad-kernel-physics/src/diff.rs
+++ b/crates/vcad-kernel-physics/src/diff.rs
@@ -20,14 +20,14 @@
 //! different places, each computed the correct way for its side of the seam:
 //!
 //! - **`dp_body/dθ`** — *exact*, from the differentiable seam. The frozen
-//!   plan plus a per-parameter [`ParamSeeding`] feeds
-//!   [`mass_properties_with_derivative`], which carries dual numbers through
+//!   plan plus a per-parameter `ParamSeeding` feeds
+//!   `mass_properties_with_derivative`, which carries dual numbers through
 //!   the polynomial mass-property integrals: every field's θ-derivative in
 //!   one pass, to machine precision. No remeshing, no topology risk.
 //!
 //! - **`∂J/∂p_body`** — two implementations of the same factor:
 //!   - **Adjoint (exact)** — [`rollout_gradient_adjoint`] hands a structured
-//!     rollout ([`AdjointRolloutSpec`]) to the **phyz trajectory adjoint**
+//!     rollout (`AdjointRolloutSpec`) to the **phyz trajectory adjoint**
 //!     (`phyz::diff`), which prices all `10·n_bodies` sensitivities in one
 //!     backward pass (dual-number lanes through a scalar-generic ABA — no
 //!     finite differences). Requires the rollout in structured form:
@@ -742,7 +742,7 @@ pub fn rollout_gradient_via_density(
 /// vcad-kernel-physics otherwise wraps phyz completely (no phyz types in
 /// public APIs). The adjoint-backed gradients are the exception: callers
 /// describe the rollout by *building a phyz model themselves*, so
-/// [`AdjointRolloutSpec`](interop::AdjointRolloutSpec) necessarily carries
+/// [`interop::AdjointRolloutSpec`] necessarily carries
 /// `phyz::Model` / `phyz::math::DVec`. Anything imported from here couples
 /// your code to phyz's API; the wrapped entry points
 /// ([`rollout_gradient_adjoint`], [`contact_rollout_gradient`]) are the

--- a/crates/vcad-kernel-sheet/src/dxf.rs
+++ b/crates/vcad-kernel-sheet/src/dxf.rs
@@ -14,7 +14,7 @@
 //!
 //! 1. **One closed exterior per part.** Panel outlines and bend-allowance
 //!    strips are unioned into a single silhouette (see
-//!    [`crate::silhouette`]); no disjoint per-panel regions, no
+//!    [`crate::silhouette()`]); no disjoint per-panel regions, no
 //!    allowance-width gaps that read as "open entities".
 //! 2. **Dashed bend lines.** Services detect bend lines by *linetype =
 //!    dashed*, not by layer name or color. Every bend `LINE` carries the

--- a/crates/vcad-kernel-sheet/src/flatten.rs
+++ b/crates/vcad-kernel-sheet/src/flatten.rs
@@ -5,7 +5,7 @@
 //! This module runs the arrow the other way — it takes the **triangle mesh
 //! of a solid that was modelled some other way** (extruded sketch, boolean,
 //! imported STEP) and reconstructs the panel/bend graph, so the existing
-//! [`unfold`](crate::unfold) → [`silhouette`](crate::silhouette) →
+//! [`unfold()`](crate::unfold()) → [`silhouette()`](crate::silhouette()) →
 //! [`dxf`](crate::dxf) pipeline can emit a fab-ready flat pattern for it.
 //!
 //! This is the mechanical counterpart of `board_from_solid`: solid in,

--- a/crates/vcad-kernel-sheet/src/lib.rs
+++ b/crates/vcad-kernel-sheet/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! This buys us **lossless bidirectional unfold**: because the bend metadata
 //! (radius, angle, K-factor) lives on the bend itself rather than being
-//! reconstructed from cylindrical face geometry, [`unfold`] and [`refold`] are
+//! reconstructed from cylindrical face geometry, [`unfold()`] and [`refold()`] are
 //! exact inverses by construction. See [`unfold::unfold`] and [`unfold::refold`].
 //!
 //! # Foundation tier

--- a/crates/vcad-kernel-sheet/src/model.rs
+++ b/crates/vcad-kernel-sheet/src/model.rs
@@ -241,7 +241,7 @@ impl SheetMetalModel {
     /// Walk the panel/bend graph from the root, yielding each `(panel_id,
     /// parent_bend_id_or_none)` in BFS order.
     ///
-    /// The first yielded item is `(root, None)`. Used by [`crate::unfold`] to
+    /// The first yielded item is `(root, None)`. Used by [`crate::unfold()`] to
     /// propagate the unfolded frame outward from the reference panel.
     pub fn bfs(&self) -> impl Iterator<Item = (PanelId, Option<BendId>)> + '_ {
         BfsIter::new(self)

--- a/crates/vcad-kernel-sheet/src/unfold.rs
+++ b/crates/vcad-kernel-sheet/src/unfold.rs
@@ -15,9 +15,9 @@
 //!   (with the bend allowance offsetting the child along the parent's
 //!   in-plane outward direction).
 //!
-//! The involution test [`tests::round_trip_is_identity`] proves
+//! The involution test `tests::round_trip_is_identity` proves
 //! `refold ∘ unfold = identity` on bent frames within tolerance, and
-//! [`tests::flat_round_trip_is_identity`] proves `unfold ∘ refold =
+//! `tests::flat_round_trip_is_identity` proves `unfold ∘ refold =
 //! identity` on flat frames.
 //!
 //! The exported [`FlatPattern`] type is the manufacturing-side view —

--- a/crates/vcad-kernel-tessellate/src/frozen.rs
+++ b/crates/vcad-kernel-tessellate/src/frozen.rs
@@ -22,7 +22,7 @@
 //!    — a changed signature means the perturbation crossed a topology change
 //!    (a subgradient) and node correspondence is meaningless, so this is a
 //!    hard error, never a silent wrong answer — then re-emit node positions
-//!    under the frozen recipes in `f64` (the stock [`TriangleMesh`] is `f32`,
+//!    under the frozen recipes in `f64` (the stock `TriangleMesh` is `f32`,
 //!    which is far too coarse for a central-difference oracle at `h ≈ 1e-6`).
 //!
 //! Node recipes reference topology entities by *canonical traversal index*
@@ -911,7 +911,7 @@ impl PointGrid {
 /// nodes from adjacent faces are merged (same quantum as the stock weld) so
 /// the frozen mesh shares vertices across face seams.
 ///
-/// The cross-face dedup is already spatial-hashed ([`PointGrid`]-style, since
+/// The cross-face dedup is already spatial-hashed (`PointGrid`-style, since
 /// the M0–M2 hardening). The remaining per-face topology-vertex
 /// classification scans a face's boundary loop, which is topology-bounded
 /// (not a function of tessellation density), so it is not a hot spot — see
@@ -1163,7 +1163,7 @@ pub fn capture_plan(
 /// position. A nearest match farther than the tolerance is
 /// [`FrozenError::CorrespondenceLost`].
 ///
-/// The `TopoVertex` resolution is grid-accelerated ([`PointGrid`]) — turning
+/// The `TopoVertex` resolution is grid-accelerated (`PointGrid`) — turning
 /// the per-node scan over all rebuilt vertices (`O(nodes · vertices)`, the one
 /// genuinely quadratic scan in the seam once dedup was hashed) into O(1)
 /// amortized. Because a node's anchor sits ~1e-6 mm from its rebuilt vertex

--- a/crates/vcad-kernel-thermal/src/receipt.rs
+++ b/crates/vcad-kernel-thermal/src/receipt.rs
@@ -378,7 +378,7 @@ pub fn compare(
 /// Same fail-closed contract as [`predicted_claims`]: `opts` must be what
 /// the run used, the model is the **base** (pre-schedule) model, and every
 /// claim carries `basis: "predicted"`. Series data stays on the
-/// [`TransientSolution`]; the claims capture the quantities a recipe is
+/// `TransientSolution`; the claims capture the quantities a recipe is
 /// judged by — the peak, the endpoint, how far the endpoint sits from
 /// steady, and the integrated energy audit.
 pub fn transient_claims(

--- a/crates/vcad-kernel-urdf/src/types.rs
+++ b/crates/vcad-kernel-urdf/src/types.rs
@@ -394,19 +394,39 @@ impl Axis {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Limit {
     /// Lower limit (radians for revolute, meters for prismatic).
-    #[serde(rename = "@lower", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@lower",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub lower: Option<f64>,
 
     /// Upper limit.
-    #[serde(rename = "@upper", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@upper",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub upper: Option<f64>,
 
     /// Maximum effort (Nm for revolute, N for prismatic).
-    #[serde(rename = "@effort", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@effort",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub effort: Option<f64>,
 
     /// Maximum velocity (rad/s for revolute, m/s for prismatic).
-    #[serde(rename = "@velocity", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@velocity",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub velocity: Option<f64>,
 }
 
@@ -414,11 +434,21 @@ pub struct Limit {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Dynamics {
     /// Viscous damping coefficient.
-    #[serde(rename = "@damping", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@damping",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub damping: Option<f64>,
 
     /// Static friction (Coulomb).
-    #[serde(rename = "@friction", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@friction",
+        default,
+        deserialize_with = "ws_f64_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub friction: Option<f64>,
 }
 

--- a/crates/vcad-kernel-urdf/src/types.rs
+++ b/crates/vcad-kernel-urdf/src/types.rs
@@ -2,7 +2,21 @@
 //!
 //! These types mirror the URDF XML schema for parsing.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Deserialize an `f64` attribute, tolerating surrounding whitespace
+/// (real-world URDFs, e.g. Booster K1, emit values like `" -0.000001"`).
+fn ws_f64<'de, D: Deserializer<'de>>(d: D) -> Result<f64, D::Error> {
+    let s = String::deserialize(d)?;
+    s.trim().parse().map_err(serde::de::Error::custom)
+}
+
+/// Like [`ws_f64`] but for optional attributes.
+fn ws_f64_opt<'de, D: Deserializer<'de>>(d: D) -> Result<Option<f64>, D::Error> {
+    let s = Option::<String>::deserialize(d)?;
+    s.map(|s| s.trim().parse().map_err(serde::de::Error::custom))
+        .transpose()
+}
 
 /// Root URDF robot element.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -106,7 +120,7 @@ pub struct Inertial {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Mass {
     /// Mass value in kg.
-    #[serde(rename = "@value")]
+    #[serde(rename = "@value", deserialize_with = "ws_f64")]
     pub value: f64,
 }
 
@@ -114,22 +128,22 @@ pub struct Mass {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Inertia {
     /// Ixx component.
-    #[serde(rename = "@ixx")]
+    #[serde(rename = "@ixx", deserialize_with = "ws_f64")]
     pub ixx: f64,
     /// Ixy component.
-    #[serde(rename = "@ixy")]
+    #[serde(rename = "@ixy", deserialize_with = "ws_f64")]
     pub ixy: f64,
     /// Ixz component.
-    #[serde(rename = "@ixz")]
+    #[serde(rename = "@ixz", deserialize_with = "ws_f64")]
     pub ixz: f64,
     /// Iyy component.
-    #[serde(rename = "@iyy")]
+    #[serde(rename = "@iyy", deserialize_with = "ws_f64")]
     pub iyy: f64,
     /// Iyz component.
-    #[serde(rename = "@iyz")]
+    #[serde(rename = "@iyz", deserialize_with = "ws_f64")]
     pub iyz: f64,
     /// Izz component.
-    #[serde(rename = "@izz")]
+    #[serde(rename = "@izz", deserialize_with = "ws_f64")]
     pub izz: f64,
 }
 
@@ -215,11 +229,11 @@ impl BoxGeom {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CylinderGeom {
     /// Radius in meters.
-    #[serde(rename = "@radius")]
+    #[serde(rename = "@radius", deserialize_with = "ws_f64")]
     pub radius: f64,
 
     /// Length (height) in meters.
-    #[serde(rename = "@length")]
+    #[serde(rename = "@length", deserialize_with = "ws_f64")]
     pub length: f64,
 }
 
@@ -227,7 +241,7 @@ pub struct CylinderGeom {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SphereGeom {
     /// Radius in meters.
-    #[serde(rename = "@radius")]
+    #[serde(rename = "@radius", deserialize_with = "ws_f64")]
     pub radius: f64,
 }
 
@@ -380,19 +394,19 @@ impl Axis {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Limit {
     /// Lower limit (radians for revolute, meters for prismatic).
-    #[serde(rename = "@lower", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@lower", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub lower: Option<f64>,
 
     /// Upper limit.
-    #[serde(rename = "@upper", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@upper", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub upper: Option<f64>,
 
     /// Maximum effort (Nm for revolute, N for prismatic).
-    #[serde(rename = "@effort", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@effort", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub effort: Option<f64>,
 
     /// Maximum velocity (rad/s for revolute, m/s for prismatic).
-    #[serde(rename = "@velocity", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@velocity", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub velocity: Option<f64>,
 }
 
@@ -400,11 +414,11 @@ pub struct Limit {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Dynamics {
     /// Viscous damping coefficient.
-    #[serde(rename = "@damping", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@damping", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub damping: Option<f64>,
 
     /// Static friction (Coulomb).
-    #[serde(rename = "@friction", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@friction", default, deserialize_with = "ws_f64_opt", skip_serializing_if = "Option::is_none")]
     pub friction: Option<f64>,
 }
 

--- a/crates/vcad-kernel-wasm/src/circuit_sim.rs
+++ b/crates/vcad-kernel-wasm/src/circuit_sim.rs
@@ -17,7 +17,7 @@ use vcad_ecad_sim::circuit::{
 };
 use wasm_bindgen::prelude::*;
 
-/// One device in a [`CircuitSpec`]. `p`/`n` are node ids (0 = ground).
+/// One device in a `CircuitSpec`. `p`/`n` are node ids (0 = ground).
 #[derive(Debug, Deserialize)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 enum DeviceSpec {
@@ -200,7 +200,7 @@ impl From<vcad_ecad_sim::circuit::Observation> for WasmObservation {
     }
 }
 
-/// A live circuit simulation. Build from a [`CircuitSpec`] JSON, then `step`.
+/// A live circuit simulation. Build from a `CircuitSpec` JSON, then `step`.
 #[wasm_bindgen]
 pub struct CircuitSim {
     env: CircuitEnv,
@@ -1003,7 +1003,7 @@ struct MappedCircuitOut {
 ///
 /// * `sch_json` — JSON-serialized `SchematicSheet` (same shape as
 ///   `ecadGenerateNetlist` takes).
-/// * `options_json` — JSON [`MapOptions`] (`{}` for defaults).
+/// * `options_json` — JSON `MapOptions` (`{}` for defaults).
 ///
 /// Returns `{ok: true, devices, nodeOfNet, deviceOfRef, ...}` on success, or
 /// `{ok: false, blockers: [{reference, message}]}` when any component can't

--- a/crates/vcad-kernel-wasm/src/keybindings.rs
+++ b/crates/vcad-kernel-wasm/src/keybindings.rs
@@ -53,7 +53,7 @@ impl WasmKeybindings {
     /// Returns a JSON array describing every registered command. The TS UI
     /// (command palette, keyboard prefs) reads this once at startup.
     ///
-    /// Each entry is a [`CommandView`] — a flattened, owned projection of
+    /// Each entry is a `CommandView` — a flattened, owned projection of
     /// `Command` that serde can serialize (the source struct uses `&'static
     /// str` and a non-serializable `ModeScope` enum).
     #[wasm_bindgen(js_name = commandsJson)]
@@ -125,7 +125,7 @@ impl WasmKeybindings {
         self.inner.save_overrides()
     }
 
-    /// Load overrides previously returned by [`save_overrides`]. Malformed
+    /// Load overrides previously returned by [`Self::save_overrides`]. Malformed
     /// entries are skipped — the caller never sees a parse failure for
     /// stale config.
     #[wasm_bindgen(js_name = loadOverrides)]

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -249,7 +249,7 @@ pub fn render_svg_annotated(
         .map_err(|e| JsError::new(&e))
 }
 
-/// Render raw `.vcad` document JSON to an SVG with the full [`SvgOptions`]
+/// Render raw `.vcad` document JSON to an SVG with the full `SvgOptions`
 /// surface in one call: arbitrary camera, part focus, section cutaway,
 /// changed-part highlight, and engineering annotations. This is the superset
 /// the MCP `render_view` "agent eyes" path drives; the narrower
@@ -305,7 +305,7 @@ pub fn render_svg_camera(
     vcad_render::render_svg_str_opts(vcad_json, scale, &opts).map_err(|e| JsError::new(&e))
 }
 
-/// Render raw `.vcad` document JSON to an SVG with the full [`SvgOptions`]
+/// Render raw `.vcad` document JSON to an SVG with the full `SvgOptions`
 /// surface expressed as one JSON options object — the forward-compatible
 /// companion to [`render_svg_camera`] (mirroring [`render_pcb_svg_opts`]),
 /// so new render options never need another positional-arg binding.
@@ -3151,7 +3151,7 @@ pub fn import_step_buffer(data: &[u8]) -> Result<JsValue, JsError> {
 }
 
 /// Import a URDF (Unified Robot Description Format) file and return a
-/// serialised vcad [`Document`].
+/// serialised vcad `Document`.
 ///
 /// Browsers cannot resolve `package://` URIs or relative mesh paths
 /// against the user's filesystem, so any `<mesh>` reference in the URDF
@@ -3876,7 +3876,7 @@ impl RayTracer {
     ///
     /// # Note
     /// This function is async to support WASM's single-threaded environment.
-    /// In JavaScript, it returns a Promise<Uint8Array>.
+    /// In JavaScript, it returns a `Promise<Uint8Array>`.
     pub async fn render(
         &self,
         camera: Vec<f64>,
@@ -5729,7 +5729,7 @@ mod cam_wasm {
     /// Generate a height field from mesh using drop-cutter algorithm.
     ///
     /// # Arguments
-    /// * `vertices_json` - Vertex array as JSON [[x,y,z], ...]
+    /// * `vertices_json` - Vertex array as JSON `[[x,y,z], ...]`
     /// * `indices_json` - Triangle indices as JSON [i0, i1, i2, ...]
     /// * `tool_json` - Tool definition as JSON
     /// * `bounds_json` - Bounds [min_x, min_y, max_x, max_y] as JSON
@@ -6259,7 +6259,7 @@ mod ecad_wasm {
 
     /// Route a net with the push-and-shove router.
     ///
-    /// Unlike [`Self::ecad_route_net`] (grid/wave BFS), this routes in
+    /// Unlike `ecad_route_net` (grid/wave BFS), this routes in
     /// continuous coordinate space and detours around existing copper on other
     /// nets, yielding cleaner diagonal paths. Coordinates are board-space mm in
     /// and out — no grid origin offset. Returns `{ net, segments, vias, success }`.
@@ -6289,7 +6289,7 @@ mod ecad_wasm {
 
     /// Route a net with the avoiding A* maze router.
     ///
-    /// Unlike [`Self::ecad_route_net_shove`] (which detours around static
+    /// Unlike `ecad_route_net_shove` (which detours around static
     /// inflated bounding boxes of other-net *traces*), this searches a grid and
     /// tests every step against the exact clearance oracle, so the route avoids
     /// *all* copper on `layer` — traces, pads, and vias. Every returned segment
@@ -7239,7 +7239,7 @@ pub fn parse_vcad_file(content: &str) -> Result<JsValue, JsError> {
 
 /// Derive parts from a Document (as JSON).
 ///
-/// Returns a JSON-serialized Vec<PartInfo>.
+/// Returns a JSON-serialized `Vec<PartInfo>`.
 #[wasm_bindgen(js_name = deriveParts)]
 pub fn derive_parts(doc_json: &str) -> Result<JsValue, JsError> {
     let doc: vcad_ir::Document = serde_json::from_str(doc_json)
@@ -8031,7 +8031,7 @@ struct WasmParticleSim {
 /// `spec_json` is a `vcad_kernel_particle::spec::DeviceSpec` (named
 /// parameters allowed), `params_json` a `{name: value}` map binding them
 /// (fail-closed: unbound names error), `options_json` a
-/// [`ParticleSimOptions`]. Returns stats + `vcad.particle-claims/1` set +
+/// `ParticleSimOptions`. Returns stats + `vcad.particle-claims/1` set +
 /// unified-receipt claims (basis `predicted` — Provisional by contract).
 #[wasm_bindgen(js_name = particleSimulate)]
 pub fn particle_simulate(
@@ -8349,7 +8349,7 @@ struct WasmToleranceAnalysis {
 /// `spec_json` is a `vcad_kernel_tolerance::spec::StackupSpec` (named
 /// parameters allowed), `params_json` a `{name: value}` map binding them
 /// (fail-closed: unbound names error), `options_json` a
-/// [`ToleranceOptions`]. Returns all three analyses +
+/// `ToleranceOptions`. Returns all three analyses +
 /// `vcad.tolerance-claims/1` + unified-receipt claims (basis `predicted`).
 #[wasm_bindgen(js_name = toleranceAnalyze)]
 pub fn tolerance_analyze(
@@ -8498,7 +8498,7 @@ struct WasmThermalSolve {
 ///
 /// `spec_json` is a `vcad_kernel_thermal::spec::ThermalSpec` (named
 /// parameters allowed), `params_json` a `{name: value}` map binding them,
-/// `options_json` a [`ThermalOptions`].
+/// `options_json` a `ThermalOptions`.
 #[wasm_bindgen(js_name = thermalSolve)]
 pub fn thermal_solve(
     spec_json: &str,
@@ -8705,7 +8705,7 @@ struct WasmThermalTransient {
 /// `spec_json` is a `ThermalSpec` (every material needs
 /// `heat_capacity_j_m3k`), `transient_json` a
 /// `vcad_kernel_thermal::spec::TransientSpec`, `params_json` a
-/// `{name: value}` map, `options_json` a [`ThermalOptions`].
+/// `{name: value}` map, `options_json` a `ThermalOptions`.
 #[wasm_bindgen(js_name = thermalSolveTransient)]
 pub fn thermal_solve_transient(
     spec_json: &str,
@@ -8927,7 +8927,7 @@ fn sample_fields_to_vertices(
 /// predicted claim is emitted.
 ///
 /// `spec_json` is a `vcad_kernel_fea::spec::FeaSpec` (material, loads,
-/// supports, resolution), `options_json` a [`FeaOptions`].
+/// supports, resolution), `options_json` a `FeaOptions`.
 #[wasm_bindgen(js_name = feaAnalyzeMesh)]
 pub fn fea_analyze_mesh(
     spec_json: &str,
@@ -9303,7 +9303,7 @@ fn em_solve_options(opts: &EmSimOptions) -> vcad_kernel::vcad_kernel_em::grid::S
 /// allowed), `planar_magnetostatics` (`PlanarSpec`, named parameters
 /// allowed), or `electrostatics` (a literal-only electrode/dielectric
 /// DTO — the crate has no serde seam for that class yet). `params_json`
-/// binds named parameters; `options_json` is [`EmSimOptions`].
+/// binds named parameters; `options_json` is `EmSimOptions`.
 #[wasm_bindgen(js_name = emSimulate)]
 pub fn em_simulate(
     spec_json: &str,
@@ -9632,7 +9632,7 @@ struct WasmAntennaAnalysis {
 ///
 /// `spec_json` is a `vcad_kernel_antenna::spec::AntennaSpec` (named
 /// parameters allowed), `params_json` a `{name: value}` map binding them,
-/// `options_json` an [`AntennaOptions`] (the frequency `band` is
+/// `options_json` an `AntennaOptions` (the frequency `band` is
 /// required).
 #[wasm_bindgen(js_name = antennaAnalyze)]
 pub fn antenna_analyze(

--- a/crates/vcad-kernel-wasm/src/sheet_metal.rs
+++ b/crates/vcad-kernel-wasm/src/sheet_metal.rs
@@ -531,7 +531,7 @@ struct NestedDxfResult {
 
 /// Produce one layered DXF per stock sheet for a set of nested parts.
 ///
-/// `placements_json` is an array of [`NestedPlacementDto`]; each chain
+/// `placements_json` is an array of `NestedPlacementDto`; each chain
 /// is independently evaluated into a flat pattern, then translated /
 /// rotated according to its placement before being written to the
 /// sheet's DXF. Layers are the same `CUT` / `BEND_UP` / `BEND_DOWN`

--- a/crates/vcad-kernel-wasm/src/strike.rs
+++ b/crates/vcad-kernel-wasm/src/strike.rs
@@ -1,5 +1,5 @@
 //! WASM binding for the structural strike simulation
-//! ([`vcad_kernel_acoustics::strike`]).
+//! (`vcad_kernel_acoustics::strike`).
 //!
 //! Single JSON-over-the-boundary entry point, like `sheet_metal`: the MCP
 //! server (and any other host) sends a [`strike::StrikeInput`] as JSON and

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -316,7 +316,7 @@ impl Solid {
     }
 
     /// Mirror the solid across a plane defined by a point on the plane and
-    /// a normal vector. Routes through [`apply_transform`] with a reflection
+    /// a normal vector. Routes through [`Self::apply_transform`] with a reflection
     /// matrix, so face / triangle winding is automatically reversed to
     /// preserve outward normals.
     pub fn mirror(&self, plane_origin: [f64; 3], plane_normal: [f64; 3]) -> Solid {

--- a/crates/vcad-process/src/masks.rs
+++ b/crates/vcad-process/src/masks.rs
@@ -1,7 +1,7 @@
 //! GDS layout → plan-view masks in µm.
 //!
-//! Bridges [`vcad_gdsii::flatten`] output (f64 database units) into the
-//! [`Masks`](crate::sim::Masks) the simulator consumes: polygons are
+//! Bridges [`vcad_gdsii::flatten()`] output (f64 database units) into the
+//! [`Masks`] the simulator consumes: polygons are
 //! scaled to µm, clipped to the region of interest, and unioned per layer
 //! so downstream booleans and interval extraction see disjoint geometry.
 

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -733,18 +733,12 @@ fn evaluate_assembly_instances(
                         .find(|pd| pd.id == inst.part_def_id)
                         .filter(|pd| !pd.mesh.indices.is_empty())
                         .map(|pd| {
-                            Solid::from_mesh(
-                                vcad_kernel::vcad_kernel_tessellate::TriangleMesh {
-                                    vertices: pd.mesh.positions.clone(),
-                                    indices: pd.mesh.indices.clone(),
-                                    normals: pd.mesh.normals.clone().unwrap_or_default(),
-                                    face_kinds: pd
-                                        .mesh
-                                        .face_kinds
-                                        .clone()
-                                        .unwrap_or_default(),
-                                },
-                            )
+                            Solid::from_mesh(vcad_kernel::vcad_kernel_tessellate::TriangleMesh {
+                                vertices: pd.mesh.positions.clone(),
+                                indices: pd.mesh.indices.clone(),
+                                normals: pd.mesh.normals.clone().unwrap_or_default(),
+                                face_kinds: pd.mesh.face_kinds.clone().unwrap_or_default(),
+                            })
                         })
                 })
             })

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -620,11 +620,28 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
         .iter()
         .filter(|r| r.visible != Some(false))
         .collect();
+    // Part-definition prototype roots: a URDF import pushes each link's
+    // geometry both as a scene root AND as a part-def referenced by a
+    // world-placed instance. Drawing the root too would pile every link
+    // untransformed at the origin on top of the FK-placed assembly.
+    let proto_roots: std::collections::HashSet<vcad_ir::NodeId> =
+        match (&parsed.document.part_defs, &parsed.document.instances) {
+            (Some(defs), Some(insts)) if !insts.is_empty() => {
+                defs.values().map(|d| d.root).collect()
+            }
+            _ => Default::default(),
+        };
     let mut solids: Vec<SceneSolid> = scene
         .parts
         .iter()
         .enumerate()
         .filter_map(|(i, p)| {
+            if visible_roots
+                .get(i)
+                .is_some_and(|r| proto_roots.contains(&r.root))
+            {
+                return None;
+            }
             // A root whose chain bottoms out in an `ImportedMesh` (frozen
             // topology-optimization results, drag-dropped STL/GLB) carries
             // no `Solid` — the evaluator has no path from a triangle soup
@@ -665,7 +682,7 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
     // definition once and place a transformed copy per instance. Without
     // this, an assembly-only document (no scene roots) rendered as
     // "no solids produced" despite being perfectly valid.
-    solids.extend(evaluate_assembly_instances(&parsed.document)?);
+    solids.extend(evaluate_assembly_instances(&parsed.document, &scene)?);
     Ok(solids)
 }
 
@@ -673,7 +690,10 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
 /// tinted solids. Part-definition solids are evaluated once and shared;
 /// per-instance world poses come from forward kinematics, falling back to
 /// the instance's static transform.
-fn evaluate_assembly_instances(doc: &vcad_ir::Document) -> Result<Vec<SceneSolid>, String> {
+fn evaluate_assembly_instances(
+    doc: &vcad_ir::Document,
+    scene: &vcad_eval::EvaluatedScene,
+) -> Result<Vec<SceneSolid>, String> {
     let (Some(part_defs), Some(instances)) = (&doc.part_defs, &doc.instances) else {
         return Ok(Vec::new());
     };
@@ -703,6 +723,30 @@ fn evaluate_assembly_instances(doc: &vcad_ir::Document) -> Result<Vec<SceneSolid
                         .flatten()
                 }))
                 .unwrap_or(None)
+                // No BRep (mesh-imported part, e.g. a URDF link's STL):
+                // wrap the evaluated triangle mesh, same as the roots path.
+                .or_else(|| {
+                    scene
+                        .part_defs
+                        .as_ref()?
+                        .iter()
+                        .find(|pd| pd.id == inst.part_def_id)
+                        .filter(|pd| !pd.mesh.indices.is_empty())
+                        .map(|pd| {
+                            Solid::from_mesh(
+                                vcad_kernel::vcad_kernel_tessellate::TriangleMesh {
+                                    vertices: pd.mesh.positions.clone(),
+                                    indices: pd.mesh.indices.clone(),
+                                    normals: pd.mesh.normals.clone().unwrap_or_default(),
+                                    face_kinds: pd
+                                        .mesh
+                                        .face_kinds
+                                        .clone()
+                                        .unwrap_or_default(),
+                                },
+                            )
+                        })
+                })
             })
             .clone();
         let Some(solid) = solid else { continue };

--- a/crates/vcad-render/src/sheet.rs
+++ b/crates/vcad-render/src/sheet.rs
@@ -3,7 +3,7 @@
 //!
 //! This module is a *composition layer*. It renders each view through the
 //! crate's ordinary public entry points ([`render_svg_str_opts`] /
-//! [`render_png_str`]) at one shared scale and arranges the results — it
+//! `render_png_str`) at one shared scale and arranges the results — it
 //! deliberately owns none of the projection, shading, or hidden-line logic.
 //! Keeping it decoupled means new single-view features (sections, exact
 //! edges, ray tracing, annotations) neither need nor get special-casing
@@ -32,7 +32,7 @@ const SHEET_VIEWS: [(View, &str, usize, usize); 4] = [
 #[derive(Debug, Clone)]
 pub struct SheetOptions {
     /// Overall sheet width in user units / pixels; height is derived
-    /// (landscape, [`SHEET_ASPECT`]).
+    /// (landscape, `SHEET_ASPECT`).
     pub width_px: f64,
     /// Title shown in the title block (typically the document/file name).
     pub title: String,

--- a/crates/vcad-slicer/src/lib.rs
+++ b/crates/vcad-slicer/src/lib.rs
@@ -199,7 +199,7 @@ pub fn slice(mesh: &TriangleMesh, settings: &SliceSettings) -> Result<SliceResul
     slice_with_progress(mesh, settings, None)
 }
 
-/// Like [`slice`], but reports progress to the given callback. The callback
+/// Like [`slice()`], but reports progress to the given callback. The callback
 /// runs synchronously on whatever thread is driving the slice; for the
 /// worker pipeline that means it can `postMessage` straight to the main
 /// thread without blocking it.

--- a/crates/vcad-typst/src/lib.rs
+++ b/crates/vcad-typst/src/lib.rs
@@ -5,7 +5,7 @@
 //! export takes a JSON config plus source bytes and returns SVG (renders)
 //! or JSON (data). The pure core lives in this module so it compiles and
 //! tests natively; the `#[wasm_func]` shims are gated to `wasm32` in
-//! [`wasm`].
+//! `wasm`.
 //!
 //! Typst plugins are sandboxed and must be pure — no filesystem, network,
 //! or cross-call state — which these functions already are: string in,

--- a/mecheval/graders/src/fit.rs
+++ b/mecheval/graders/src/fit.rs
@@ -102,7 +102,7 @@ fn aggregate_solid(snap: &EvalSnapshot) -> Option<Solid> {
     Some(iter.fold(first, |acc, s| acc.union(s)))
 }
 
-/// Same as [`aggregate_solid`] but for the candidate snapshot. Pulled
+/// Same as `aggregate_solid` but for the candidate snapshot. Pulled
 /// out so the grader's main loop can build it once and share across
 /// every fit check.
 pub fn aggregate_candidate(snap: &EvalSnapshot) -> Option<Solid> {


### PR DESCRIPTION
## Summary

Importing the [Booster K1 humanoid](https://github.com/BoosterRobotics/booster_assets) (22 DOF, 23 mesh links) surfaced three defects that affect any mesh-based URDF (including the in-repo Unitree G1/Go2 examples):

- **URDF parse**: real-world files pad numeric attributes with whitespace (K1: `ixz=" -0.000001"`); strict serde f64 rejected the whole file. Added trimming deserializers (`ws_f64`/`ws_f64_opt`) for all numeric URDF attributes.
- **vcad-eval**: `MeshImport` nodes (CLI-imported STL by absolute path) evaluated to nothing outside the browser — render/export/info saw zero geometry. Native builds now load the STL from disk (m→mm + URDF scale); wasm is untouched (browser flow already rewrites to `ImportedMesh`).
- **vcad-render**: assembly documents drew every part-def prototype root untransformed at the origin, while the FK-placed instances were silently skipped whenever the part had no BRep (true of every mesh import). Prototype roots are now excluded when instances exist, and instances fall back to `Solid::from_mesh` on the evaluated part-def mesh — same fallback the roots path already had.

Result: `vcad import-urdf K1_22dof.urdf` produces a document that renders FK-placed (standing T-pose, all 23 links) and steps cleanly in `vcad simulate` — arms swing down symmetrically and stop exactly at their URDF limits.

This is groundwork for K1 sim2real; follow-ups (contact/ground plane in the gym path, floating base, effort limits, domain randomization, MCP `import_urdf`) are queued as separate tasks.

## Testing

- `cargo test -p vcad-kernel-urdf -p vcad-eval -p vcad-render` — all green (50 tests)
- `cargo clippy -p vcad-kernel-urdf -p vcad-eval -p vcad-render -- -D warnings` — clean
- Manual: K1 import → front/iso renders verified FK-correct; 240-step passive sim finite with joints respecting limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)