### PR TITLE
perf(booleans): stop classification cost scaling with tessellation density

### DIFF
--- a/crates/vcad-kernel-booleans/src/classify.rs
+++ b/crates/vcad-kernel-booleans/src/classify.rs
@@ -28,6 +28,15 @@ pub enum FaceClassification {
     OnOpposite,
 }
 
+/// Most boundary probes to take for one face, on top of its interior
+/// sample point.
+///
+/// The probes exist to stop a single unlucky sample from deciding a face
+/// that straddles the other solid, so what matters is that they are spread
+/// around the boundary — not that there is one per vertex. Capping them
+/// decouples classification cost from tessellation density.
+const MAX_BOUNDARY_PROBES: usize = 24;
+
 /// How far a classification probe must sit from the other solid's boundary
 /// before its in/out verdict is trusted to veto (mm).
 ///
@@ -1121,9 +1130,19 @@ fn extra_probe_points(brep: &BRepSolid, face_id: FaceId, centroid: Point3) -> Ve
     if outer_verts.len() < 3 {
         return Vec::new();
     }
+    // One probe per boundary edge, but capped: probe count should follow
+    // how much confidence the vote needs, not how finely the boundary
+    // happens to be discretized. A band face cut by a sampled ellipse can
+    // carry hundreds of vertices, and since every probe costs a full
+    // point-in-mesh scan, one-probe-per-vertex made classification scale
+    // with tessellation density — 21x on the fillet corpus. Sampling the
+    // boundary at an even stride keeps the probes spread all the way
+    // around the face, which is what makes the vote robust.
     let n = outer_verts.len();
-    let mut probes = Vec::with_capacity(n);
-    for i in 0..n {
+    let count = n.min(MAX_BOUNDARY_PROBES);
+    let mut probes = Vec::with_capacity(count);
+    for k in 0..count {
+        let i = k * n / count;
         let a = outer_verts[i];
         let b = outer_verts[(i + 1) % n];
         let mid = Point3::new(0.5 * (a.x + b.x), 0.5 * (a.y + b.y), 0.5 * (a.z + b.z));

--- a/crates/vcad-kernel-booleans/src/pipeline.rs
+++ b/crates/vcad-kernel-booleans/src/pipeline.rs
@@ -49,23 +49,6 @@ macro_rules! debug_bool {
 /// it has to reject is 4e-7mm).
 const MIN_CROSSING_ARC: f64 = 1e-3;
 
-/// Largest curved-surface radius in a solid's geometry (0.0 when the solid
-/// is all-planar). Drives the classification tessellation density.
-fn max_curved_radius(brep: &BRepSolid) -> f64 {
-    let mut r = 0.0f64;
-    for s in &brep.geometry.surfaces {
-        let any = s.as_any();
-        if let Some(c) = any.downcast_ref::<vcad_kernel_geom::CylinderSurface>() {
-            r = r.max(c.radius.abs());
-        } else if let Some(sp) = any.downcast_ref::<vcad_kernel_geom::SphereSurface>() {
-            r = r.max(sp.radius.abs());
-        } else if let Some(t) = any.downcast_ref::<vcad_kernel_geom::TorusSurface>() {
-            r = r.max(t.major_radius.abs() + t.minor_radius.abs());
-        }
-    }
-    r
-}
-
 /// Handle boolean operations on non-overlapping solids.
 pub(crate) fn non_overlapping_boolean(
     solid_a: &BRepSolid,
@@ -996,19 +979,9 @@ pub(crate) fn brep_boolean(
     // cracks along the shared circles), so pick it per boolean from the
     // largest curved radius across both operands: a 45mm part classifies at
     // the 256 cap (~4e-3mm sag) while a fillet-scale solid stays cheap.
-    let cls_segments = {
-        let max_r = max_curved_radius(&a).max(max_curved_radius(&b));
-        const SAG: f64 = 1.5e-3;
-        let needed = if max_r > SAG {
-            let arg = (1.0 - SAG / max_r).clamp(-1.0, 1.0);
-            (std::f64::consts::PI / arg.acos()).ceil() as u32
-        } else {
-            0
-        };
-        needed.min(256).max(segments)
-    };
-    let mesh_b = tessellate_brep(&b, cls_segments);
-    let mesh_a = tessellate_brep(&a, cls_segments);
+    // Tessellate each solid once and reuse for classification.
+    let mesh_b = tessellate_brep(&b, segments);
+    let mesh_a = tessellate_brep(&a, segments);
     let classes_a = classify::classify_all_faces_with_mesh(&a, &b, &mesh_b);
     let classes_b = classify::classify_all_faces_with_mesh(&b, &a, &mesh_a);
 

--- a/crates/vcad-kernel-booleans/src/ssi.rs
+++ b/crates/vcad-kernel-booleans/src/ssi.rs
@@ -311,8 +311,15 @@ fn plane_sphere(plane: &Plane, sphere: &SphereSurface) -> IntersectionCurve {
 // =============================================================================
 
 /// Sample count for a sampled ellipse (oblique plane × cylinder) so the
-/// polyline's chordal sag stays under ~1e-3 mm on the cylinder of radius
-/// `r`. `n = π / acos(1 − sag/r)`, clamped to [64, 512].
+/// polyline's chordal sag stays under ~1e-3 mm on the cylinder of radius `r`.
+/// `n = π / acos(1 − sag/r)`, clamped to [64, 512].
+///
+/// The target is finer than `split::arc_segments` (5e-3) because the torr
+/// A1 sliver case fails at that coarser value — trim boundaries derived
+/// from this polyline need the extra accuracy. Sample count feeds band
+/// vertex count and hence result triangle count, so this is not free;
+/// `MAX_BOUNDARY_PROBES` in `classify` is what keeps classification cost
+/// from scaling with it.
 fn ellipse_samples(r: f64) -> usize {
     const SAG: f64 = 1e-3;
     let n = if r > SAG {

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -5028,15 +5028,6 @@ pub fn tessellate(brep: &BRepSolid, segments: u32) -> TriangleMesh {
 /// This is the primary tessellation function used by the facade crate.
 pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
     let params = TessellationParams::from_segments(segments);
-    tessellate_brep_with_params(brep, &params)
-}
-
-/// `tessellate_brep` with explicit [`TessellationParams`] — for callers that
-/// need sag-driven adaptive resolution (e.g. boolean classification meshes,
-/// which must track the analytic surfaces far more tightly than the display
-/// tessellation without paying flat-high segment counts on small radii).
-pub fn tessellate_brep_with_params(brep: &BRepSolid, params: &TessellationParams) -> TriangleMesh {
-    let params = *params;
     let solid = &brep.topology.solids[brep.solid_id];
     let shell = &brep.topology.shells[solid.outer_shell];
 


### PR DESCRIPTION
Follow-up to #756.

That PR carried a classification-mesh densification I described as load-bearing for the trim-overshoot fix. **It was not** — all three torr trim cases pass with it removed. It was, however, expensive enough to take CI's `Rust (stable)` job from ~30 minutes to **3h50m**.

The two changes here share one theme: boolean classification cost was scaling with how finely geometry happens to be discretized, rather than with how much confidence the classifier actually needs.

## 1. Remove the classification densification

It forced a **flat** high segment count across every face of both operands. Flat on purpose — per-radius adaptivity cracks the mesh along circles shared between a wall and its cap, which I verified the hard way (`a2_boolean_over_pattern_doc10` failed 5/5 that way).

But spheres and tori subdivide in *both* parameters, so one sphere at 256 segments is ~65k triangles, and `point_in_mesh` is a linear scan over triangles run once per probe per face. On blend-heavy input the classification mesh grew into the hundreds of thousands of triangles.

Also removes `tessellate_brep_with_params`, the entry point I added to `vcad-kernel-tessellate` to serve this. It now has no callers — this retires the open question I flagged in #756's description.

## 2. Cap boundary probes

`extra_probe_points` emitted **one probe per boundary vertex**. A band face cut by a sampled ellipse carries hundreds of vertices, so probe count — and with it the number of full mesh scans — tracked tessellation density directly.

Capped at 24, sampled at an even stride so probes still spread all the way around the boundary. That spread is the property that makes the vote robust against a single unlucky sample; one-per-vertex was never the point.

On `fillet_torture` this alone was 2139s → 1496s.

## Also

Documents why `ellipse_samples` targets a finer sag (`1e-3`) than `split::arc_segments` (`5e-3`). `a1_pattern_child_boolean_sliver` fails at the coarser value, so the deviation is deliberate rather than an oversight — worth stating, since the asymmetry otherwise reads as an accident.

## Verification

Run on this base (merged `main`):

| Check | Result |
|---|---|
| `torr_boolean_catalogue` | 26 passed / 0 failed / 6 pre-existing ignores — **85.7s** (102s before #756, 132s with densification) |
| `torr_phantom_intersection` | 5 passed |
| loon / mirror / assembly / clash / gradient | all green |
| `vcad-kernel-booleans` | all green |
| Torture track (pr subset) | clean, all 6 of #756's improvements retained |
| `clippy --workspace --exclude vcad-desktop` | clean |
| `cargo fmt --all --check` | clean |

`control_rotating_group_volume` in the phantom suite is the one that matters most here: it guards the straddling-face veto that the probe cap could in principle weaken. It passes.

## Known remaining

`fillet_torture` still runs well above its pre-#756 baseline. Completed A/B runs rule out both the densification and the circle-anchor `crosses()` test (1518s vs 1496s — no difference). The untested candidate is the `is_seam_loop` gate, which replaces compact 4-vertex seam loops with dense two-chain bands. The systemic fix is likely a spatial index for `point_in_mesh` — an O(triangles) linear scan called once per probe per face — rather than anything in this diff. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)