### PR TITLE
Add ground-plane contact to physics simulation

### DIFF
--- a/changelog/entries/2026-07-31-gym-ground-contact.json
+++ b/changelog/entries/2026-07-31-gym-ground-contact.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-31-gym-ground-contact",
+  "version": "0.9.4",
+  "date": "2026-07-31",
+  "category": "feat",
+  "title": "Gym physics gets ground contact",
+  "summary": "Robot simulation now has a configurable ground plane with friction — dropped bodies land and rest instead of falling forever, enabling legged locomotion training.",
+  "features": ["physics", "simulation", "rl"],
+  "mcpTools": ["create_robot_env", "batch_create_envs"]
+}

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use vcad_ir::Document;
 
 use crate::error::PhysicsError;
-use crate::world::PhysicsWorld;
+use crate::world::{GroundConfig, PhysicsWorld};
 
 /// Observation from the robot environment.
 ///
@@ -65,6 +65,8 @@ pub struct RobotEnv {
     initial_doc: Document,
     /// Random seed.
     seed: u64,
+    /// Ground-plane contact configuration, reapplied on every reset.
+    ground: GroundConfig,
 }
 
 impl RobotEnv {
@@ -76,13 +78,19 @@ impl RobotEnv {
     /// * `end_effector_ids` - Instance IDs to track as end effectors
     /// * `dt` - Base simulation timestep in seconds (default: 1/240)
     /// * `substeps` - Number of physics steps per environment step (default: 4)
+    /// * `ground` - Ground-plane contact config. `None` enables the default
+    ///   ground: plane at z = 0, friction 0.8, inelastic. Pass
+    ///   `Some(GroundConfig::disabled())` for the old contact-free dynamics.
     pub fn new(
         doc: Document,
         end_effector_ids: Vec<String>,
         dt: Option<f32>,
         substeps: Option<u32>,
+        ground: Option<GroundConfig>,
     ) -> Result<Self, PhysicsError> {
-        let world = PhysicsWorld::from_document(&doc)?;
+        let ground = ground.unwrap_or_default();
+        let mut world = PhysicsWorld::from_document(&doc)?;
+        world.set_ground(ground);
         let joint_ids = world.joint_ids();
         let actuated_joint_ids = world.actuated_joint_ids();
 
@@ -97,6 +105,7 @@ impl RobotEnv {
             current_step: 0,
             initial_doc: doc,
             seed: 0,
+            ground,
         })
     }
 
@@ -110,6 +119,7 @@ impl RobotEnv {
         // violation (e.g. a non-deterministic bug in PhysicsWorld::from_document).
         self.world = PhysicsWorld::from_document(&self.initial_doc)
             .expect("gym reset: PhysicsWorld::from_document failed on a doc that was valid at construction — this should be unreachable");
+        self.world.set_ground(self.ground);
         self.joint_ids = self.world.joint_ids();
         self.actuated_joint_ids = self.world.actuated_joint_ids();
         self.current_step = 0;
@@ -482,7 +492,7 @@ mod tests {
     #[test]
     fn joint_observation_order_matches_document_order() {
         let doc = create_three_joint_robot_reversed();
-        let env = RobotEnv::new(doc, vec!["link3_inst".to_string()], None, None).unwrap();
+        let env = RobotEnv::new(doc, vec!["link3_inst".to_string()], None, None, None).unwrap();
 
         // The contract: joint_ids() is doc.joints order, not BFS or HashMap
         // order. Before joint_order landed this permuted run-to-run.
@@ -607,6 +617,7 @@ mod tests {
             vec!["tip_inst".to_string(), "arm_inst".to_string()],
             None,
             None,
+            None,
         )
         .unwrap();
 
@@ -658,10 +669,271 @@ mod tests {
         env.step(Action::VelocityTarget(vec![10.0]));
     }
 
+    /// A free 100 mm cube dropped from 1 m plus the mandatory (fixed, and
+    /// therefore contact-exempt) ground instance parked off to the side.
+    fn create_drop_test_doc() -> Document {
+        let mut doc = Document::new();
+        doc.nodes.insert(
+            1,
+            vcad_ir::Node {
+                id: 1,
+                name: Some("anchor".to_string()),
+                op: vcad_ir::CsgOp::Cube {
+                    size: Vec3::new(20.0, 20.0, 20.0),
+                },
+            },
+        );
+        doc.nodes.insert(
+            2,
+            vcad_ir::Node {
+                id: 2,
+                name: Some("crate".to_string()),
+                op: vcad_ir::CsgOp::Cube {
+                    size: Vec3::new(100.0, 100.0, 100.0),
+                },
+            },
+        );
+        let mut part_defs = HashMap::new();
+        for (root, name) in [(1, "anchor"), (2, "crate")] {
+            part_defs.insert(
+                name.to_string(),
+                PartDef {
+                    id: name.to_string(),
+                    name: None,
+                    root,
+                    default_material: None,
+                    inertial: None,
+                },
+            );
+        }
+        doc.part_defs = Some(part_defs);
+        doc.instances = Some(vec![
+            Instance {
+                id: "anchor_inst".to_string(),
+                part_def_id: "anchor".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                transform: Some(vcad_ir::Transform3D {
+                    translation: Vec3::new(1000.0, 0.0, 0.0),
+                    ..Default::default()
+                }),
+                material: None,
+            },
+            Instance {
+                id: "crate_inst".to_string(),
+                part_def_id: "crate".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                // Cube spans z ∈ [0, 100] mm in its own frame; lift it 1 m.
+                transform: Some(vcad_ir::Transform3D {
+                    translation: Vec3::new(0.0, 0.0, 1000.0),
+                    ..Default::default()
+                }),
+                material: None,
+            },
+        ]);
+        doc.joints = Some(std::vec::Vec::new());
+        doc.ground_instance_id = Some("anchor_inst".to_string());
+        doc
+    }
+
+    /// The M0 acceptance test: a box dropped from 1 m must land on the
+    /// ground plane and come to rest — not tunnel through the world.
+    #[test]
+    fn free_box_drop_lands_and_rests() {
+        let doc = create_drop_test_doc();
+        // Default ground: on at z = 0, friction 0.8, inelastic.
+        let mut env = RobotEnv::new(doc, vec!["crate_inst".to_string()], None, None, None).unwrap();
+        env.set_max_steps(100_000);
+
+        let mut min_z = f64::INFINITY;
+        let mut last = env.observe();
+        assert!((last.end_effector_poses[0][2] - 1.0).abs() < 1e-6);
+
+        // 480 env steps × 4 substeps at 1/240 s = 8 s of sim time; the fall
+        // itself takes ~0.45 s.
+        for _ in 0..480 {
+            let (obs, _, _) = env.step(Action::Torque(vec![]));
+            let z = obs.end_effector_poses[0][2];
+            assert!(z.is_finite(), "box pose went non-finite");
+            min_z = min_z.min(z);
+            last = obs;
+        }
+
+        // Never tunneled: the body origin (cube bottom face) may dip a
+        // little below the plane while the solve catches it, but must not
+        // pass through.
+        assert!(
+            min_z > -0.05,
+            "box tunneled through the ground: min z = {min_z} m"
+        );
+        // At rest ON the floor: origin back within a couple of cm of z = 0
+        // (it started at 1 m, so this also proves it actually fell).
+        assert!(
+            last.end_effector_poses[0][2].abs() < 0.03,
+            "box did not come to rest on the floor: final z = {} m",
+            last.end_effector_poses[0][2]
+        );
+    }
+
+    /// The same drop with the ground disabled must fall straight through —
+    /// proving the previous test exercises contact rather than some other
+    /// floor the dynamics grew.
+    #[test]
+    fn free_box_drop_without_ground_falls_forever() {
+        let doc = create_drop_test_doc();
+        let mut env = RobotEnv::new(
+            doc,
+            vec!["crate_inst".to_string()],
+            None,
+            None,
+            Some(crate::world::GroundConfig::disabled()),
+        )
+        .unwrap();
+        env.set_max_steps(100_000);
+        let mut last_z = 1.0;
+        for _ in 0..480 {
+            let (obs, _, _) = env.step(Action::Torque(vec![]));
+            last_z = obs.end_effector_poses[0][2];
+        }
+        assert!(
+            last_z < -1.0,
+            "with ground disabled the box should keep falling, final z = {last_z} m"
+        );
+    }
+
+    /// Fixed base at height with a long pendulum arm: under gravity the arm
+    /// swings down and must come to rest ON the floor instead of swinging
+    /// through it. Also a stability check — a PD position hold is engaged
+    /// while the arm rests against the plane, and nothing may diverge.
+    fn create_pendulum_over_floor() -> Document {
+        let mut doc = Document::new();
+        doc.nodes.insert(
+            1,
+            vcad_ir::Node {
+                id: 1,
+                name: None,
+                op: vcad_ir::CsgOp::Cube {
+                    size: Vec3::new(60.0, 60.0, 60.0),
+                },
+            },
+        );
+        doc.nodes.insert(
+            2,
+            vcad_ir::Node {
+                id: 2,
+                name: None,
+                op: vcad_ir::CsgOp::Cube {
+                    size: Vec3::new(20.0, 20.0, 300.0),
+                },
+            },
+        );
+        let mut part_defs = HashMap::new();
+        for (root, name) in [(1, "post"), (2, "arm")] {
+            part_defs.insert(
+                name.to_string(),
+                PartDef {
+                    id: name.to_string(),
+                    name: None,
+                    root,
+                    default_material: None,
+                    inertial: None,
+                },
+            );
+        }
+        doc.part_defs = Some(part_defs);
+        doc.instances = Some(vec![
+            Instance {
+                id: "post_inst".to_string(),
+                part_def_id: "post".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                // Post top face at z = 200 mm.
+                transform: Some(vcad_ir::Transform3D {
+                    translation: Vec3::new(0.0, 0.0, 140.0),
+                    ..Default::default()
+                }),
+                material: None,
+            },
+            Instance {
+                id: "arm_inst".to_string(),
+                part_def_id: "arm".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                transform: None,
+                material: None,
+            },
+        ]);
+        // Pivot at the post top; the arm's own frame spans z ∈ [0, 300] mm
+        // and hangs from its top end — a 300 mm pendulum from a 200 mm-high
+        // pivot swings well below z = 0.
+        doc.joints = Some(vec![Joint {
+            id: "pivot".to_string(),
+            name: None,
+            parent_instance_id: Some("post_inst".to_string()),
+            child_instance_id: "arm_inst".to_string(),
+            parent_anchor: Vec3::new(0.0, 0.0, 60.0),
+            child_anchor: Vec3::new(10.0, 10.0, 300.0),
+            kind: JointKind::Revolute {
+                axis: Vec3::new(0.0, 1.0, 0.0),
+                limits: None,
+            },
+            // Start horizontal so it has to swing down into the floor.
+            state: 90.0,
+        }]);
+        doc.ground_instance_id = Some("post_inst".to_string());
+        doc
+    }
+
+    #[test]
+    fn pendulum_rests_on_floor_instead_of_swinging_through() {
+        let doc = create_pendulum_over_floor();
+        let mut env = RobotEnv::new(doc, vec!["arm_inst".to_string()], None, None, None).unwrap();
+        env.set_max_steps(100_000);
+
+        // Phase 1: passive swing under gravity. Track the arm's lowest
+        // pose-origin z (the origin is the arm's own frame corner; its
+        // lowest mesh point is what actually touches, so allow the ~20 mm
+        // arm cross-section plus contact slop).
+        let mut min_z = f64::INFINITY;
+        let mut last = env.observe();
+        for _ in 0..600 {
+            let (obs, _, _) = env.step(Action::Torque(vec![0.0]));
+            assert!(obs.joint_positions[0].is_finite());
+            min_z = min_z.min(obs.end_effector_poses[0][2]);
+            last = obs;
+        }
+        // A frictionless-through-floor swing would carry the origin to
+        // roughly -(300 + 200) mm below the pivot at the bottom of the arc.
+        assert!(
+            min_z > -0.06,
+            "arm swung through the floor: min origin z = {min_z} m"
+        );
+        // It ended up resting against the plane (not oscillating wildly).
+        assert!(
+            last.joint_velocities[0].abs() < 20.0,
+            "arm still moving fast after 10 s: {} deg/s",
+            last.joint_velocities[0]
+        );
+
+        // Phase 2: engage a PD hold at the resting pose while in contact —
+        // the explicit integrator must stay finite and the arm must stay
+        // above the floor.
+        let hold = last.joint_positions[0];
+        for _ in 0..240 {
+            let (obs, _, _) = env.step(Action::PositionTarget(vec![hold]));
+            assert!(
+                obs.joint_positions[0].is_finite() && obs.joint_velocities[0].is_finite(),
+                "PD hold in contact diverged"
+            );
+            assert!(obs.end_effector_poses[0][2] > -0.06);
+        }
+    }
+
     #[test]
     fn test_env_creation() {
         let doc = create_simple_robot();
-        let env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None).unwrap();
+        let env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None, None).unwrap();
 
         assert_eq!(env.num_joints(), 2);
         assert_eq!(env.action_dim(), 2);
@@ -670,7 +942,7 @@ mod tests {
     #[test]
     fn test_env_reset() {
         let doc = create_simple_robot();
-        let mut env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None).unwrap();
+        let mut env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None, None).unwrap();
 
         let obs = env.reset();
         assert_eq!(obs.joint_positions.len(), 2);
@@ -681,7 +953,7 @@ mod tests {
     #[test]
     fn test_env_step() {
         let doc = create_simple_robot();
-        let mut env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None).unwrap();
+        let mut env = RobotEnv::new(doc, vec!["link2_inst".to_string()], None, None, None).unwrap();
 
         env.reset();
 

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -53,4 +53,4 @@ pub use diff::{
 };
 pub use error::PhysicsError;
 pub use gym::{Action, Observation, RobotEnv};
-pub use world::{JointState, PhysicsWorld};
+pub use world::{GroundConfig, JointState, PhysicsWorld};

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use phyz::aba_with_external_forces;
 use phyz::math::{Mat3, Quat, SpatialInertia, SpatialTransform, Vec3};
 use phyz::model::{Model, ModelBuilder, State};
-use phyz::{forward_kinematics, Geometry};
+use phyz::{
+    forward_kinematics, Collision, ContactMaterial, ContactProblem, ContactSolverConfig, Geometry,
+};
 use vcad_ir::{Document, InertialProperties, JointKind};
 
 use crate::colliders::{estimate_mass, mesh_to_collider, ColliderStrategy};
@@ -14,6 +16,51 @@ use crate::joints::{
     convert_state_from_physics, convert_state_to_physics, joint_ndof, vcad_joint_to_phyz,
     MotorMode, MotorTarget,
 };
+
+/// Ground-plane contact configuration for a physics world.
+///
+/// The ground is an infinite horizontal plane at `z = height` (metres,
+/// world frame). When enabled, every *movable* body's collision geometry is
+/// tested against it each substep and resolved through phyz's convex contact
+/// solver (Coulomb friction cone, restitution as a target normal velocity).
+/// Bodies welded to the world through nothing but Fixed joints are skipped —
+/// their contacts could exert no force and would only pad the Delassus
+/// system.
+///
+/// Body-body (robot self-) collision is not handled here yet.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GroundConfig {
+    /// Whether ground contact is active.
+    pub enabled: bool,
+    /// Ground plane height, metres in the world frame (plane is z = height).
+    pub height: f64,
+    /// Coulomb friction coefficient of the ground.
+    pub friction: f64,
+    /// Restitution (0 = inelastic rest, 1 = elastic bounce).
+    pub restitution: f64,
+}
+
+impl Default for GroundConfig {
+    /// Ground on at z = 0 with friction 0.8 and inelastic contact.
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            height: 0.0,
+            friction: 0.8,
+            restitution: 0.0,
+        }
+    }
+}
+
+impl GroundConfig {
+    /// A disabled ground plane — the pre-contact, contact-free dynamics.
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            ..Self::default()
+        }
+    }
+}
 
 /// Per-instance world-frame pose: `(position_m, quaternion_wxyz)`.
 pub type Pose = ([f64; 3], [f64; 4]);
@@ -64,6 +111,15 @@ pub struct PhysicsWorld {
     // the axis-alignment rotation and anchored at the child anchor. Identity
     // for ground/free bodies. Needed to report part poses to callers.
     body_part_frames: Vec<(Mat3, Vec3)>,
+
+    // Ground-plane contact configuration. Disabled by default at this level;
+    // RobotEnv turns it on for gym use.
+    ground: GroundConfig,
+
+    // Per-body collision geometry used for ground contact, `None` for bodies
+    // that cannot move (welded to the world through Fixed joints only) —
+    // contacts on those would contribute empty Jacobian rows.
+    contact_geometries: Vec<Option<Geometry>>,
 }
 
 impl PhysicsWorld {
@@ -340,6 +396,23 @@ impl PhysicsWorld {
             }
         }
 
+        // A body can move iff some joint between it and the world root has a
+        // degree of freedom. Only movable bodies get contact geometry — the
+        // fixed base (and anything welded to it) can't respond to contact
+        // impulses, so testing it against the ground is pure waste.
+        let mut movable = vec![false; model.bodies.len()];
+        for i in 0..model.bodies.len() {
+            let body = &model.bodies[i];
+            let own_dof = model.joints[body.joint_idx].ndof() > 0;
+            movable[i] = own_dof || (body.parent >= 0 && movable[body.parent as usize]);
+        }
+        let contact_geometries: Vec<Option<Geometry>> = model
+            .bodies
+            .iter()
+            .enumerate()
+            .map(|(i, b)| if movable[i] { b.geometry.clone() } else { None })
+            .collect();
+
         let state = model.default_state();
 
         // Pre-compute joint DOF offsets
@@ -362,6 +435,8 @@ impl PhysicsWorld {
             joint_q_offsets,
             joint_v_offsets,
             body_part_frames,
+            ground: GroundConfig::disabled(),
+            contact_geometries,
         };
 
         // Set initial joint states (zero-dof joints have no q slot to write)
@@ -384,7 +459,25 @@ impl PhysicsWorld {
         Ok(world)
     }
 
+    /// Configure the ground plane. Takes effect on the next [`Self::step`].
+    pub fn set_ground(&mut self, ground: GroundConfig) {
+        self.ground = ground;
+    }
+
+    /// Current ground-plane configuration.
+    pub fn ground(&self) -> GroundConfig {
+        self.ground
+    }
+
     /// Step the physics simulation by dt seconds.
+    ///
+    /// With the ground enabled ([`Self::set_ground`]) the step is
+    /// FK → ground contact detection → ABA → convex contact solve at the
+    /// velocity level → joint-aware semi-implicit Euler, mirroring phyz's
+    /// `Simulator::step_with_contacts`. The velocity-level impulse solve
+    /// (rather than a penalty force) keeps the explicit integrator stable at
+    /// gym timesteps: contact can only remove approach velocity, never
+    /// inject energy.
     pub fn step(&mut self, dt: f32) {
         // Temporarily set the model timestep
         let original_dt = self.model.dt;
@@ -393,27 +486,164 @@ impl PhysicsWorld {
         // Apply PD motor torques to state.ctrl
         self.apply_motor_torques();
 
-        // Step: ABA forward dynamics + semi-implicit Euler integration
         {
-            let qdd = aba_with_external_forces(&self.model, &self.state, None);
-
             let dt = self.model.dt;
             let nv = self.state.v.len();
-            for i in 0..nv {
-                self.state.v[i] += qdd[i] * dt;
+
+            // Contact detection reads world-frame body transforms — refresh
+            // them so contacts are found where the bodies are *now*, not
+            // where the last caller left body_xform.
+            let (xforms, _) = forward_kinematics(&self.model, &self.state);
+            self.state.body_xform = xforms;
+
+            // Free velocity: where the system lands after this step with
+            // every force except contact (ABA reads state.ctrl internally).
+            let qdd = aba_with_external_forces(&self.model, &self.state, None);
+            let free_v = &self.state.v + &(&qdd * dt);
+
+            let contacts = if self.ground.enabled {
+                self.ground_contacts()
+            } else {
+                Vec::new()
+            };
+
+            if contacts.is_empty() {
+                self.state.v = free_v;
+            } else {
+                // Contact solve: all contacts coupled through the Delassus
+                // operator, Coulomb friction disc with stiction.
+                let material = ContactMaterial {
+                    friction: self.ground.friction,
+                    restitution: self.ground.restitution,
+                    ..ContactMaterial::default()
+                };
+                let config = ContactSolverConfig::simulation();
+                let mut asm = phyz::contact::assemble(
+                    &self.model,
+                    &self.state,
+                    &contacts,
+                    &[material],
+                    &free_v,
+                    &config,
+                );
+                // Capped Baumgarte stabilization: bias the normal target
+                // velocity to push bodies out of penetration deeper than the
+                // slop, so a landed body settles near flush instead of
+                // freezing at its impact-frame penetration. The cap bounds
+                // the energy the bias can inject.
+                const SLOP_M: f64 = 0.002;
+                const BETA: f64 = 0.2;
+                const MAX_PUSH_M_S: f64 = 0.1;
+                for (ci, c) in contacts.iter().enumerate() {
+                    let push =
+                        (BETA * (c.penetration_depth - SLOP_M) / dt).clamp(0.0, MAX_PUSH_M_S);
+                    asm.problem.free_velocity[3 * ci] -= push;
+                }
+                let impulses = solve_contacts_pgs(&asm.problem);
+                // v' = v_free + M⁻¹ Jᵀ f.
+                self.state.v = &free_v + &asm.velocity_delta(&impulses);
             }
 
-            let nq = self.state.q.len();
-            for i in 0..nq {
-                self.state.q[i] += self.state.v[i.min(nv - 1)] * dt;
-            }
+            // Velocity is already updated; integrate positions only. The
+            // joint-aware integrator is required here: a flat `q += v·dt`
+            // mixes body angular velocity into the position slots of Free
+            // (floating-base) joints.
+            let zero_qdd = vec![0.0; nv];
+            phyz::rigid::semi_implicit_euler(&self.model, &mut self.state, &zero_qdd, dt);
 
             self.enforce_joint_limits();
 
-            forward_kinematics(&self.model, &self.state);
+            let (xforms, _) = forward_kinematics(&self.model, &self.state);
+            self.state.body_xform = xforms;
         }
 
         self.model.dt = original_dt;
+    }
+
+    /// Contacts between movable bodies' collision geometry and the ground
+    /// plane at `z = self.ground.height`.
+    ///
+    /// This intentionally does not use `phyz::find_ground_contacts`: that
+    /// routine multiplies vertices by `body_xform.rot`, but `body_xform` is
+    /// the world→body Plücker rotation `E` (`p_body = E (p − r)`), so
+    /// body→world needs `Eᵀ` — for any body whose frame is rotated (every
+    /// vcad joint whose axis isn't already Z) it places the candidates
+    /// wrongly and a swinging link passes straight through the floor. It
+    /// also truncates the manifold by depth *before* deduplicating, and
+    /// vcad's tessellated colliders duplicate each corner vertex per
+    /// incident face, so a flat box impact could spend the whole manifold
+    /// budget on copies of a single corner and lose its support polygon.
+    fn ground_contacts(&self) -> Vec<Collision> {
+        // Same manifold cap as phyz_collision::MAX_MANIFOLD_POINTS.
+        const MAX_POINTS: usize = 4;
+        let h = self.ground.height;
+        let mut contacts = Vec::new();
+
+        for (i, geom) in self.contact_geometries.iter().enumerate() {
+            let Some(geom) = geom else { continue };
+            let xform = &self.state.body_xform[i];
+            let (pos, e_t) = (xform.pos, xform.rot.transpose());
+            if !(pos.x.is_finite() && pos.y.is_finite() && pos.z.is_finite()) {
+                continue;
+            }
+
+            // World-frame candidate support points.
+            let candidates: Vec<Vec3> = match geom {
+                Geometry::Mesh { vertices, .. } => {
+                    vertices.iter().map(|v| e_t.mul_vec(*v) + pos).collect()
+                }
+                Geometry::Box { half_extents } => {
+                    let he = half_extents;
+                    let mut v = Vec::with_capacity(8);
+                    for sx in [-1.0, 1.0] {
+                        for sy in [-1.0, 1.0] {
+                            for sz in [-1.0, 1.0] {
+                                v.push(
+                                    e_t.mul_vec(Vec3::new(sx * he.x, sy * he.y, sz * he.z)) + pos,
+                                );
+                            }
+                        }
+                    }
+                    v
+                }
+                Geometry::Sphere { radius } => {
+                    vec![pos - Vec3::new(0.0, 0.0, *radius)]
+                }
+                // Colliders built by this crate are Mesh or Box; anything
+                // else has no ground support here yet.
+                _ => continue,
+            };
+
+            // Penetrating points, deduplicated (tessellated meshes repeat
+            // each corner per incident face), deepest first, capped.
+            let mut hits: Vec<(f64, Vec3)> = Vec::new();
+            'cand: for p in candidates {
+                if !p.z.is_finite() || p.z >= h {
+                    continue;
+                }
+                for (_, q) in &hits {
+                    if (p - *q).norm() < 1e-9 {
+                        continue 'cand;
+                    }
+                }
+                hits.push((h - p.z, p));
+            }
+            hits.sort_by(|a, b| b.0.total_cmp(&a.0));
+            hits.truncate(MAX_POINTS);
+
+            for (depth, p) in hits {
+                contacts.push(Collision {
+                    body_i: i,
+                    body_j: usize::MAX, // ground is not a body
+                    // Midsurface between the vertex and the plane.
+                    contact_point: Vec3::new(p.x, p.y, h - depth * 0.5),
+                    contact_normal: Vec3::new(0.0, 0.0, 1.0),
+                    penetration_depth: depth,
+                });
+            }
+        }
+
+        contacts
     }
 
     /// Clamp single-DOF joints to their limits after integration.
@@ -956,6 +1186,79 @@ fn euler_to_mat3(rx: f64, ry: f64, rz: f64) -> Mat3 {
         cx * sy * sz + sx * cz,
         cx * cy,
     )
+}
+
+/// Scalar projected Gauss-Seidel over an assembled contact problem.
+///
+/// Replaces `phyz::solve_contacts` for the gym step: phyz's staged
+/// per-contact block solve drops the within-block normal↔tangential
+/// coupling (its residual excludes the contact's own impulse, then solves
+/// the normal from `A_nn` alone and the tangential 2×2 without the
+/// `A_tn·f_n` term). For a multi-corner manifold — where a normal impulse
+/// at one corner induces tangential velocity at the others through the
+/// body's rotation — its fixed point satisfies the wrong equations and a
+/// 4 m/s box impact bounces off the floor at 25 m/s. Verified empirically:
+/// same assembly, phyz's solve diverges, this one rests.
+///
+/// This is the textbook sequential-impulse iteration on the PSD Delassus
+/// operator: each scalar row relaxed against the *full* current residual,
+/// normal impulses projected to `≥ 0`, tangential pairs clamped to the
+/// isotropic friction disc `‖f_t‖ ≤ μ f_n`.
+fn solve_contacts_pgs(problem: &ContactProblem) -> Vec<Vec3> {
+    let n = problem.n;
+    let dim = 3 * n;
+    let a = &problem.delassus;
+    let at = |i: usize, j: usize| a[i * dim + j];
+    let mut f = vec![0.0f64; dim];
+
+    for _ in 0..200 {
+        let mut max_move: f64 = 0.0;
+        for c in 0..n {
+            let base = 3 * c;
+
+            // Normal row: full residual over every impulse but its own.
+            let mut r = problem.free_velocity[base];
+            for (j, fj) in f.iter().enumerate() {
+                if j != base {
+                    r += at(base, j) * fj;
+                }
+            }
+            let a_nn = at(base, base).max(1e-12);
+            let f_n = (-r / a_nn).max(0.0);
+            max_move = max_move.max((f_n - f[base]).abs());
+            f[base] = f_n;
+
+            // Tangential rows, relaxed one scalar at a time, then projected
+            // onto the friction disc the fresh normal admits.
+            for t in 1..3 {
+                let i = base + t;
+                let mut r = problem.free_velocity[i];
+                for (j, fj) in f.iter().enumerate() {
+                    if j != i {
+                        r += at(i, j) * fj;
+                    }
+                }
+                let a_ii = at(i, i).max(1e-12);
+                let f_t = -r / a_ii;
+                max_move = max_move.max((f_t - f[i]).abs());
+                f[i] = f_t;
+            }
+            let limit = problem.rows[c].mu * f[base];
+            let t_norm = (f[base + 1] * f[base + 1] + f[base + 2] * f[base + 2]).sqrt();
+            if t_norm > limit {
+                let s = if t_norm > 0.0 { limit / t_norm } else { 0.0 };
+                f[base + 1] *= s;
+                f[base + 2] *= s;
+            }
+        }
+        if max_move < 1e-10 {
+            break;
+        }
+    }
+
+    (0..n)
+        .map(|c| Vec3::new(f[3 * c], f[3 * c + 1], f[3 * c + 2]))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -1778,4 +1778,75 @@ mod tests {
             }
         }
     }
+
+    /// Movability propagation keys off `Joint::ndof() > 0`, so a body with
+    /// no parent (added via `add_free_body`) is movable only because phyz
+    /// gives a free joint 6 DOF. If that contract ever changes, free bodies
+    /// silently lose their contact geometry and fall through the floor — a
+    /// failure that surfaces as a confusing tunneling assertion elsewhere.
+    /// Pin it here so the breakage names itself.
+    #[test]
+    fn phyz_free_joint_has_dof_so_unparented_bodies_are_movable() {
+        let free = phyz::model::Joint::free(phyz::math::SpatialTransform::identity());
+        assert_eq!(
+            free.ndof(),
+            6,
+            "phyz free joint no longer reports 6 DOF; PhysicsWorld's movability \
+             propagation would exclude free bodies from ground contact"
+        );
+
+        // End-to-end: an instance with no joints becomes a free body and must
+        // come out of construction with contact geometry attached.
+        let mut doc = Document::new();
+        doc.nodes.insert(
+            1,
+            vcad_ir::Node {
+                id: 1,
+                name: None,
+                op: vcad_ir::CsgOp::Cube {
+                    size: VcadVec3::new(100.0, 100.0, 100.0),
+                },
+            },
+        );
+        let mut part_defs = HashMap::new();
+        for id in ["crate", "anchor"] {
+            part_defs.insert(
+                id.to_string(),
+                PartDef {
+                    id: id.to_string(),
+                    name: None,
+                    root: 1,
+                    default_material: None,
+                    inertial: None,
+                },
+            );
+        }
+        doc.part_defs = Some(part_defs);
+        doc.instances = Some(vec![
+            Instance {
+                id: "anchor_inst".to_string(),
+                part_def_id: "anchor".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                transform: None,
+                material: None,
+            },
+            Instance {
+                id: "crate_inst".to_string(),
+                part_def_id: "crate".to_string(),
+                name: None,
+                tags: std::vec::Vec::new(),
+                transform: None,
+                material: None,
+            },
+        ]);
+        doc.joints = Some(std::vec::Vec::new());
+        doc.ground_instance_id = Some("anchor_inst".to_string());
+
+        let world = PhysicsWorld::from_document(&doc).unwrap();
+        assert!(
+            world.contact_geometries.iter().any(|g| g.is_some()),
+            "free body was built without contact geometry — it can never touch the ground"
+        );
+    }
 }

--- a/crates/vcad-kernel-physics/tests/unitree.rs
+++ b/crates/vcad-kernel-physics/tests/unitree.rs
@@ -4,7 +4,7 @@
 
 use std::path::PathBuf;
 
-use vcad_kernel_physics::PhysicsWorld;
+use vcad_kernel_physics::{Action, GroundConfig, PhysicsWorld, RobotEnv};
 
 fn examples_dir() -> PathBuf {
     // CARGO_MANIFEST_DIR points at crates/vcad-kernel-physics; examples/ lives
@@ -119,4 +119,73 @@ fn unitree_go2_loads_and_steps() {
         }
     }
     assert_finite_states(&mut world, 60, "Go2");
+}
+
+/// The gym path with ground contact enabled on a real humanoid: PD position
+/// hold at the zero pose while the legs interact with a ground plane placed
+/// at knee height, at the documented near-divergence regime (1/240 s × 4
+/// substeps). The URDF base link is the fixed root here, so "standing" is a
+/// stability claim, not a balance claim: with contact impulses acting on a
+/// 23-DOF articulated chain every substep, nothing may go non-finite and no
+/// link may be driven through the floor.
+#[test]
+fn unitree_g1_pd_hold_with_ground_contact_stays_finite() {
+    let urdf_path = examples_dir().join("unitree-g1.urdf");
+    let doc = vcad_kernel_urdf::read_urdf(&urdf_path).expect("parse unitree-g1.urdf");
+    let instance_ids: Vec<String> = doc
+        .instances
+        .as_ref()
+        .expect("instances")
+        .iter()
+        .map(|i| i.id.clone())
+        .collect();
+
+    // Find the lowest body origin so the plane can be placed where it
+    // actually intersects the dangling legs.
+    let mut probe = PhysicsWorld::from_document(&doc).expect("build PhysicsWorld");
+    let n_actuated = probe.actuated_joint_ids().len();
+    let zero_q = vec![0.0; n_actuated];
+    let poses = probe.forward_kinematics_at(&zero_q).expect("fk");
+    let min_z = poses
+        .values()
+        .map(|(p, _)| p[2])
+        .fold(f64::INFINITY, f64::min);
+    assert!(
+        min_z.is_finite() && min_z < 0.0,
+        "G1 legs should hang below the base"
+    );
+
+    let ground = GroundConfig {
+        enabled: true,
+        height: min_z + 0.05,
+        friction: 0.8,
+        restitution: 0.0,
+    };
+    let mut env =
+        RobotEnv::new(doc, instance_ids.clone(), None, None, Some(ground)).expect("RobotEnv");
+
+    let hold = vec![0.0; env.action_dim()];
+    for _ in 0..120 {
+        let (obs, _, _) = env.step(Action::PositionTarget(hold.clone()));
+        for (i, v) in obs.joint_velocities.iter().enumerate() {
+            assert!(
+                v.is_finite(),
+                "joint {i} velocity non-finite under PD+contact"
+            );
+        }
+        for (i, pose) in obs.end_effector_poses.iter().enumerate() {
+            assert!(
+                pose.iter().all(|c| c.is_finite()),
+                "instance {} pose non-finite",
+                instance_ids[i]
+            );
+            assert!(
+                pose[2] > ground.height - 0.2,
+                "instance {} driven through the floor: z = {} (floor {})",
+                instance_ids[i],
+                pose[2],
+                ground.height
+            );
+        }
+    }
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -4307,18 +4307,36 @@ impl PhysicsSim {
     /// * `end_effector_ids` - Array of instance IDs to track as end effectors
     /// * `dt` - Simulation timestep in seconds (default: 1/240)
     /// * `substeps` - Number of physics substeps per step (default: 4)
+    /// * `ground_enabled` - Ground-plane contact at z = `ground_height` (default: true)
+    /// * `ground_height` - Ground plane height in meters (default: 0)
+    /// * `ground_friction` - Ground Coulomb friction coefficient (default: 0.8)
+    /// * `ground_restitution` - Ground restitution, 0 = inelastic (default: 0)
     #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         doc_json: &str,
         end_effector_ids: Vec<String>,
         dt: Option<f32>,
         substeps: Option<u32>,
+        ground_enabled: Option<bool>,
+        ground_height: Option<f64>,
+        ground_friction: Option<f64>,
+        ground_restitution: Option<f64>,
     ) -> Result<PhysicsSim, JsError> {
         let doc = vcad_ir::Document::from_json(doc_json)
             .map_err(|e| JsError::new(&format!("Invalid document JSON: {}", e)))?;
 
-        let env = vcad_kernel_physics::RobotEnv::new(doc, end_effector_ids, dt, substeps)
-            .map_err(|e| JsError::new(&format!("Failed to create physics env: {}", e)))?;
+        let defaults = vcad_kernel_physics::GroundConfig::default();
+        let ground = vcad_kernel_physics::GroundConfig {
+            enabled: ground_enabled.unwrap_or(defaults.enabled),
+            height: ground_height.unwrap_or(defaults.height),
+            friction: ground_friction.unwrap_or(defaults.friction),
+            restitution: ground_restitution.unwrap_or(defaults.restitution),
+        };
+
+        let env =
+            vcad_kernel_physics::RobotEnv::new(doc, end_effector_ids, dt, substeps, Some(ground))
+                .map_err(|e| JsError::new(&format!("Failed to create physics env: {}", e)))?;
 
         web_sys::console::log_1(
             &format!("[WASM] PhysicsSim created with {} joints", env.num_joints()).into(),

--- a/mecheval/graders/src/suite_c.rs
+++ b/mecheval/graders/src/suite_c.rs
@@ -358,7 +358,16 @@ pub fn check_task_success(
 
     // Build a fresh RobotEnv (RobotEnv re-builds its own PhysicsWorld
     // internally, so the snapshot's world is unaffected).
-    let mut env = match RobotEnv::new(snap.doc.clone(), vec![tip_id.clone()], None, Some(4)) {
+    // Ground contact disabled: Suite C grades pure articulated dynamics of a
+    // fixed-base reacher; an implicit floor at z=0 would perturb rollouts of
+    // arms that dip below the base plane.
+    let mut env = match RobotEnv::new(
+        snap.doc.clone(),
+        vec![tip_id.clone()],
+        None,
+        Some(4),
+        Some(vcad_kernel_physics::GroundConfig::disabled()),
+    ) {
         Ok(e) => e,
         Err(e) => {
             return (

--- a/packages/docs/content/architecture/kernel-features.mdx
+++ b/packages/docs/content/architecture/kernel-features.mdx
@@ -259,7 +259,7 @@ Honesty: the luminance edge-stopping weight is scaled by the estimator's own var
 
 ### Physics
 
-`vcad-kernel-physics` converts BRep assemblies into articulated rigid-body simulations (phyz): revolute, prismatic, cylindrical, ball, and fixed joints, with a gym-style `reset()` / `step(action)` / `observe()` interface for reinforcement learning — actions as torques, position targets, or velocity targets.
+`vcad-kernel-physics` converts BRep assemblies into articulated rigid-body simulations (phyz): revolute, prismatic, cylindrical, ball, and fixed joints, with a gym-style `reset()` / `step(action)` / `observe()` interface for reinforcement learning — actions as torques, position targets, or velocity targets. The step includes ground contact: each part's convex collision geometry is tested against a configurable ground plane (height, Coulomb friction, restitution — on by default at z = 0) and resolved with a velocity-level projected Gauss-Seidel impulse solve over the coupled contact manifold, so dropped bodies land and rest and legged assemblies can push against a floor instead of falling through the world.
 
 ### Differentiable Geometry
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -319,6 +319,7 @@ export type {
   PhysicsObservation,
   PhysicsStepResult,
   PhysicsEnvOptions,
+  PhysicsGroundOptions,
   ActionType as PhysicsActionType,
 } from "./physics.js";
 

--- a/packages/engine/src/physics.ts
+++ b/packages/engine/src/physics.ts
@@ -33,6 +33,18 @@ export interface PhysicsStepResult {
 /** Action types for controlling joints */
 export type ActionType = "torque" | "position" | "velocity";
 
+/** Ground-plane contact configuration for a physics environment. */
+export interface PhysicsGroundOptions {
+  /** Whether ground contact is active (default: true) */
+  enabled?: boolean;
+  /** Ground plane height in meters — the plane is z = height (default: 0) */
+  height?: number;
+  /** Coulomb friction coefficient of the ground (default: 0.8) */
+  friction?: number;
+  /** Restitution: 0 = inelastic rest, 1 = elastic bounce (default: 0) */
+  restitution?: number;
+}
+
 /** Options for creating a physics environment */
 export interface PhysicsEnvOptions {
   /** Instance IDs to track as end effectors */
@@ -43,6 +55,12 @@ export interface PhysicsEnvOptions {
   substeps?: number;
   /** Maximum episode length (default: 1000) */
   maxSteps?: number;
+  /**
+   * Ground-plane contact. Defaults to enabled at z = 0 with friction 0.8.
+   * A kernel WASM predating ground contact ignores these extra constructor
+   * arguments and runs contact-free, as before.
+   */
+  ground?: PhysicsGroundOptions;
 }
 
 /**
@@ -147,11 +165,29 @@ export class PhysicsEnv {
     }
 
     const docJson = JSON.stringify(document);
-    const sim = new module.PhysicsSim(
+    // The ground-config arguments postdate some shipped kernel builds; the
+    // structural cast keeps typecheck green against a checked-in .d.ts that
+    // predates them, and an older WASM simply ignores the extras (running
+    // contact-free, its previous behavior).
+    const Sim = module.PhysicsSim as unknown as new (
+      docJson: string,
+      endEffectorIds: string[],
+      dt: number | null,
+      substeps: number | null,
+      groundEnabled?: boolean | null,
+      groundHeight?: number | null,
+      groundFriction?: number | null,
+      groundRestitution?: number | null,
+    ) => WasmPhysicsSim;
+    const sim = new Sim(
       docJson,
       options.endEffectorIds,
       options.dt ?? null,
       options.substeps ?? null,
+      options.ground?.enabled ?? null,
+      options.ground?.height ?? null,
+      options.ground?.friction ?? null,
+      options.ground?.restitution ?? null,
     );
 
     if (options.maxSteps) {

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -7010,7 +7010,7 @@
   {
     "name": "create_robot_env",
     "title": "Create Robot Env",
-    "description": "Create a physics simulation environment from a vcad assembly. Session-first: pass the `document_id` of the assembly already open — the env binds to that same session, so there is no IR round-trip and the sim can't run against a stale copy. Inline `document` IR is the stateless fallback; exactly one of the two is required. Returns env_id (for gym_step / gym_reset / gym_observe / gym_close) and document_id (what the replay viewer and the other session tools bind to). Mounts the inline 3D viewer with a play button — gym_step rollouts replay right in the chat.",
+    "description": "Create a physics simulation environment from a vcad assembly. Session-first: pass the `document_id` of the assembly already open — the env binds to that same session, so there is no IR round-trip and the sim can't run against a stale copy. Inline `document` IR is the stateless fallback; exactly one of the two is required. Returns env_id (for gym_step / gym_reset / gym_observe / gym_close) and document_id (what the replay viewer and the other session tools bind to). A ground plane at z = 0 (friction 0.8) is on by default, so dropped bodies land and legged assemblies can touch a floor — tune or disable it via the ground_* params. Mounts the inline 3D viewer with a play button — gym_step rollouts replay right in the chat.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -7040,6 +7040,22 @@
         "max_steps": {
           "type": "number",
           "description": "Maximum episode length (default: 1000)"
+        },
+        "ground_enabled": {
+          "type": "boolean",
+          "description": "Ground-plane contact between robot collision shapes and a horizontal plane at z = ground_height. Default: true. Set false for the old contact-free dynamics (bodies fall forever)."
+        },
+        "ground_height": {
+          "type": "number",
+          "description": "Ground plane height in meters (default: 0)"
+        },
+        "ground_friction": {
+          "type": "number",
+          "description": "Ground Coulomb friction coefficient (default: 0.8)"
+        },
+        "ground_restitution": {
+          "type": "number",
+          "description": "Ground restitution: 0 = inelastic rest, 1 = elastic bounce (default: 0)"
         }
       },
       "required": [
@@ -7499,6 +7515,22 @@
         "max_steps": {
           "type": "number",
           "description": "Maximum episode length (default: 1000)"
+        },
+        "ground_enabled": {
+          "type": "boolean",
+          "description": "Ground-plane contact between robot collision shapes and a horizontal plane at z = ground_height. Default: true. Set false for the old contact-free dynamics (bodies fall forever)."
+        },
+        "ground_height": {
+          "type": "number",
+          "description": "Ground plane height in meters (default: 0)"
+        },
+        "ground_friction": {
+          "type": "number",
+          "description": "Ground Coulomb friction coefficient (default: 0.8)"
+        },
+        "ground_restitution": {
+          "type": "number",
+          "description": "Ground restitution: 0 = inelastic rest, 1 = elastic bounce (default: 0)"
         }
       },
       "required": [

--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -124,6 +124,57 @@ const INLINE_DOC_DESC =
   "(e.g. a cold serverless instance). Exactly one of `document_id` or " +
   "`document` must be given.";
 
+/** Shared ground-plane schema fragment for the two env-creating tools. */
+const GROUND_SCHEMA_PROPS = {
+  ground_enabled: {
+    type: "boolean" as const,
+    description:
+      "Ground-plane contact between robot collision shapes and a horizontal " +
+      "plane at z = ground_height. Default: true. Set false for the old " +
+      "contact-free dynamics (bodies fall forever).",
+  },
+  ground_height: {
+    type: "number" as const,
+    description: "Ground plane height in meters (default: 0)",
+  },
+  ground_friction: {
+    type: "number" as const,
+    description: "Ground Coulomb friction coefficient (default: 0.8)",
+  },
+  ground_restitution: {
+    type: "number" as const,
+    description:
+      "Ground restitution: 0 = inelastic rest, 1 = elastic bounce (default: 0)",
+  },
+};
+
+/** Ground-config args shared by create_robot_env and batch_create_envs. */
+interface GroundArgs {
+  ground_enabled?: boolean;
+  ground_height?: number;
+  ground_friction?: number;
+  ground_restitution?: number;
+}
+
+/** Fold the flat ground_* args into the engine's ground options, or undefined
+ *  when none were passed (the engine then applies its own defaults). */
+function resolveGroundOptions(args: GroundArgs) {
+  if (
+    args.ground_enabled === undefined &&
+    args.ground_height === undefined &&
+    args.ground_friction === undefined &&
+    args.ground_restitution === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    enabled: args.ground_enabled,
+    height: args.ground_height,
+    friction: args.ground_friction,
+    restitution: args.ground_restitution,
+  };
+}
+
 const SESSION_DOC_DESC =
   "Session id of the assembly to simulate (from open_document / " +
   "create_cad_loon). Preferred: the env binds to this same session, so no " +
@@ -262,6 +313,7 @@ export const createRobotEnvSchema = {
       type: "number" as const,
       description: "Maximum episode length (default: 1000)",
     },
+    ...GROUND_SCHEMA_PROPS,
   },
   required: ["end_effector_ids"],
 };
@@ -334,7 +386,7 @@ export async function createRobotEnv(input: unknown): Promise<GymResult> {
     dt?: number;
     substeps?: number;
     max_steps?: number;
-  };
+  } & GroundArgs;
 
   // Check if physics is available
   const available = await isPhysicsAvailable();
@@ -365,6 +417,7 @@ export async function createRobotEnv(input: unknown): Promise<GymResult> {
       dt: args.dt,
       substeps: args.substeps,
       maxSteps: args.max_steps,
+      ground: resolveGroundOptions(args),
     });
 
     simulations.set(envId, env);
@@ -422,6 +475,15 @@ export async function createRobotEnv(input: unknown): Promise<GymResult> {
       dt: args.dt ?? 1 / 240,
       substeps: args.substeps ?? 4,
       max_steps: args.max_steps ?? 1000,
+      // Ground-contact contract, echoed so the caller knows there is a
+      // floor: robot collision shapes rest on the plane z = ground_height
+      // instead of falling forever.
+      ground: {
+        enabled: args.ground_enabled ?? true,
+        height: args.ground_height ?? 0,
+        friction: args.ground_friction ?? 0.8,
+        restitution: args.ground_restitution ?? 0,
+      },
     };
 
     return {
@@ -650,6 +712,7 @@ export const batchCreateEnvsSchema = {
       type: "number" as const,
       description: "Maximum episode length (default: 1000)",
     },
+    ...GROUND_SCHEMA_PROPS,
   },
   required: ["n_envs", "end_effector_ids"],
 };
@@ -701,7 +764,7 @@ export async function batchCreateEnvs(input: unknown): Promise<GymResult> {
     dt?: number;
     substeps?: number;
     max_steps?: number;
-  };
+  } & GroundArgs;
 
   const available = await isPhysicsAvailable();
   if (!available) {
@@ -729,6 +792,7 @@ export async function batchCreateEnvs(input: unknown): Promise<GymResult> {
       dt: args.dt,
       substeps: args.substeps,
       maxSteps: args.max_steps,
+      ground: resolveGroundOptions(args),
     };
 
     // Create N environments in parallel
@@ -885,6 +949,8 @@ export const toolDefs: ToolDef[] = [
       "one of the two is required. " +
       "Returns env_id (for gym_step / gym_reset / gym_observe / gym_close) and " +
       "document_id (what the replay viewer and the other session tools bind to). " +
+      "A ground plane at z = 0 (friction 0.8) is on by default, so dropped bodies land " +
+      "and legged assemblies can touch a floor — tune or disable it via the ground_* params. " +
       "Mounts the inline 3D viewer with a play button — gym_step rollouts replay right in the chat.",
     inputSchema: createRobotEnvSchema,
     handler: (a) => createRobotEnv(a),


### PR DESCRIPTION
## Summary

Adds configurable ground-plane contact to the physics simulation, enabling bodies to rest on a horizontal plane instead of falling forever. This is essential for legged locomotion training and general physics realism in gym environments.

## Key Changes

- **Ground configuration struct** (`GroundConfig`): New configurable type for ground-plane parameters (enabled, height, friction, restitution) with sensible defaults (z=0, friction=0.8, inelastic)

- **Contact detection and solving**: 
  - Implements `ground_contacts()` method that detects collisions between movable bodies and the ground plane
  - Correctly transforms body geometry to world frame (fixing a bug in phyz's `find_ground_contacts` that used wrong rotation direction)
  - Deduplicates contact points from tessellated meshes before manifold capping
  - Supports Mesh, Box, and Sphere collision geometries

- **Velocity-level impulse solver** (`solve_contacts_pgs`): Custom projected Gauss-Seidel solver that properly couples normal and tangential impulses across multi-point contact manifolds, fixing energy divergence in phyz's staged solver for multi-corner impacts

- **Integration into step loop**:
  - Forward kinematics → ground contact detection → ABA dynamics → contact solve → semi-implicit Euler
  - Capped Baumgarte stabilization prevents bodies from freezing at impact-frame penetration
  - Only movable bodies (those with DOF to the world root) generate contact geometry; fixed-base bodies are skipped

- **RobotEnv API**: Added `ground` parameter to `RobotEnv::new()` and `set_ground()` method; ground config is reapplied on every reset

- **WASM bindings**: Exposed ground parameters to JavaScript constructor for gym tools

- **MCP tools**: Updated `create_robot_env` and `batch_create_envs` with `ground_*` parameters; updated tool descriptions to document the default floor behavior

- **Tests**: Added comprehensive acceptance tests:
  - Free box drop from 1 m lands and rests without tunneling
  - Same drop with ground disabled falls forever (control)
  - Pendulum swings down and rests on floor instead of passing through
  - Humanoid PD hold with ground contact stays finite under contact impulses

## Notable Implementation Details

- The custom contact solver was necessary because phyz's staged per-contact block solve drops within-block normal↔tangential coupling, causing multi-corner manifolds to diverge (verified: 4 m/s box impact bounced at 25 m/s with phyz's solver, rests with this one)
- Contact geometry is pre-computed at world construction to identify movable vs. fixed bodies, avoiding wasted contact tests on the fixed base
- Manifold deduplication happens before depth sorting to prevent tessellated mesh corners from exhausting the 4-point budget
- Explicit integrator stability at gym timesteps (1/240 s) is maintained by velocity-level impulse solve rather than penalty forces

https://claude.ai/code/session_01UW6g5EG7iHhpRHaTb9izqj