### PR TITLE
Add import_urdf MCP tool for URDF robot import

### DIFF
--- a/changelog/entries/2026-07-31-import-urdf-mcp-tool.json
+++ b/changelog/entries/2026-07-31-import-urdf-mcp-tool.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-31-import-urdf-mcp-tool",
+  "version": "0.9.4",
+  "date": "2026-07-31",
+  "category": "feat",
+  "title": "import_urdf MCP tool",
+  "summary": "Agents can import a URDF robot (links, joints, FK-placed instances, STL meshes) straight into a session document, ready for create_robot_env.",
+  "features": ["urdf", "robotics", "physics", "import"],
+  "mcpTools": ["import_urdf"]
+}

--- a/packages/mcp/src/__tests__/import-urdf.test.ts
+++ b/packages/mcp/src/__tests__/import-urdf.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, beforeAll } from "vitest";
+import { importUrdf } from "../tools/import-urdf.js";
+import { getSession, documents } from "../tools/session.js";
+import { Engine } from "@vcad/engine";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+let engine: Engine;
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+afterEach(() => {
+  delete process.env.VCAD_MCP_REMOTE;
+  delete process.env.VCAD_MCP_EXPORT_DIR;
+  documents.clear();
+});
+
+const EXAMPLES_DIR = resolve(__dirname, "../../../../examples");
+
+function parseResult(res: { content: Array<{ type: string; text: string }> }) {
+  return JSON.parse(res.content[0].text);
+}
+
+describe("import_urdf", () => {
+  it("rejects filesystem paths in remote mode", () => {
+    process.env.VCAD_MCP_REMOTE = "1";
+    expect(() => importUrdf({ path: "robot.urdf" }, engine)).toThrow(
+      /no access to your filesystem/,
+    );
+  });
+
+  it("requires path or content_base64", () => {
+    expect(() => importUrdf({}, engine)).toThrow(
+      /Provide either `path` or `content_base64`/,
+    );
+  });
+
+  it("imports the 2-DOF arm fixture and registers a session", () => {
+    process.env.VCAD_MCP_EXPORT_DIR = EXAMPLES_DIR;
+    const out = parseResult(importUrdf({ path: "robot-arm-2dof.urdf" }, engine));
+    expect(out.document_id).toMatch(/^doc_/);
+    expect(out.summary.parts).toBeGreaterThan(0);
+    expect(out.summary.joints).toBeGreaterThan(0);
+    expect(out.summary.ground_instance_id).toBeTruthy();
+    for (const j of out.summary.joint_list) {
+      expect(j.id).toBeTruthy();
+      expect(j.kind).toBeTruthy();
+    }
+    // The session is live — create_robot_env and render_view resolve it.
+    expect(getSession(out.document_id)).toBeTruthy();
+  });
+
+  it("imports via content_base64 and reports unresolvable meshes", () => {
+    const xml = `<robot name="r">
+      <link name="base"><visual><geometry><mesh filename="meshes/base.STL"/></geometry></visual></link>
+    </robot>`;
+    const out = parseResult(
+      importUrdf({ content_base64: Buffer.from(xml).toString("base64") }, engine),
+    );
+    expect(out.summary.unresolved_meshes).toHaveLength(1);
+    expect(out.summary.warning).toMatch(/placeholder/);
+  });
+
+  it("inlines a binary STL referenced relative to the URDF", () => {
+    const dir = mkdtempSync(join(tmpdir(), "urdf-test-"));
+    try {
+      // One-triangle binary STL: 80-byte header, count, 50 bytes.
+      const stl = Buffer.alloc(84 + 50);
+      stl.writeUInt32LE(1, 80);
+      const tri = [0, 0, 1, /* normal */ 0, 0, 0, 1, 0, 0, 0, 1, 0];
+      tri.forEach((v, i) => stl.writeFloatLE(v, 84 + i * 4));
+      writeFileSync(join(dir, "tri.stl"), stl);
+      writeFileSync(
+        join(dir, "bot.urdf"),
+        `<robot name="bot"><link name="base"><visual><geometry><mesh filename="tri.stl"/></geometry></visual></link></robot>`,
+      );
+      process.env.VCAD_MCP_EXPORT_DIR = dir;
+      const out = parseResult(importUrdf({ path: "bot.urdf" }, engine));
+      expect(out.summary.meshes_inlined).toBe(1);
+      expect(out.summary.unresolved_meshes).toBeUndefined();
+      const doc = getSession(out.document_id)!;
+      const inlined = Object.values(doc.nodes).find(
+        (n) => (n.op as { type: string }).type === "ImportedMesh",
+      );
+      expect(inlined).toBeTruthy();
+      // Meters → mm: the 1m vertex coordinates come back as 1000.
+      const op = inlined!.op as unknown as { positions: number[] };
+      expect(Math.max(...op.positions)).toBe(1000);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -6937,6 +6937,47 @@
     }
   },
   {
+    "name": "import_urdf",
+    "title": "Import URDF",
+    "description": "Import a URDF (Unified Robot Description Format) robot from a server-local file. Builds the full kinematic tree — one part per link, instances FK-placed from joint origins, joints (revolute/prismatic/fixed) with limits, and a grounded root link — ready for create_robot_env. STL mesh references are resolved against the URDF's directory and optional package_roots and inlined; unresolved meshes fall back to placeholder geometry with an explicit warning.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to the .urdf file on the server filesystem, relative to the server working directory (or VCAD_MCP_EXPORT_DIR if set). Relative mesh references inside the URDF resolve against the URDF's own directory. On hosted servers pass content_base64 instead."
+        },
+        "content_base64": {
+          "type": "string",
+          "description": "Base64-encoded URDF XML. Use instead of `path` when the server has no access to your filesystem (hosted/remote deployments). Mesh references cannot be resolved in this mode — links with meshes get placeholder geometry, but joints and inertials import exactly."
+        },
+        "package_roots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Directories to search when resolving package://NAME/... mesh URIs, relative to the server working directory. Each root is checked for a NAME/ subdirectory; first match wins."
+        },
+        "name": {
+          "type": "string",
+          "description": "Robot name (default: filename without extension)"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": false
+    },
+    "_meta": {
+      "ui": {
+        "resourceUri": "ui://vcad/viewer"
+      },
+      "ui/resourceUri": "ui://vcad/viewer",
+      "openai/outputTemplate": "ui://vcad/viewer-openai.html",
+      "openai/toolInvocation/invoking": "Modeling geometry…",
+      "openai/toolInvocation/invoked": "Model updated"
+    }
+  },
+  {
     "name": "import_kicad",
     "title": "Import KiCad",
     "description": "Import an existing KiCad .kicad_pcb board into a live session — board outline, footprints with pads + nets, design rules, and any routed traces/vias/zones. Returns a document_id ready for render_pcb, run_drc, get_pad_positions, route_nets, and export_gerber. Pass content_base64 on hosted servers.",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -166,6 +166,7 @@ import { toolDefs as sheetMetalToolDefs } from "./tools/sheet-metal.js";
 import { toolDefs as flatPatternToolDefs } from "./tools/flat-pattern.js";
 import { toolDefs as acousticsToolDefs } from "./tools/acoustics.js";
 import { toolDefs as importToolDefs } from "./tools/import.js";
+import { toolDefs as importUrdfToolDefs } from "./tools/import-urdf.js";
 import { toolDefs as importPcbToolDefs } from "./tools/import-pcb.js";
 import { toolDefs as shareToolDefs } from "./tools/share.js";
 import { toolDefs as gymToolDefs } from "./tools/gym.js";
@@ -357,6 +358,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...flatPatternToolDefs,
   ...acousticsToolDefs,
   ...importToolDefs,
+  ...importUrdfToolDefs,
   ...importPcbToolDefs,
   ...shareToolDefs,
   ...gymToolDefs,
@@ -486,6 +488,7 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "simulate_strike",
   // ── Import + share ─────────────────────────────────────────
   "import_step",
+  "import_urdf",
   "import_kicad",
   "import_eagle",
   "open_in_browser",

--- a/packages/mcp/src/tools/import-urdf.ts
+++ b/packages/mcp/src/tools/import-urdf.ts
@@ -1,0 +1,373 @@
+/**
+ * import_urdf tool — import a URDF robot description as a session document.
+ *
+ * The kernel's URDF reader (via the WASM seam, same parser the browser
+ * drag-drop uses) builds the kinematic tree: part_defs per link, instances,
+ * joints, and a ground instance at the root link. `<mesh>` references come
+ * back as `MeshImport` nodes carrying the URDF filename verbatim; this tool
+ * resolves them against the URDF's directory and any `package_roots` and
+ * inlines STL data Node-side (the browser flow does the same swap with
+ * three.js loaders in `urdf-meshes.ts`). Unresolved references are reported,
+ * not fatal — the kernel falls back to a placeholder cube per link, so joint
+ * topology and inertials still simulate correctly.
+ *
+ * Local-mode-first: the hosted server has no client filesystem, so `path`
+ * errors there. `content_base64` still works remotely, but mesh references
+ * cannot be resolved without a filesystem.
+ */
+
+import type { Document, Node, NodeId } from "@vcad/ir";
+import type { Engine } from "@vcad/engine";
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { basename, dirname, isAbsolute, resolve, sep } from "node:path";
+import { resolveWithinRoot } from "./safe-path.js";
+import { isRemoteDeployment } from "./remote.js";
+import { registerSession } from "./session.js";
+import { behavior, type ToolDef } from "./tool-def.js";
+
+// URDF descriptors are tiny; the kernel rejects >8 MB XML anyway.
+const MAX_URDF_BYTES = 8 * 1024 * 1024;
+// Cap individual mesh files so a caller can't pin memory with a huge STL.
+const MAX_MESH_BYTES = 100 * 1024 * 1024;
+
+interface ImportUrdfInput {
+  path?: string;
+  content_base64?: string;
+  package_roots?: string[];
+  name?: string;
+}
+
+export const importUrdfSchema = {
+  type: "object" as const,
+  properties: {
+    path: {
+      type: "string" as const,
+      description:
+        "Path to the .urdf file on the server filesystem, relative to the server " +
+        "working directory (or VCAD_MCP_EXPORT_DIR if set). Relative mesh " +
+        "references inside the URDF resolve against the URDF's own directory. " +
+        "On hosted servers pass content_base64 instead.",
+    },
+    content_base64: {
+      type: "string" as const,
+      description:
+        "Base64-encoded URDF XML. Use instead of `path` when the server has no " +
+        "access to your filesystem (hosted/remote deployments). Mesh references " +
+        "cannot be resolved in this mode — links with meshes get placeholder " +
+        "geometry, but joints and inertials import exactly.",
+    },
+    package_roots: {
+      type: "array" as const,
+      items: { type: "string" as const },
+      description:
+        "Directories to search when resolving package://NAME/... mesh URIs, " +
+        "relative to the server working directory. Each root is checked for a " +
+        "NAME/ subdirectory; first match wins.",
+    },
+    name: {
+      type: "string" as const,
+      description: "Robot name (default: filename without extension)",
+    },
+  },
+};
+
+/** Minimal mesh payload swapped into the document for a resolved reference. */
+interface LoadedMesh {
+  positions: number[];
+  indices: number[];
+}
+
+/**
+ * Parse an STL file (binary or ASCII) into a triangle soup. Vertices are in
+ * meters (the ROS convention) and are converted to mm here, matching the
+ * kernel's ×1000 on URDF primitive dimensions and the browser mesh loader.
+ */
+function parseStl(buf: Buffer): LoadedMesh {
+  const positions: number[] = [];
+  // Binary layout: 80-byte header, uint32 triangle count, 50 bytes/triangle.
+  const looksBinary =
+    buf.length >= 84 && buf.length === 84 + buf.readUInt32LE(80) * 50;
+  if (looksBinary) {
+    const count = buf.readUInt32LE(80);
+    for (let t = 0; t < count; t++) {
+      const base = 84 + t * 50 + 12; // skip the facet normal
+      for (let v = 0; v < 3; v++) {
+        const off = base + v * 12;
+        positions.push(
+          buf.readFloatLE(off) * 1000,
+          buf.readFloatLE(off + 4) * 1000,
+          buf.readFloatLE(off + 8) * 1000,
+        );
+      }
+    }
+  } else {
+    const text = buf.toString("utf8");
+    if (!/^\s*solid/.test(text)) {
+      throw new Error("not a recognizable STL file (neither binary nor ASCII)");
+    }
+    const vertexRe =
+      /vertex\s+([-+eE0-9.]+)\s+([-+eE0-9.]+)\s+([-+eE0-9.]+)/g;
+    let m: RegExpExecArray | null;
+    while ((m = vertexRe.exec(text)) !== null) {
+      positions.push(
+        parseFloat(m[1]) * 1000,
+        parseFloat(m[2]) * 1000,
+        parseFloat(m[3]) * 1000,
+      );
+    }
+    if (positions.length === 0 || positions.length % 9 !== 0) {
+      throw new Error("malformed ASCII STL");
+    }
+  }
+  const indices = new Array(positions.length / 3);
+  for (let i = 0; i < indices.length; i++) indices[i] = i;
+  return { positions, indices };
+}
+
+/**
+ * Resolve a URDF `<mesh filename="...">` value to an absolute on-disk path,
+ * mirroring the Rust `UrdfReadOptions::resolve_mesh`. Every candidate is
+ * required to stay under `confineRoot` — the same working-directory jail
+ * `resolveWithinRoot` enforces on tool inputs, extended here to paths the
+ * URDF content (untrusted) supplies.
+ */
+function resolveMeshPath(
+  filename: string,
+  urdfDir: string | null,
+  packageRoots: string[],
+  confineRoot: string,
+): string | null {
+  const confined = (p: string): string | null => {
+    const abs = resolve(p);
+    const root = resolve(confineRoot);
+    const rootSep = root.endsWith(sep) ? root : root + sep;
+    if (abs !== root && !abs.startsWith(rootSep)) return null;
+    return existsSync(abs) && statSync(abs).isFile() ? abs : null;
+  };
+
+  if (filename.includes("\0")) return null;
+
+  const pkgMatch = filename.match(/^package:\/\/([^/]+)\/?(.*)$/);
+  if (pkgMatch) {
+    for (const root of packageRoots) {
+      const hit = confined(resolve(root, pkgMatch[1], pkgMatch[2]));
+      if (hit) return hit;
+    }
+    return null;
+  }
+
+  const stripped = filename.startsWith("file://")
+    ? filename.slice("file://".length)
+    : filename;
+  if (isAbsolute(stripped)) return confined(stripped);
+  if (urdfDir) return confined(resolve(urdfDir, stripped));
+  return null;
+}
+
+/**
+ * Swap every resolvable `MeshImport` node for an inline `ImportedMesh`
+ * (the Node-side analogue of the app's `inlineMeshImports`). Returns the
+ * inlined count and the references that could not be resolved or parsed.
+ */
+function inlineMeshImports(
+  doc: Document,
+  urdfDir: string | null,
+  packageRoots: string[],
+  confineRoot: string,
+): { inlined: number; unresolved: Array<{ path: string; reason: string }> } {
+  let inlined = 0;
+  const unresolved: Array<{ path: string; reason: string }> = [];
+  for (const key of Object.keys(doc.nodes)) {
+    const node = doc.nodes[key] as Node;
+    // MeshImport serializes as `"type": "mesh_import"` (the IR's one serde
+    // rename); it isn't in the TS CsgOp union since it only exists en route
+    // to being swapped, so go through a structural cast.
+    const opLoose = node.op as unknown as {
+      type: string;
+      path?: string;
+      scale?: { x: number; y: number; z: number } | null;
+    };
+    if (opLoose.type !== "mesh_import" && opLoose.type !== "MeshImport") {
+      continue;
+    }
+    const ref = opLoose.path ?? "";
+    const filepath = resolveMeshPath(ref, urdfDir, packageRoots, confineRoot);
+    if (!filepath) {
+      unresolved.push({ path: ref, reason: "file not found" });
+      continue;
+    }
+    if (!/\.stl$/i.test(filepath)) {
+      unresolved.push({
+        path: ref,
+        reason: "unsupported mesh format (only STL is inlined server-side)",
+      });
+      continue;
+    }
+    if (statSync(filepath).size > MAX_MESH_BYTES) {
+      unresolved.push({ path: ref, reason: "mesh exceeds size limit" });
+      continue;
+    }
+    let mesh: LoadedMesh;
+    try {
+      mesh = parseStl(readFileSync(filepath));
+    } catch (e) {
+      unresolved.push({ path: ref, reason: `parse error: ${e}` });
+      continue;
+    }
+    const scale = opLoose.scale;
+    let positions = mesh.positions;
+    if (scale && (scale.x !== 1 || scale.y !== 1 || scale.z !== 1)) {
+      positions = positions.map((v, i) =>
+        i % 3 === 0 ? v * scale.x : i % 3 === 1 ? v * scale.y : v * scale.z,
+      );
+    }
+    doc.nodes[key] = {
+      id: node.id as NodeId,
+      name: node.name,
+      op: {
+        type: "ImportedMesh",
+        positions,
+        indices: mesh.indices,
+        source: ref,
+        // biome-ignore lint/suspicious/noExplicitAny: bridging IR shape
+      } as any,
+    };
+    inlined++;
+  }
+  return { inlined, unresolved };
+}
+
+export function importUrdf(
+  input: unknown,
+  engine: Engine,
+): { content: Array<{ type: "text"; text: string }> } {
+  const { path, content_base64, package_roots, name } =
+    input as ImportUrdfInput;
+
+  const confineRoot = process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd();
+  let fileBuffer: Buffer;
+  let urdfDir: string | null = null;
+  let sourceLabel: string;
+
+  if (content_base64) {
+    fileBuffer = Buffer.from(content_base64, "base64");
+    if (fileBuffer.length === 0) {
+      throw new Error("content_base64 decoded to zero bytes");
+    }
+    sourceLabel = "urdf-import";
+  } else if (path) {
+    if (isRemoteDeployment()) {
+      throw new Error(
+        "This hosted server has no access to your filesystem — pass the URDF " +
+          "XML as `content_base64` instead of `path`. Mesh references cannot " +
+          "be resolved in that mode (links fall back to placeholder geometry); " +
+          "run the MCP server locally for full mesh import.",
+      );
+    }
+    const filepath = resolveWithinRoot(path, confineRoot);
+    if (!existsSync(filepath)) {
+      throw new Error(`URDF file not found: ${path}`);
+    }
+    const stat = statSync(filepath);
+    if (!stat.isFile()) {
+      throw new Error("URDF path is not a regular file");
+    }
+    if (stat.size > MAX_URDF_BYTES) {
+      throw new Error(`URDF file exceeds ${MAX_URDF_BYTES} byte limit`);
+    }
+    fileBuffer = readFileSync(filepath);
+    urdfDir = dirname(filepath);
+    sourceLabel = path;
+  } else {
+    throw new Error("Provide either `path` or `content_base64`");
+  }
+  if (fileBuffer.length > MAX_URDF_BYTES) {
+    throw new Error(`URDF content exceeds ${MAX_URDF_BYTES} byte limit`);
+  }
+
+  const packageRoots = (package_roots ?? []).map((r) =>
+    resolveWithinRoot(r, confineRoot),
+  );
+
+  // Parse through the WASM seam — the same kernel parser the browser
+  // drag-drop uses. Copy into a plain ArrayBuffer (Buffer.buffer may be a
+  // pooled slice).
+  const arrayBuffer = new ArrayBuffer(fileBuffer.byteLength);
+  new Uint8Array(arrayBuffer).set(fileBuffer);
+  const doc = JSON.parse(engine.importUrdf(arrayBuffer)) as Document;
+
+  const meshes = inlineMeshImports(doc, urdfDir, packageRoots, confineRoot);
+
+  const robotName =
+    name ?? basename(sourceLabel).replace(/\.(urdf|xml)$/i, "");
+
+  const parts = Object.values(doc.partDefs ?? {}).map((p) => ({
+    id: p.id,
+    name: p.name,
+  }));
+  const joints = (doc.joints ?? []).map((j) => ({
+    id: j.id,
+    name: j.name,
+    kind: j.kind.type,
+    parent_instance_id: j.parentInstanceId,
+    child_instance_id: j.childInstanceId,
+  }));
+
+  const documentId = registerSession(doc);
+
+  const summary = {
+    robot: robotName,
+    parts: parts.length,
+    joints: joints.length,
+    instances: (doc.instances ?? []).length,
+    ground_instance_id: doc.groundInstanceId ?? null,
+    joint_list: joints,
+    ...(meshes.inlined > 0 ? { meshes_inlined: meshes.inlined } : {}),
+    ...(meshes.unresolved.length > 0
+      ? {
+          warning:
+            `${meshes.unresolved.length} mesh reference(s) could not be inlined — ` +
+            "those links use placeholder geometry. Joint topology and authored " +
+            "inertials are exact, so physics still behaves to first order.",
+          unresolved_meshes: meshes.unresolved,
+        }
+      : {}),
+  };
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            document_id: documentId,
+            summary,
+            note:
+              "The robot is registered as a session document — pass document_id " +
+              "to create_robot_env to simulate it, render_view to see it, or any " +
+              "CAD tool to edit it.",
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "import_urdf",
+    pack: null,
+    description:
+      "Import a URDF (Unified Robot Description Format) robot from a server-local file. " +
+      "Builds the full kinematic tree — one part per link, instances FK-placed from joint " +
+      "origins, joints (revolute/prismatic/fixed) with limits, and a grounded root link — " +
+      "ready for create_robot_env. STL mesh references are resolved against the URDF's " +
+      "directory and optional package_roots and inlined; unresolved meshes fall back to " +
+      "placeholder geometry with an explicit warning.",
+    inputSchema: importUrdfSchema,
+    handler: (a, c) => importUrdf(a, c.engine),
+    behavior: behavior({ writesDoc: true, geometry: true, mount: true }),
+  },
+];

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -188,6 +188,7 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
 
   // ── Import + share ─────────────────────────────────────────────────────
   import_step: { title: "Import STEP", annotations: RW },
+  import_urdf: { title: "Import URDF", annotations: RW },
   import_kicad: { title: "Import KiCad", annotations: RW },
   import_eagle: { title: "Import EAGLE", annotations: RW },
   open_in_browser: { title: "Open in Browser", annotations: RW },


### PR DESCRIPTION
Adds a new `import_urdf` MCP tool that imports URDF (Unified Robot Description Format) robot descriptions into session documents, enabling agents to load complete kinematic trees ready for simulation and visualization.

## Summary

The tool parses URDF files via the kernel's WASM parser (the same one the browser drag-drop uses) and builds a full kinematic tree: one part per link, FK-placed instances from joint origins, joints with limits (revolute/prismatic/fixed), and a grounded root link. STL mesh references are resolved against the URDF's directory and optional `package_roots`, parsed server-side, and inlined into the document. Unresolved mesh references fall back to placeholder geometry with explicit warnings, so joint topology and inertials remain accurate even when meshes can't be loaded.

## Key Changes

- **`packages/mcp/src/tools/import-urdf.ts`** — New tool implementation:
  - Accepts URDF via `path` (local filesystem) or `content_base64` (for remote/hosted deployments)
  - Parses binary and ASCII STL files, converting vertex coordinates from meters to mm
  - Resolves `package://` URIs and relative mesh paths against configurable `package_roots`
  - Enforces filesystem jail (`VCAD_MCP_EXPORT_DIR` or cwd) to prevent path traversal
  - Inlines resolved meshes as `ImportedMesh` nodes; reports unresolved references with reasons
  - Registers the imported document as a session and returns kinematic tree summary (parts, joints, instances, ground link)
  - Rejects filesystem paths in remote deployments with clear guidance to use `content_base64`

- **`packages/mcp/src/__tests__/import-urdf.test.ts`** — Comprehensive test suite:
  - Verifies remote mode rejection of filesystem paths
  - Tests import of the 2-DOF arm fixture with session registration
  - Validates `content_base64` mode and unresolved mesh warnings
  - Tests binary STL parsing and unit conversion (meters → mm)

- **`packages/mcp/src/server.ts`** — Registers the new tool in the MCP server

- **`packages/mcp/src/tools/tool-metadata.ts`** — Adds tool metadata entry

- **`packages/mcp/src/__tests__/tool-surface.fixture.json`** — Updates tool surface snapshot with `import_urdf` schema and UI metadata

- **`changelog/entries/2026-07-31-import-urdf-mcp-tool.json`** — Changelog entry

## Notable Implementation Details

- **Mesh resolution mirrors Rust behavior:** The `resolveMeshPath` function implements the same logic as the kernel's `UrdfReadOptions::resolve_mesh`, checking `package://` URIs first, then absolute/relative file:// paths, with filesystem jail enforcement at each step.
- **STL parsing:** Detects binary vs. ASCII format; binary parser reads triangle count and 50-byte records; ASCII parser uses regex to extract vertex coordinates. Both convert from ROS meters to mm (×1000) to match kernel primitive scaling and browser mesh loaders.
- **Size limits:** URDF capped at 8 MB (kernel's own limit), individual meshes at 100 MB to prevent memory exhaustion.
- **Session durability:** Imported documents are registered via `registerSession` and persist according to the server's configured session store (disk or Supabase).
- **Graceful degradation:** Unresolved meshes don't fail the import; links get placeholder cubes, and the tool reports which references couldn't be resolved and why.

https://claude.ai/code/session_01QCLywtbBg6H5HjdHcCKBBW