### PR TITLE
feat(physics): per-foot contact state in the gym observation

### DIFF
--- a/changelog/entries/2026-07-31-gym-foot-contact-observation.json
+++ b/changelog/entries/2026-07-31-gym-foot-contact-observation.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-31-gym-foot-contact-observation",
+  "version": "0.9.4",
+  "date": "2026-07-31",
+  "category": "feat",
+  "title": "Foot contact reaches the gym observation",
+  "summary": "Every end effector now reports an in-contact flag, normal force, and center of pressure — the foot-force channel a locomotion policy needs to tell a loaded foot from a swinging one.",
+  "features": ["physics", "simulation", "rl"],
+  "mcpTools": ["gym_observe", "gym_step", "gym_reset", "create_robot_env"]
+}

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use vcad_ir::Document;
 
 use crate::error::PhysicsError;
-use crate::world::{GroundConfig, PhysicsWorld};
+use crate::world::{ContactState, GroundConfig, PhysicsWorld};
 
 /// Observation from the robot environment.
 ///
@@ -41,9 +41,18 @@ pub struct Observation {
     /// then rad/s), world frame.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_velocity: Option<[f64; 6]>,
-    // TODO(contact): per-foot contact state (in-contact flag + normal force).
-    // Ground-plane contact now exists (`PhysicsWorld::ground_contacts`), but
-    // the per-body manifold isn't surfaced through the observation yet.
+    /// Ground contact under each end effector, one entry per
+    /// [`RobotEnv::end_effector_ids`] entry, in that order — the foot-force
+    /// sensor a real humanoid reads (FSR / ankle F/T). Five observation slots
+    /// each: `in_contact` (as 0/1), `normal_force`, and the 3-vector center of
+    /// pressure. An unknown end-effector id contributes the default
+    /// (not-in-contact) state rather than being skipped, so the layout stays
+    /// index-aligned with `end_effector_poses`.
+    ///
+    /// This is a *sensed* quantity, so [`ObservationNoise::contact_force_std`]
+    /// perturbs it in `step`/`reset` observations like any other sensor.
+    #[serde(default)]
+    pub end_effector_contacts: Vec<ContactState>,
 }
 
 impl Observation {
@@ -60,6 +69,7 @@ impl Observation {
             end_effector_poses: vec![[0.0; 7]; num_end_effectors],
             base_pose: None,
             base_velocity: None,
+            end_effector_contacts: vec![ContactState::default(); num_end_effectors],
         }
     }
 }
@@ -129,6 +139,11 @@ pub struct ObservationNoise {
     pub base_rot_std: f64,
     /// Std-dev on base linear/angular velocity (m/s and rad/s).
     pub base_vel_std: f64,
+    /// Std-dev on end-effector contact normal force (newtons). The noisy
+    /// force is clamped to `>= 0` — a load cell can't report negative normal
+    /// load. The `in_contact` flag stays clean: it models a foot switch,
+    /// a separate (and far less noisy) sensor from the force channel.
+    pub contact_force_std: f64,
 }
 
 impl ObservationNoise {
@@ -138,6 +153,7 @@ impl ObservationNoise {
             && self.base_pos_std == 0.0
             && self.base_rot_std == 0.0
             && self.base_vel_std == 0.0
+            && self.contact_force_std == 0.0
     }
 }
 
@@ -543,6 +559,7 @@ impl RobotEnv {
         }
 
         let mut end_effector_poses = Vec::with_capacity(self.end_effector_ids.len());
+        let mut end_effector_contacts = Vec::with_capacity(self.end_effector_ids.len());
         for ee_id in &self.end_effector_ids {
             if let Some((pos, quat)) = self.world.get_instance_pose(ee_id) {
                 end_effector_poses
@@ -550,6 +567,7 @@ impl RobotEnv {
             } else {
                 end_effector_poses.push([0.0; 7]);
             }
+            end_effector_contacts.push(self.world.get_instance_contact(ee_id).unwrap_or_default());
         }
 
         let (base_pose, base_velocity) = match self.base_instance_id.as_deref() {
@@ -568,6 +586,7 @@ impl RobotEnv {
             end_effector_poses,
             base_pose,
             base_velocity,
+            end_effector_contacts,
         }
     }
 
@@ -619,6 +638,12 @@ impl RobotEnv {
         if let Some(vel) = obs.base_velocity.as_mut() {
             for v in vel.iter_mut() {
                 *v += gaussian(&mut self.rng) * noise.base_vel_std;
+            }
+        }
+        if noise.contact_force_std > 0.0 {
+            for c in &mut obs.end_effector_contacts {
+                c.normal_force =
+                    (c.normal_force + gaussian(&mut self.rng) * noise.contact_force_std).max(0.0);
             }
         }
         obs
@@ -705,6 +730,13 @@ impl RobotEnv {
             .collect()
     }
 
+    /// End-effector instance ids in observation order — the order of
+    /// [`Observation::end_effector_poses`] and
+    /// [`Observation::end_effector_contacts`].
+    pub fn end_effector_ids(&self) -> &[String] {
+        &self.end_effector_ids
+    }
+
     /// Actuated joint ids in action order (document order, Fixed joints excluded).
     pub fn actuated_joint_ids(&self) -> &[String] {
         &self.actuated_joint_ids
@@ -719,13 +751,15 @@ impl RobotEnv {
     ///
     /// Each joint contributes `max(1, ndof)` position slots plus the same
     /// number of velocity slots (Fixed = 1 zero slot, Ball = 3, Free = 6).
+    /// Each end effector contributes 7 pose slots plus 5 contact slots
+    /// (in-contact flag, normal force, 3-vector center of pressure).
     pub fn observation_dim(&self) -> usize {
         let joint_slots: usize = self
             .joint_ids
             .iter()
             .map(|id| self.world.joint_dof_count(id).max(1))
             .sum();
-        joint_slots * 2 + self.end_effector_ids.len() * 7
+        joint_slots * 2 + self.end_effector_ids.len() * (7 + 5)
     }
 
     /// Get the action dimension: one entry per actuated (non-Fixed) joint.

--- a/crates/vcad-kernel-physics/src/lib.rs
+++ b/crates/vcad-kernel-physics/src/lib.rs
@@ -56,4 +56,4 @@ pub use gym::{
     Action, DomainRandomization, EnvConfig, Observation, ObservationNoise, Range, RobotEnv,
     StepInfo, StepResult, TerminationConfig,
 };
-pub use world::{GroundConfig, JointState, PhysicsWorld};
+pub use world::{ContactState, GroundConfig, JointState, PhysicsWorld};

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -8,6 +8,7 @@ use phyz::model::{Model, ModelBuilder, State};
 use phyz::{
     forward_kinematics, Collision, ContactMaterial, ContactProblem, ContactSolverConfig, Geometry,
 };
+use serde::{Deserialize, Serialize};
 use vcad_ir::{Document, InertialProperties, JointKind};
 
 use crate::colliders::{estimate_mass, mesh_to_collider, ColliderStrategy};
@@ -145,6 +146,43 @@ pub struct PhysicsWorld {
     // floating-base robot. Gates gravity-compensation feedforward (see
     // `apply_motor_torques`).
     has_floating_base: bool,
+
+    // Per-body ground-contact state from the most recent `step`, indexed like
+    // `model.bodies`. Overwritten every step (so after a multi-substep env
+    // step it reports the final substep), and cleared to "no contact" when a
+    // step finds no manifold or the ground is disabled.
+    body_contacts: Vec<ContactState>,
+}
+
+/// Ground-contact state of one body, as of the most recent
+/// [`PhysicsWorld::step`].
+///
+/// This is the physical sensor a foot force plate / ankle F/T would read: a
+/// touch flag, the total normal load, and where it acts.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct ContactState {
+    /// True when the body's collider had at least one point penetrating the
+    /// ground plane during the last step — touching, whether or not the
+    /// solver had to push (a grazing touch reports `normal_force == 0`).
+    pub in_contact: bool,
+    /// Total normal force over the body's contact manifold, in newtons
+    /// (the solved normal impulse divided by the step's `dt`). A body at rest
+    /// reads its supported weight; airborne reads `0`.
+    pub normal_force: f64,
+    /// Impulse-weighted centroid of the manifold in world meters — the
+    /// center of pressure. `[0, 0, 0]` when not in contact; falls back to the
+    /// unweighted centroid when the manifold carries no normal impulse.
+    pub point: [f64; 3],
+}
+
+impl Default for ContactState {
+    fn default() -> Self {
+        Self {
+            in_contact: false,
+            normal_force: 0.0,
+            point: [0.0; 3],
+        }
+    }
 }
 
 impl PhysicsWorld {
@@ -514,6 +552,7 @@ impl PhysicsWorld {
             contact_geometries,
             contact_support,
             has_floating_base,
+            body_contacts: vec![ContactState::default(); nbodies],
         };
 
         // Seed the initial configuration from the authored joint states.
@@ -592,6 +631,12 @@ impl PhysicsWorld {
                 Vec::new()
             };
 
+            // Contact sensing is per-step, not cumulative: last step's
+            // manifold says nothing about this one.
+            for c in &mut self.body_contacts {
+                *c = ContactState::default();
+            }
+
             if contacts.is_empty() {
                 self.state.v = free_v;
             } else {
@@ -625,6 +670,50 @@ impl PhysicsWorld {
                     asm.problem.free_velocity[3 * ci] -= push;
                 }
                 let impulses = solve_contacts_pgs(&asm.problem);
+
+                // Publish the per-body manifold as a foot-force sensor. The
+                // solve returns impulses in each contact's local frame with
+                // the normal first, so force = impulse_n / dt, and the center
+                // of pressure is the impulse-weighted point centroid.
+                for (ci, c) in contacts.iter().enumerate() {
+                    let s = &mut self.body_contacts[c.body_i];
+                    let fn_ = impulses[ci].x.max(0.0) / dt;
+                    let p = c.contact_point;
+                    if !s.in_contact {
+                        *s = ContactState {
+                            in_contact: true,
+                            normal_force: 0.0,
+                            point: [0.0; 3],
+                        };
+                    }
+                    s.normal_force += fn_;
+                    // Accumulate weighted point; normalized below.
+                    s.point[0] += fn_ * p.x;
+                    s.point[1] += fn_ * p.y;
+                    s.point[2] += fn_ * p.z;
+                }
+                for (bi, s) in self.body_contacts.iter_mut().enumerate() {
+                    if !s.in_contact {
+                        continue;
+                    }
+                    if s.normal_force > 1e-12 {
+                        for v in &mut s.point {
+                            *v /= s.normal_force;
+                        }
+                    } else {
+                        // Grazing touch: no impulse to weight by, so report
+                        // the plain centroid of this body's manifold.
+                        let pts: Vec<&Collision> =
+                            contacts.iter().filter(|c| c.body_i == bi).collect();
+                        let n = pts.len().max(1) as f64;
+                        let mut acc = Vec3::new(0.0, 0.0, 0.0);
+                        for c in pts {
+                            acc += c.contact_point;
+                        }
+                        s.point = [acc.x / n, acc.y / n, acc.z / n];
+                    }
+                }
+
                 // v' = v_free + M⁻¹ Jᵀ f.
                 self.state.v = &free_v + &asm.velocity_delta(&impulses);
             }
@@ -1092,6 +1181,17 @@ impl PhysicsWorld {
         Some(self.part_pose(body_idx))
     }
 
+    /// Ground-contact state of an instance as of the most recent
+    /// [`Self::step`] — `None` for an unknown instance id.
+    ///
+    /// A body whose collider never reaches the ground (or any body at all,
+    /// with the ground disabled) reports the default "not in contact, zero
+    /// force" state.
+    pub fn get_instance_contact(&self, instance_id: &str) -> Option<ContactState> {
+        let &body_idx = self.instance_to_body.get(instance_id)?;
+        self.body_contacts.get(body_idx).copied()
+    }
+
     /// World pose of the PART frame for a body: composes the body-in-world
     /// pose from FK with the stored part→body frame, so callers see the
     /// part's local origin/axes (the thing renderers pose), not the internal
@@ -1115,6 +1215,12 @@ impl PhysicsWorld {
     /// Set gravity vector.
     pub fn set_gravity(&mut self, x: f32, y: f32, z: f32) {
         self.model.gravity = Vec3::new(x as f64, y as f64, z as f64);
+    }
+
+    /// An instance's body mass in kilograms — `None` for an unknown id.
+    pub fn get_instance_mass(&self, instance_id: &str) -> Option<f64> {
+        let &body_idx = self.instance_to_body.get(instance_id)?;
+        Some(self.model.bodies[body_idx].inertia.mass)
     }
 
     /// Scale an instance's mass (and rotational inertia) by `scale`.

--- a/crates/vcad-kernel-physics/tests/contact_observation.rs
+++ b/crates/vcad-kernel-physics/tests/contact_observation.rs
@@ -1,0 +1,133 @@
+//! Per-end-effector ground contact must reach the gym observation: a resting
+//! body reports in-contact with a normal force equal to its supported weight,
+//! and an airborne body reports no contact at all.
+//!
+//! This is the foot-force channel every real humanoid locomotion policy gets
+//! (foot FSRs / ankle F/T). Without it a balance policy cannot tell a loaded
+//! foot from a swinging one.
+
+use vcad_ir::Document;
+use vcad_kernel_physics::{Action, GroundConfig, PhysicsWorld, RobotEnv};
+
+const G: f64 = 9.81;
+
+/// Ground base + a torso on a Free joint, starting `z0` mm up.
+fn free_base_doc(z0: f64) -> Document {
+    serde_json::from_value(serde_json::json!({
+        "version": "0.1",
+        "nodes": {
+            "0": {"id": 0, "op": {"type": "Cube", "size": {"x": 100.0, "y": 100.0, "z": 20.0}}},
+            "1": {"id": 1, "op": {"type": "Cube", "size": {"x": 60.0, "y": 40.0, "z": 120.0}}}
+        },
+        "roots": [],
+        "materials": {},
+        "part_materials": {},
+        "partDefs": {
+            "base": {"id": "base", "name": "base", "root": 0},
+            "torso": {"id": "torso", "name": "torso", "root": 1}
+        },
+        "instances": [
+            {"id": "base_inst", "partDefId": "base"},
+            {"id": "torso_inst", "partDefId": "torso"}
+        ],
+        "joints": [
+            {"id": "floating_base", "parentInstanceId": "base_inst",
+             "childInstanceId": "torso_inst",
+             "parentAnchor": {"x": 0.0, "y": 0.0, "z": z0},
+             "childAnchor": {"x": 0.0, "y": 0.0, "z": 0.0},
+             "kind": {"type": "Free"},
+             "state": 0.0}
+        ],
+        "groundInstanceId": "base_inst"
+    }))
+    .expect("valid doc")
+}
+
+#[test]
+fn resting_body_reports_contact_carrying_its_weight() {
+    // Start just above the floor so the drop is short and the body has
+    // settled well before the measurement.
+    let doc = free_base_doc(30.0);
+    let mut world = PhysicsWorld::from_document(&doc).unwrap();
+    world.set_ground(GroundConfig::default());
+    let mass = world.get_instance_mass("torso_inst").expect("torso body");
+
+    // 2 s at 1/240: land, bleed off the impact, settle.
+    for _ in 0..480 {
+        world.step(1.0 / 240.0);
+    }
+
+    let c = world
+        .get_instance_contact("torso_inst")
+        .expect("torso body");
+    assert!(c.in_contact, "settled body reports no ground contact");
+
+    let weight = mass * G;
+    let err = (c.normal_force - weight).abs() / weight;
+    assert!(
+        err < 0.05,
+        "normal force {} N should carry the body's weight {} N (rel err {err:.3})",
+        c.normal_force,
+        weight
+    );
+
+    // Center of pressure under the body, on the floor.
+    assert!(
+        c.point[0].abs() < 0.05 && c.point[1].abs() < 0.05 && c.point[2].abs() < 0.01,
+        "center of pressure {:?} is not under the resting body at z≈0",
+        c.point
+    );
+}
+
+#[test]
+fn airborne_body_reports_no_contact() {
+    let doc = free_base_doc(2000.0);
+    let mut world = PhysicsWorld::from_document(&doc).unwrap();
+    world.set_ground(GroundConfig::default());
+
+    // A tenth of a second of free fall from 2 m: still far above the floor.
+    for _ in 0..24 {
+        world.step(1.0 / 240.0);
+    }
+
+    let c = world
+        .get_instance_contact("torso_inst")
+        .expect("torso body");
+    assert!(!c.in_contact, "airborne body reports ground contact");
+    assert_eq!(c.normal_force, 0.0);
+}
+
+#[test]
+fn gym_observation_surfaces_end_effector_contact() {
+    let mut env = RobotEnv::new(
+        free_base_doc(30.0),
+        vec!["torso_inst".to_string()],
+        None,
+        None,
+        None, // default ground: plane at z = 0
+    )
+    .unwrap();
+
+    // Fresh reset: no step has run yet, so nothing is in contact.
+    let obs = env.reset();
+    assert_eq!(obs.end_effector_contacts.len(), 1);
+    assert!(!obs.end_effector_contacts[0].in_contact);
+
+    // 120 env steps × 4 substeps = 2 s: landed and settled.
+    let mut last = obs;
+    for _ in 0..120 {
+        let (o, _, _) = env.step(Action::Torque(vec![0.0; env.action_dim()]));
+        last = o;
+    }
+
+    let c = last.end_effector_contacts[0];
+    assert!(c.in_contact, "settled end effector reports no contact");
+    assert!(
+        c.normal_force > 0.0,
+        "settled end effector carries no normal force"
+    );
+
+    // The layout the docs promise: 7 pose slots + 5 contact slots per EE.
+    let joint_slots: usize = env.joint_slot_counts().iter().sum();
+    assert_eq!(env.observation_dim(), joint_slots * 2 + 12);
+}

--- a/crates/vcad-kernel-physics/tests/free_joint.rs
+++ b/crates/vcad-kernel-physics/tests/free_joint.rs
@@ -119,7 +119,9 @@ fn free_joint_gym_observation_layout() {
     // but not in the action space.
     assert_eq!(env.num_joints(), 1);
     assert_eq!(env.action_dim(), 0);
-    assert_eq!(env.observation_dim(), 6 * 2 + 7);
+    // 6 position + 6 velocity slots, plus the end effector's 7 pose slots and
+    // 5 contact slots (flag, normal force, center of pressure).
+    assert_eq!(env.observation_dim(), 6 * 2 + 7 + 5);
 
     let obs = env.reset();
     assert_eq!(obs.joint_positions.len(), 6);

--- a/crates/vcad-sim/examples/k1_stand.rs
+++ b/crates/vcad-sim/examples/k1_stand.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect();
     let slots = actuated_slots(&probe);
     let act_dim = probe.action_dim();
-    let obs_dim = 10 + 2 * slots.len();
+    let obs_dim = vcad_sim::rl::feature_dim(&probe, &slots);
     drop(probe);
 
     // Reward: stay alive, hold the nominal height and an upright trunk, don't

--- a/crates/vcad-sim/src/rl.rs
+++ b/crates/vcad-sim/src/rl.rs
@@ -247,7 +247,14 @@ pub struct IterationLog {
 ///
 /// Layout (all SI-ish and roughly unit-scaled before whitening):
 /// `[projected gravity (3), base linear vel (3), base angular vel (3),
-///   base height − nominal (1), joint angles rad (n), joint velocities rad/s (n)]`
+///   base height − nominal (1), joint angles rad (n), joint velocities rad/s (n),
+///   per-end-effector (in_contact 0/1, normal force N) (2·m)]`
+///
+/// The trailing contact pair is the foot-force channel: without it a balance
+/// policy has no way to tell a loaded foot from a swinging one. Raw newtons
+/// are fine here — ARS whitens every feature against its running statistics.
+///
+/// Use [`feature_dim`] rather than recomputing this length by hand.
 pub fn features(
     obs: &vcad_kernel_physics::Observation,
     slots: &[usize],
@@ -276,7 +283,19 @@ pub fn features(
     for &s in slots {
         f.push(obs.joint_velocities[s].to_radians());
     }
+    for c in &obs.end_effector_contacts {
+        f.push(if c.in_contact { 1.0 } else { 0.0 });
+        f.push(c.normal_force);
+    }
     f
+}
+
+/// Length of the [`features`] vector for an env — the policy's `obs_dim`.
+///
+/// `10` fixed base features, two per actuated joint slot, two per end
+/// effector (contact flag + normal force).
+pub fn feature_dim(env: &RobotEnv, slots: &[usize]) -> usize {
+    10 + 2 * slots.len() + 2 * env.end_effector_ids().len()
 }
 
 /// Flattened observation slot index of each actuated joint's first DOF.

--- a/crates/vcad-sim/src/rl.rs
+++ b/crates/vcad-sim/src/rl.rs
@@ -292,8 +292,15 @@ pub fn features(
 
 /// Length of the [`features`] vector for an env — the policy's `obs_dim`.
 ///
-/// `10` fixed base features, two per actuated joint slot, two per end
-/// effector (contact flag + normal force).
+/// `10` fixed base features, two per entry in `slots` (a position and a
+/// velocity), and two per end effector (contact flag + normal force).
+///
+/// `slots` is [`actuated_slots`]' output — one *index* per actuated joint,
+/// pointing at that joint's FIRST DOF, not a per-joint DOF count. So
+/// `features` reads exactly one position and one velocity per actuated joint
+/// even for a multi-DOF (Ball, 3 DOF) one, whose remaining slots it ignores.
+/// Every actuated joint on the K1 is single-DOF; a multi-DOF actuated joint
+/// would need `features` extended first, and this length with it.
 pub fn feature_dim(env: &RobotEnv, slots: &[usize]) -> usize {
     10 + 2 * slots.len() + 2 * env.end_effector_ids().len()
 }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -317,6 +317,7 @@ export type {
 export { PhysicsEnv, isPhysicsAvailable } from "./physics.js";
 export type {
   PhysicsObservation,
+  PhysicsContactState,
   PhysicsStepResult,
   PhysicsStepInfo,
   PhysicsEnvOptions,

--- a/packages/engine/src/physics.ts
+++ b/packages/engine/src/physics.ts
@@ -32,6 +32,22 @@ export interface PhysicsObservation {
   base_pose?: [number, number, number, number, number, number, number];
   /** Base velocity as [vx, vy, vz, wx, wy, wz] (m/s, rad/s, world frame). */
   base_velocity?: [number, number, number, number, number, number];
+  /**
+   * Ground contact under each end effector, index-aligned with
+   * `end_effector_poses` — the foot-force sensor (FSR / ankle F/T). Absent on
+   * kernel builds predating contact observations.
+   */
+  end_effector_contacts?: PhysicsContactState[];
+}
+
+/** One end effector's ground contact as of the last step. */
+export interface PhysicsContactState {
+  /** The collider touched the ground plane during the last step. */
+  in_contact: boolean;
+  /** Total normal force over the contact manifold, newtons. */
+  normal_force: number;
+  /** Center of pressure in world meters; [0, 0, 0] when not in contact. */
+  point: [number, number, number];
 }
 
 /** Per-step diagnostics from the kernel — reward inputs for the client. */
@@ -92,6 +108,9 @@ export interface PhysicsObservationNoise {
   base_pos_std?: number;
   base_rot_std?: number;
   base_vel_std?: number;
+  /** Std-dev on end-effector contact normal force (newtons); the noisy force
+   *  is clamped at 0. The in-contact flag stays clean. */
+  contact_force_std?: number;
 }
 
 /** Configurable termination conditions. */

--- a/packages/mcp/src/__tests__/gym-session-first.test.ts
+++ b/packages/mcp/src/__tests__/gym-session-first.test.ts
@@ -151,7 +151,15 @@ describe("observation labeling", () => {
 
       // End effectors are keyed by the instance id they were requested under.
       expect(obs.end_effectors).toEqual([
-        { id: "link1_inst", pose: obs.end_effector_poses[0] },
+        {
+          id: "link1_inst",
+          pose: obs.end_effector_poses[0],
+          // Kernel builds that report per-foot contact get the labeled
+          // view too; older ones omit it rather than guessing.
+          ...(obs.end_effector_contacts
+            ? { contact: obs.end_effector_contacts[0] }
+            : {}),
+        },
       ]);
 
       // Joints are keyed by joint id when the kernel reports them; older
@@ -265,7 +273,15 @@ describe("batch_create_envs document input", () => {
     expect(reset.observations).toHaveLength(2);
     for (const obs of reset.observations) {
       expect(obs.end_effectors).toEqual([
-        { id: "link1_inst", pose: obs.end_effector_poses[0] },
+        {
+          id: "link1_inst",
+          pose: obs.end_effector_poses[0],
+          // Kernel builds that report per-foot contact get the labeled
+          // view too; older ones omit it rather than guessing.
+          ...(obs.end_effector_contacts
+            ? { contact: obs.end_effector_contacts[0] }
+            : {}),
+        },
       ]);
     }
   });

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -7103,7 +7103,7 @@
         },
         "config": {
           "type": "object",
-          "description": "Optional env config for sim2real training. `randomization`: seeded domain randomization applied on every reset — {mass_scale: {min, max} (per-link multiplicative, e.g. 0.9–1.1), friction_scale: {min, max} (per-joint friction/damping), pd_gain_scale: {min, max} (global PD gain), action_latency_steps: [min, max] (actuator delay in physics substeps, e.g. [2, 8]), joint_pos_perturb / joint_vel_perturb (uniform ± initial state, deg/mm)}. `observation_noise`: gaussian std-devs {joint_pos_std, joint_vel_std, base_pos_std, base_rot_std, base_vel_std}. `termination`: {base_height_below (m), base_tilt_above_deg, terminate_on_joint_limit}. `base_instance_id`: instance used for base pose/velocity observations (default: the ground instance)."
+          "description": "Optional env config for sim2real training. `randomization`: seeded domain randomization applied on every reset — {mass_scale: {min, max} (per-link multiplicative, e.g. 0.9–1.1), friction_scale: {min, max} (per-joint friction/damping), pd_gain_scale: {min, max} (global PD gain), action_latency_steps: [min, max] (actuator delay in physics substeps, e.g. [2, 8]), joint_pos_perturb / joint_vel_perturb (uniform ± initial state, deg/mm)}. `observation_noise`: gaussian std-devs {joint_pos_std, joint_vel_std, base_pos_std, base_rot_std, base_vel_std, contact_force_std (N)}. `termination`: {base_height_below (m), base_tilt_above_deg, terminate_on_joint_limit}. `base_instance_id`: instance used for base pose/velocity observations (default: the ground instance)."
         },
         "ground_enabled": {
           "type": "boolean",

--- a/packages/mcp/src/tools/gym.ts
+++ b/packages/mcp/src/tools/gym.ts
@@ -12,6 +12,7 @@ import type { Document } from "@vcad/ir";
 import {
   PhysicsEnv,
   isPhysicsAvailable,
+  type PhysicsContactState,
   type PhysicsObservation,
   type PhysicsStepResult,
   type PhysicsActionType,
@@ -248,6 +249,8 @@ interface LabeledJoint {
 interface LabeledEndEffector {
   id: string;
   pose: [number, number, number, number, number, number, number];
+  /** Ground contact under this end effector, when the kernel reports it. */
+  contact?: PhysicsContactState;
 }
 
 /** An observation with the bare arrays retained (unchanged wire contract) plus
@@ -323,6 +326,9 @@ export function labelObservation(
     labeled.end_effectors = endEffectorIds.map((id, i) => ({
       id,
       pose: obs.end_effector_poses[i],
+      ...(obs.end_effector_contacts?.[i]
+        ? { contact: obs.end_effector_contacts[i] }
+        : {}),
     }));
   }
   return labeled;
@@ -386,7 +392,7 @@ export const createRobotEnvSchema = {
         "e.g. [2, 8]), joint_pos_perturb / joint_vel_perturb (uniform ± initial " +
         "state, deg/mm)}. " +
         "`observation_noise`: gaussian std-devs {joint_pos_std, joint_vel_std, " +
-        "base_pos_std, base_rot_std, base_vel_std}. " +
+        "base_pos_std, base_rot_std, base_vel_std, contact_force_std (N)}. " +
         "`termination`: {base_height_below (m), base_tilt_above_deg, " +
         "terminate_on_joint_limit}. " +
         "`base_instance_id`: instance used for base pose/velocity observations " +


### PR DESCRIPTION
Closes the `TODO(contact)` at the top of `crates/vcad-kernel-physics/src/gym.rs`.

## Why

#766 added the ARS trainer and a Booster K1 balance policy that tops out around 30 of 400 steps. Its observation was projected gravity, base velocities, height error, and joint state — nothing about whether either foot was loaded. Every real humanoid locomotion policy gets contact/force feedback, and the solver was already computing the manifold every substep and discarding it.

## What changed

**Kernel (`vcad-kernel-physics`)**
- `world.rs`: public `ContactState { in_contact, normal_force, point }`, retained per body in `body_contacts` and rewritten on every `step` — cleared first, then filled from the final substep's solve. Force is the solved normal impulse ÷ dt; `point` is the impulse-weighted manifold centroid (the center of pressure), falling back to the plain centroid on a grazing touch that carries no impulse. New accessors `get_instance_contact` and `get_instance_mass`.
- `gym.rs`: `Observation::end_effector_contacts`, one entry per `end_effector_ids` entry in that order (`#[serde(default)]`, so older JSON still deserializes). `observation_dim()` now counts `7 + 5` per end effector — pose, then flag/force/CoP — and the layout is documented alongside the existing joint-slot docs. An unknown end-effector id contributes the default state rather than being skipped, so the vector stays index-aligned with `end_effector_poses`.

**Privileged-information split respected.** Contact force is a real sensor (foot FSRs / ankle F/T), so it rides the noisy observation: `ObservationNoise::contact_force_std` perturbs `StepResult::observation` only, clamped at ≥ 0 (a load cell can't report negative normal load), while `observe()` and `StepInfo` stay ground truth. The `in_contact` flag is deliberately left clean — it models a foot switch, a separate and far less noisy sensor from the force channel.

**Trainer (`vcad-sim`)** — `rl::features()` appends `(in_contact, normal_force)` per end effector (K1: 54 → 58 features); new `rl::feature_dim()` so callers stop recomputing the length by hand, now used by `examples/k1_stand.rs`.

**Surface** — `end_effector_contacts` and `contact_force_std` added to `@vcad/engine`'s `PhysicsObservation` / `PhysicsObservationNoise`, plus a `contact` field on the MCP labeled-observation view (tool-surface fixture regenerated for the one-line schema description change).

## Tests

New `crates/vcad-kernel-physics/tests/contact_observation.rs`:
- a body settled on the ground reports in-contact with normal force within 5% of its supported weight, and a center of pressure under it at z ≈ 0;
- a body 0.1 s into a 2 m fall reports not-in-contact with zero force;
- the same reaches the gym `Observation`, with the promised `observation_dim()`.

One existing assertion in `free_joint.rs` updated for the 5 new slots. Full `vcad-kernel-physics` and `vcad-sim` suites pass, as does `npm test -w @vcad/mcp`.

## Measured effect on K1 training

Paired 200-iteration ARS runs, identical seeds/config/gains, same machine, run concurrently — one arm built with the contact features stripped from `features()`:

| | 10-seed mean return | best-iterate eval | steps |
|---|---|---|---|
| hold-rest-pose baseline | 6.14 | — | 17 |
| control (54 features) | 11.01 | 114.89 | ~32 |
| with contact (58 features) | **19.02** | 124.18 | ~36 |

The control landed on exactly the 11.01 recorded in #766, which confirms the arms are matched and that #766's best iterate was already found within the first 200 iterations.

**Two caveats worth holding to.** This is one paired run on a metric #766 documented as seed-dominated — suggestive, not significant; several seeds per arm would be needed to call it. And the task is still unsolved: neither policy survives a full episode (0/10), and the worst seed in both still tips out at ~15 steps.

## Reviewer notes

- Reproducing the K1 env needs one manual step the URDF import doesn't do: raise `world_joint.parentAnchor.z` to 620 mm after importing `K1_22dof_floating.urdf`. The import anchors the floating base at z = 0, where every episode terminates on `base_height` at step 1. With 620 mm the hold-rest-pose baseline reproduces at 6.14 / 17 steps.
- Not touched: `cargo clippy -p vcad-kernel-physics --all-targets` fails on a pre-existing `absurd_extreme_comparisons` in a gym.rs test at HEAD (`action_latency_substeps <= u32::MAX`). It predates this branch and sits outside the `--workspace` lint the project gate runs, so CI is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)