### PR TITLE
feat(urdf): floating-base import option

### DIFF
--- a/changelog/entries/2026-07-31-urdf-floating-base.json
+++ b/changelog/entries/2026-07-31-urdf-floating-base.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-07-31-urdf-floating-base",
+  "version": "0.9.4",
+  "date": "2026-07-31",
+  "category": "feat",
+  "title": "URDF import can synthesize a floating base",
+  "summary": "Humanoid URDFs ship the world link and floating joint commented out; import_urdf's floating_base option injects them so the robot can fall and walk instead of being welded to the world.",
+  "features": ["urdf", "physics", "simulation"],
+  "mcpTools": ["import_urdf"]
+}

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -78,6 +78,25 @@ enum Commands {
         input: PathBuf,
         /// Output .vcad file
         output: PathBuf,
+        /// Synthesize a floating (6-DOF) base when the URDF has none.
+        ///
+        /// Most humanoid/quadruped URDFs ship the world link and its
+        /// `type="floating"` joint commented out, leaving the robot welded
+        /// to the world on import. This injects them.
+        #[arg(long)]
+        floating_base: bool,
+        /// Link to attach the floating base to (default: the tree's root).
+        #[arg(long, value_name = "LINK", requires = "floating_base")]
+        floating_base_link: Option<String>,
+        /// Initial base height in mm for the synthesized floating base.
+        /// Spawn just above the settled standing height (Booster K1: 620).
+        #[arg(
+            long,
+            value_name = "MM",
+            default_value = "0",
+            requires = "floating_base"
+        )]
+        spawn_height_mm: f64,
     },
 
     /// Render document to image
@@ -257,6 +276,19 @@ enum Commands {
         /// subdirectories (the standard ROS package layout).
         #[arg(long = "package-root", value_name = "DIR")]
         package_roots: Vec<PathBuf>,
+        /// Synthesize a floating (6-DOF) base when a .urdf input has none.
+        /// Without it the root link is grounded and the robot is welded to
+        /// the world — it can neither walk nor fall.
+        #[arg(long)]
+        floating_base: bool,
+        /// Initial base height in mm for `--floating-base`.
+        #[arg(
+            long,
+            value_name = "MM",
+            default_value = "0",
+            requires = "floating_base"
+        )]
+        spawn_height_mm: f64,
     },
 
     /// Slice a .vcad file for 3D printing
@@ -347,8 +379,20 @@ fn main() -> Result<()> {
         }) => {
             import_step(&input, &output, name)?;
         }
-        Some(Commands::ImportUrdf { input, output }) => {
-            import_urdf(&input, &output)?;
+        Some(Commands::ImportUrdf {
+            input,
+            output,
+            floating_base,
+            floating_base_link,
+            spawn_height_mm,
+        }) => {
+            import_urdf(
+                &input,
+                &output,
+                floating_base,
+                floating_base_link,
+                spawn_height_mm,
+            )?;
         }
         Some(Commands::Render {
             input,
@@ -450,8 +494,18 @@ fn main() -> Result<()> {
             dt,
             log_every,
             package_roots,
+            floating_base,
+            spawn_height_mm,
         }) => {
-            simulate_file(&input, steps, dt, log_every, &package_roots)?;
+            simulate_file(
+                &input,
+                steps,
+                dt,
+                log_every,
+                &package_roots,
+                floating_base,
+                spawn_height_mm,
+            )?;
         }
         Some(Commands::Slice {
             input,
@@ -1070,11 +1124,31 @@ fn print_timing(timing: &vcad_eval::EvalTiming) {
     }
 }
 
-fn import_urdf(input: &PathBuf, output: &PathBuf) -> Result<()> {
+fn import_urdf(
+    input: &PathBuf,
+    output: &PathBuf,
+    floating_base: bool,
+    floating_base_link: Option<String>,
+    spawn_height_mm: f64,
+) -> Result<()> {
     use std::fs;
+    use vcad_kernel_urdf::UrdfReadOptions;
 
     // Import the URDF file
-    let doc = vcad_kernel_urdf::read_urdf(input)?;
+    let opts = UrdfReadOptions {
+        urdf_dir: input.parent().map(|p| p.to_path_buf()),
+        floating_base,
+        floating_base_link,
+        spawn_height_mm,
+        ..UrdfReadOptions::default()
+    };
+    let doc = vcad_kernel_urdf::read_urdf_with_options(input, &opts)?;
+    if floating_base {
+        println!(
+            "Floating base: synthesized a 6-DOF root joint at z = {spawn_height_mm} mm \
+             (parentAnchor.z sets the spawn height)"
+        );
+    }
 
     // Write the document
     let json = doc.to_json()?;
@@ -1100,6 +1174,8 @@ fn simulate_file(
     dt: f64,
     log_every: u32,
     package_roots: &[PathBuf],
+    floating_base: bool,
+    spawn_height_mm: f64,
 ) -> Result<()> {
     use vcad_kernel_physics::PhysicsWorld;
     use vcad_kernel_urdf::UrdfReadOptions;
@@ -1115,6 +1191,9 @@ fn simulate_file(
             let opts = UrdfReadOptions {
                 package_roots: package_roots.to_vec(),
                 urdf_dir: input.parent().map(|p| p.to_path_buf()),
+                floating_base,
+                spawn_height_mm,
+                ..UrdfReadOptions::default()
             };
             vcad_kernel_urdf::read_urdf_with_options(input, &opts)?
         }

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -281,6 +281,9 @@ enum Commands {
         /// the world — it can neither walk nor fall.
         #[arg(long)]
         floating_base: bool,
+        /// Link to attach the floating base to (default: the tree's root).
+        #[arg(long, value_name = "LINK", requires = "floating_base")]
+        floating_base_link: Option<String>,
         /// Initial base height in mm for `--floating-base`.
         #[arg(
             long,
@@ -495,6 +498,7 @@ fn main() -> Result<()> {
             log_every,
             package_roots,
             floating_base,
+            floating_base_link,
             spawn_height_mm,
         }) => {
             simulate_file(
@@ -504,6 +508,7 @@ fn main() -> Result<()> {
                 log_every,
                 &package_roots,
                 floating_base,
+                floating_base_link,
                 spawn_height_mm,
             )?;
         }
@@ -1175,6 +1180,7 @@ fn simulate_file(
     log_every: u32,
     package_roots: &[PathBuf],
     floating_base: bool,
+    floating_base_link: Option<String>,
     spawn_height_mm: f64,
 ) -> Result<()> {
     use vcad_kernel_physics::PhysicsWorld;
@@ -1192,6 +1198,7 @@ fn simulate_file(
                 package_roots: package_roots.to_vec(),
                 urdf_dir: input.parent().map(|p| p.to_path_buf()),
                 floating_base,
+                floating_base_link,
                 spawn_height_mm,
                 ..UrdfReadOptions::default()
             };

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -392,9 +392,11 @@ fn main() -> Result<()> {
             import_urdf(
                 &input,
                 &output,
-                floating_base,
-                floating_base_link,
-                spawn_height_mm,
+                FloatingBase {
+                    enabled: floating_base,
+                    link: floating_base_link,
+                    spawn_height_mm,
+                },
             )?;
         }
         Some(Commands::Render {
@@ -507,9 +509,11 @@ fn main() -> Result<()> {
                 dt,
                 log_every,
                 &package_roots,
-                floating_base,
-                floating_base_link,
-                spawn_height_mm,
+                FloatingBase {
+                    enabled: floating_base,
+                    link: floating_base_link,
+                    spawn_height_mm,
+                },
             )?;
         }
         Some(Commands::Slice {
@@ -1129,28 +1133,34 @@ fn print_timing(timing: &vcad_eval::EvalTiming) {
     }
 }
 
-fn import_urdf(
-    input: &PathBuf,
-    output: &PathBuf,
-    floating_base: bool,
-    floating_base_link: Option<String>,
+/// The `--floating-base` family of flags, shared by `import-urdf` and
+/// `simulate`.
+struct FloatingBase {
+    /// Synthesize a world link + 6-DOF joint when the URDF declares none.
+    enabled: bool,
+    /// Link to attach it to (default: the tree's root link).
+    link: Option<String>,
+    /// Initial base height in mm, written as the joint's `parentAnchor.z`.
     spawn_height_mm: f64,
-) -> Result<()> {
+}
+
+fn import_urdf(input: &PathBuf, output: &PathBuf, floating: FloatingBase) -> Result<()> {
     use std::fs;
     use vcad_kernel_urdf::UrdfReadOptions;
 
     // Import the URDF file
     let opts = UrdfReadOptions {
         urdf_dir: input.parent().map(|p| p.to_path_buf()),
-        floating_base,
-        floating_base_link,
-        spawn_height_mm,
+        floating_base: floating.enabled,
+        floating_base_link: floating.link,
+        spawn_height_mm: floating.spawn_height_mm,
         ..UrdfReadOptions::default()
     };
     let doc = vcad_kernel_urdf::read_urdf_with_options(input, &opts)?;
-    if floating_base {
+    if floating.enabled {
+        let z = floating.spawn_height_mm;
         println!(
-            "Floating base: synthesized a 6-DOF root joint at z = {spawn_height_mm} mm \
+            "Floating base: synthesized a 6-DOF root joint at z = {z} mm \
              (parentAnchor.z sets the spawn height)"
         );
     }
@@ -1179,9 +1189,7 @@ fn simulate_file(
     dt: f64,
     log_every: u32,
     package_roots: &[PathBuf],
-    floating_base: bool,
-    floating_base_link: Option<String>,
-    spawn_height_mm: f64,
+    floating: FloatingBase,
 ) -> Result<()> {
     use vcad_kernel_physics::PhysicsWorld;
     use vcad_kernel_urdf::UrdfReadOptions;
@@ -1197,10 +1205,9 @@ fn simulate_file(
             let opts = UrdfReadOptions {
                 package_roots: package_roots.to_vec(),
                 urdf_dir: input.parent().map(|p| p.to_path_buf()),
-                floating_base,
-                floating_base_link,
-                spawn_height_mm,
-                ..UrdfReadOptions::default()
+                floating_base: floating.enabled,
+                floating_base_link: floating.link,
+                spawn_height_mm: floating.spawn_height_mm,
             };
             vcad_kernel_urdf::read_urdf_with_options(input, &opts)?
         }

--- a/crates/vcad-kernel-physics/tests/stl_loader.rs
+++ b/crates/vcad-kernel-physics/tests/stl_loader.rs
@@ -99,6 +99,7 @@ fn urdf_resolves_package_uri() {
     let opts = UrdfReadOptions {
         package_roots: vec![tmp.clone()],
         urdf_dir: None,
+        ..UrdfReadOptions::default()
     };
     let doc = read_urdf_from_str_with_options(urdf, &opts).expect("parse URDF");
 

--- a/crates/vcad-kernel-physics/tests/unitree.rs
+++ b/crates/vcad-kernel-physics/tests/unitree.rs
@@ -189,3 +189,94 @@ fn unitree_g1_pd_hold_with_ground_contact_stays_finite() {
         }
     }
 }
+
+/// The G1 URDF, like nearly every humanoid descriptor, declares no floating
+/// joint — the convention is that the simulator supplies the free base.
+/// Imported plainly, the root link is grounded and the robot is welded to
+/// the world; with `floating_base` the importer synthesizes the world link
+/// and a 6-DOF `Free` joint, and the base falls under gravity.
+#[test]
+fn unitree_g1_floating_base_falls_under_gravity() {
+    use vcad_ir::JointKind;
+    use vcad_kernel_urdf::UrdfReadOptions;
+
+    let urdf_path = examples_dir().join("unitree-g1.urdf");
+
+    // Baseline: default import is unchanged — no Free joint, root grounded.
+    let welded = vcad_kernel_urdf::read_urdf(&urdf_path).expect("parse unitree-g1.urdf");
+    assert!(
+        !welded
+            .joints
+            .as_ref()
+            .expect("joints")
+            .iter()
+            .any(|j| matches!(j.kind, JointKind::Free)),
+        "default import must not synthesize a floating base"
+    );
+
+    let opts = UrdfReadOptions {
+        urdf_dir: urdf_path.parent().map(|p| p.to_path_buf()),
+        floating_base: true,
+        spawn_height_mm: 900.0,
+        ..UrdfReadOptions::default()
+    };
+    let doc = vcad_kernel_urdf::read_urdf_with_options(&urdf_path, &opts)
+        .expect("parse unitree-g1.urdf with floating base");
+
+    // Exactly one link and one joint more than the welded import.
+    assert_eq!(
+        doc.part_defs.as_ref().unwrap().len(),
+        welded.part_defs.as_ref().unwrap().len() + 1
+    );
+    let joints = doc.joints.as_ref().expect("joints");
+    let free: Vec<_> = joints
+        .iter()
+        .filter(|j| matches!(j.kind, JointKind::Free))
+        .collect();
+    assert_eq!(free.len(), 1, "exactly one synthesized floating joint");
+    // parentAnchor.z carries the spawn height (a Free joint's scalar state
+    // cannot).
+    assert!((free[0].parent_anchor.z - 900.0).abs() < 1e-9);
+
+    // The floating base is what the *root* link hangs from, so the welded
+    // import's grounded instance is now the Free joint's child.
+    let root_instance = welded.ground_instance_id.as_ref().expect("welded ground");
+    assert_eq!(&free[0].child_instance_id, root_instance);
+    assert_ne!(doc.ground_instance_id.as_ref(), Some(root_instance));
+
+    // No ground plane: with a free base the whole robot accelerates
+    // downward. Welded, that instance cannot move at all.
+    let mut world = PhysicsWorld::from_document(&doc).expect("build PhysicsWorld");
+    let z0 = world
+        .get_instance_pose(root_instance)
+        .expect("root instance pose")
+        .0[2];
+    for _ in 0..240 {
+        world.step(1.0 / 240.0);
+    }
+    let z1 = world
+        .get_instance_pose(root_instance)
+        .expect("root instance pose")
+        .0[2];
+    assert!(
+        z1.is_finite() && z1 < z0 - 1.0,
+        "floating base should fall under gravity over 1 s: z {z0} -> {z1}"
+    );
+
+    let mut welded_world = PhysicsWorld::from_document(&welded).expect("build welded world");
+    let wz0 = welded_world
+        .get_instance_pose(root_instance)
+        .expect("root instance pose")
+        .0[2];
+    for _ in 0..240 {
+        welded_world.step(1.0 / 240.0);
+    }
+    let wz1 = welded_world
+        .get_instance_pose(root_instance)
+        .expect("root instance pose")
+        .0[2];
+    assert!(
+        (wz1 - wz0).abs() < 1e-6,
+        "welded root must stay pinned: z {wz0} -> {wz1}"
+    );
+}

--- a/crates/vcad-kernel-urdf/src/lib.rs
+++ b/crates/vcad-kernel-urdf/src/lib.rs
@@ -31,7 +31,7 @@ mod writer;
 
 pub use error::UrdfError;
 pub use reader::{
-    read_urdf, read_urdf_from_str, read_urdf_from_str_with_options, read_urdf_with_options,
-    UrdfReadOptions,
+    commented_out_floating_joint, read_urdf, read_urdf_from_str, read_urdf_from_str_with_options,
+    read_urdf_with_options, UrdfReadOptions,
 };
 pub use writer::{write_urdf, write_urdf_to_string};

--- a/crates/vcad-kernel-urdf/src/reader.rs
+++ b/crates/vcad-kernel-urdf/src/reader.rs
@@ -163,6 +163,32 @@ pub struct UrdfReadOptions {
     /// Directory the URDF lives in — used as the base for resolving
     /// relative mesh paths. Set automatically by [`read_urdf`].
     pub urdf_dir: Option<PathBuf>,
+    /// Synthesize a floating base when the URDF has no floating joint.
+    ///
+    /// Most humanoid/quadruped URDFs ship the `world` link and its
+    /// `type="floating"` joint **commented out**, because the convention is
+    /// that the simulator supplies the free base (MuJoCo's MJCF for the same
+    /// robot carries `<joint type="free"/>`). Without it vcad grounds the
+    /// tree's root link and the robot is welded to the world — physically
+    /// pinned, useless for locomotion. Setting this injects exactly the
+    /// commented-out block: a geometry-less `world` link plus a
+    /// [`JointKind::Free`] joint from it to the root link.
+    ///
+    /// No-op when the URDF already declares a floating joint.
+    pub floating_base: bool,
+    /// Link to attach the synthesized floating base to. Defaults to the
+    /// tree's root link (the one that is never a joint's child). Ignored
+    /// unless [`Self::floating_base`] is set.
+    pub floating_base_link: Option<String>,
+    /// Initial base height in **millimetres**, written as the synthesized
+    /// joint's origin `z`.
+    ///
+    /// A `Free` joint's `state` is a scalar and therefore meaningless for
+    /// 6 DOF, so `parentAnchor.z` is what actually sets the spawn height.
+    /// Spawn slightly above the settled standing height so the robot drops
+    /// onto the ground rather than starting interpenetrated (for the Booster
+    /// K1, 620 mm against a 549.8 mm settled stand). Defaults to 0.
+    pub spawn_height_mm: f64,
 }
 
 impl UrdfReadOptions {
@@ -286,8 +312,162 @@ pub fn read_urdf_from_str_with_options(
             MAX_JOINTS
         )));
     }
+    let mut robot = robot;
+    apply_floating_base(&mut robot, opts, xml)?;
     let reader = UrdfReader::new(&robot, opts);
     reader.into_document()
+}
+
+/// Name of the floating joint found inside a commented-out region of `xml`,
+/// if any.
+///
+/// The near-universal convention is to ship the world link and its floating
+/// joint commented out and let the simulator supply the free base. That
+/// comment is a strong signal the author *wants* a floating base, so callers
+/// can surface it when [`UrdfReadOptions::floating_base`] was not requested.
+pub fn commented_out_floating_joint(xml: &str) -> Option<String> {
+    let mut rest = xml;
+    loop {
+        let start = rest.find("<!--")?;
+        let after = &rest[start + 4..];
+        match after.find("-->") {
+            Some(end) => {
+                if let Some(name) = floating_joint_name_in(&after[..end]) {
+                    return Some(name);
+                }
+                rest = &after[end + 3..];
+            }
+            // Unterminated comment: everything left is commented out.
+            None => return floating_joint_name_in(after),
+        }
+    }
+}
+
+/// Scan a fragment of URDF-ish text for `<joint ... type="floating">` and
+/// return the joint's `name` (or a placeholder when it has none). Purely
+/// textual — the fragment lives inside a comment, so it need not be
+/// well-formed enough to parse.
+fn floating_joint_name_in(body: &str) -> Option<String> {
+    let mut rest = body;
+    while let Some(idx) = rest.find("<joint") {
+        rest = &rest[idx + 6..];
+        let tag_end = rest.find('>').unwrap_or(rest.len());
+        let tag = &rest[..tag_end];
+        if attr_value(tag, "type").as_deref() == Some("floating") {
+            return Some(attr_value(tag, "name").unwrap_or_else(|| "<unnamed>".to_string()));
+        }
+    }
+    None
+}
+
+/// Extract `name="value"` (or `name='value'`) from an XML start-tag body.
+fn attr_value(tag: &str, attr: &str) -> Option<String> {
+    for quote in ['"', '\''] {
+        let needle = format!("{attr}={quote}");
+        if let Some(i) = tag.find(&needle) {
+            let after = &tag[i + needle.len()..];
+            if let Some(j) = after.find(quote) {
+                return Some(after[..j].to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Inject the `world` link + `type="floating"` joint that the URDF left
+/// commented out, when [`UrdfReadOptions::floating_base`] asks for it.
+///
+/// When the option is *not* set but the XML's comments do contain a floating
+/// joint, warn on stderr — that is the case this option exists for.
+fn apply_floating_base(
+    robot: &mut Robot,
+    opts: &UrdfReadOptions,
+    xml: &str,
+) -> Result<(), UrdfError> {
+    let already_floating = robot
+        .joints
+        .iter()
+        .any(|j| j.joint_type.trim() == "floating");
+
+    if !opts.floating_base {
+        if !already_floating {
+            if let Some(name) = commented_out_floating_joint(xml) {
+                eprintln!(
+                    "urdf: '{}' declares a floating joint ({name}) inside a comment — the \
+                     robot will be welded to the world. Re-import with floating_base to \
+                     synthesize it (CLI: --floating-base).",
+                    robot.name
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    if already_floating {
+        return Ok(());
+    }
+
+    let root = match &opts.floating_base_link {
+        Some(link) => {
+            if !robot.links.iter().any(|l| &l.name == link) {
+                return Err(UrdfError::UnknownLink(link.clone()));
+            }
+            link.clone()
+        }
+        None => find_root_link_name(robot)?,
+    };
+
+    let world = unique_name("world", |n| robot.links.iter().any(|l| l.name == n));
+    let joint_name = unique_name("world_joint", |n| robot.joints.iter().any(|j| j.name == n));
+
+    robot.links.push(Link {
+        name: world.clone(),
+        visuals: Vec::new(),
+        collisions: Vec::new(),
+        inertial: None,
+    });
+    // URDF origins are metres; the IR converts ×1000 on the way in.
+    let z_m = opts.spawn_height_mm / 1000.0;
+    robot.joints.push(Joint {
+        name: joint_name,
+        joint_type: "floating".to_string(),
+        origin: Some(crate::types::Origin {
+            xyz: Some(format!("0 0 {z_m}")),
+            rpy: None,
+        }),
+        parent: crate::types::ParentLink { link: world },
+        child: crate::types::ChildLink { link: root },
+        axis: None,
+        limit: None,
+        dynamics: None,
+    });
+    Ok(())
+}
+
+/// First `base` name not already taken, suffixing `_1`, `_2`, … as needed.
+fn unique_name(base: &str, taken: impl Fn(&str) -> bool) -> String {
+    if !taken(base) {
+        return base.to_string();
+    }
+    (1..)
+        .map(|i| format!("{base}_{i}"))
+        .find(|n| !taken(n))
+        .unwrap()
+}
+
+/// The link that is never a joint's child — see
+/// [`UrdfReader::find_root_link`], which does the same on the reader's
+/// borrowed robot.
+fn find_root_link_name(robot: &Robot) -> Result<String, UrdfError> {
+    let children: std::collections::HashSet<_> =
+        robot.joints.iter().map(|j| &j.child.link).collect();
+    robot
+        .links
+        .iter()
+        .find(|l| !children.contains(&l.name))
+        .or_else(|| robot.links.first())
+        .map(|l| l.name.clone())
+        .ok_or_else(|| UrdfError::MissingElement("No links found".to_string()))
 }
 
 /// Case-insensitive scan for `<!DOCTYPE` that ignores leading whitespace.
@@ -977,6 +1157,162 @@ mod tests {
             }
             _ => panic!("Expected Revolute joint"),
         }
+    }
+
+    /// A humanoid-shaped URDF that, like Booster's K1 and most real ones,
+    /// ships its world link + floating joint commented out.
+    const COMMENTED_FLOATING: &str = r#"<?xml version="1.0"?>
+<robot name="k1">
+    <!-- <link name="world"/>
+    <joint name="world_joint" type="floating">
+      <origin xyz="0 0 0"/>
+      <parent link="world"/>
+      <child link="Trunk"/>
+    </joint> -->
+    <link name="Trunk"/>
+    <link name="Thigh"/>
+    <joint name="hip" type="revolute">
+        <parent link="Trunk"/>
+        <child link="Thigh"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1" upper="1" effort="40" velocity="12.5"/>
+    </joint>
+</robot>"#;
+
+    fn floating_opts(height_mm: f64) -> UrdfReadOptions {
+        UrdfReadOptions {
+            floating_base: true,
+            spawn_height_mm: height_mm,
+            ..UrdfReadOptions::default()
+        }
+    }
+
+    #[test]
+    fn test_floating_base_off_by_default() {
+        let doc = read_urdf_from_str(COMMENTED_FLOATING).unwrap();
+        // Unchanged: Trunk is still the ground, no Free joint synthesized.
+        let instances = doc.instances.as_ref().unwrap();
+        assert_eq!(instances.len(), 2);
+        assert_eq!(doc.ground_instance_id.as_deref(), Some("Trunk_inst"));
+        let joints = doc.joints.as_ref().unwrap();
+        assert_eq!(joints.len(), 1);
+        assert!(!matches!(joints[0].kind, JointKind::Free));
+    }
+
+    #[test]
+    fn test_floating_base_synthesizes_free_root_joint() {
+        let doc =
+            read_urdf_from_str_with_options(COMMENTED_FLOATING, &floating_opts(620.0)).unwrap();
+
+        // world is now the grounded link, Trunk hangs off it via Free.
+        assert_eq!(doc.ground_instance_id.as_deref(), Some("world_inst"));
+        assert_eq!(doc.instances.as_ref().unwrap().len(), 3);
+
+        let joints = doc.joints.as_ref().unwrap();
+        let free = joints
+            .iter()
+            .find(|j| matches!(j.kind, JointKind::Free))
+            .expect("synthesized floating joint must map to JointKind::Free");
+        assert_eq!(free.parent_instance_id.as_deref(), Some("world_inst"));
+        assert_eq!(free.child_instance_id, "Trunk_inst");
+        // parentAnchor.z is what sets the spawn height (state is a scalar
+        // and meaningless for 6 DOF).
+        assert!((free.parent_anchor.z - 620.0).abs() < 1e-9);
+        // The authored hip joint survives untouched.
+        assert_eq!(joints.len(), 2);
+    }
+
+    #[test]
+    fn test_floating_base_noop_when_urdf_already_has_one() {
+        let urdf = r#"<?xml version="1.0"?>
+<robot name="declared">
+    <link name="world"/>
+    <link name="Trunk"/>
+    <joint name="world_joint" type="floating">
+        <origin xyz="0 0 1.0"/>
+        <parent link="world"/>
+        <child link="Trunk"/>
+    </joint>
+</robot>"#;
+        let doc = read_urdf_from_str_with_options(urdf, &floating_opts(620.0)).unwrap();
+        let joints = doc.joints.as_ref().unwrap();
+        assert_eq!(joints.len(), 1, "must not add a second floating joint");
+        // The authored origin wins over spawn_height_mm.
+        assert!((joints[0].parent_anchor.z - 1000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_floating_base_explicit_link() {
+        let opts = UrdfReadOptions {
+            floating_base: true,
+            floating_base_link: Some("Thigh".to_string()),
+            ..UrdfReadOptions::default()
+        };
+        let doc = read_urdf_from_str_with_options(COMMENTED_FLOATING, &opts).unwrap();
+        let free = doc
+            .joints
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|j| matches!(j.kind, JointKind::Free))
+            .unwrap()
+            .clone();
+        assert_eq!(free.child_instance_id, "Thigh_inst");
+    }
+
+    #[test]
+    fn test_floating_base_unknown_link_is_an_error() {
+        let opts = UrdfReadOptions {
+            floating_base: true,
+            floating_base_link: Some("Nope".to_string()),
+            ..UrdfReadOptions::default()
+        };
+        assert!(read_urdf_from_str_with_options(COMMENTED_FLOATING, &opts).is_err());
+    }
+
+    #[test]
+    fn test_detect_commented_out_floating_joint() {
+        assert_eq!(
+            commented_out_floating_joint(COMMENTED_FLOATING).as_deref(),
+            Some("world_joint")
+        );
+        // An *active* floating joint is not a comment hit.
+        assert!(commented_out_floating_joint(
+            r#"<robot name="a"><joint name="w" type="floating"/></robot>"#
+        )
+        .is_none());
+        // Ordinary comments don't trip it.
+        assert!(commented_out_floating_joint(
+            r#"<robot name="a"><!-- a plain note --><link name="l"/></robot>"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn test_floating_base_name_collision() {
+        let urdf = r#"<?xml version="1.0"?>
+<robot name="collide">
+    <link name="world"/>
+    <link name="Trunk"/>
+    <joint name="world_joint" type="fixed">
+        <parent link="world"/>
+        <child link="Trunk"/>
+    </joint>
+</robot>"#;
+        // `world`/`world_joint` are taken by a *fixed* joint here, so the
+        // synthesized pair must not clash with them.
+        let doc = read_urdf_from_str_with_options(urdf, &floating_opts(100.0)).unwrap();
+        let instances = doc.instances.as_ref().unwrap();
+        assert_eq!(instances.len(), 3);
+        assert!(instances.iter().any(|i| i.id == "world_1_inst"));
+        let joints = doc.joints.as_ref().unwrap();
+        assert_eq!(
+            joints
+                .iter()
+                .filter(|j| matches!(j.kind, JointKind::Free))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -3258,6 +3258,56 @@ pub fn import_urdf_buffer(data: &[u8]) -> Result<String, JsError> {
         .map_err(|e| JsError::new(&format!("Document serialise error: {e}")))
 }
 
+/// Import a URDF, optionally synthesizing a floating (6-DOF) base.
+///
+/// Most humanoid/quadruped URDFs ship the `world` link and its
+/// `type="floating"` joint commented out, on the convention that the
+/// simulator supplies the free base. Without it the root link is grounded
+/// and the robot is welded to the world — useless for locomotion. Passing
+/// `floating_base` injects exactly that commented-out block.
+///
+/// # Arguments
+///
+/// * `data` - Raw URDF XML bytes (UTF-8).
+/// * `floating_base` - Synthesize the world link + `Free` joint.
+/// * `root_link` - Link to attach it to (default: the tree's root link).
+/// * `spawn_height_mm` - Initial base height in mm, written as the joint's
+///   `parentAnchor.z` (a `Free` joint's scalar `state` cannot carry it).
+#[module("urdf")]
+#[wasm_bindgen(js_name = importUrdfBufferWithOptions)]
+pub fn import_urdf_buffer_with_options(
+    data: &[u8],
+    floating_base: bool,
+    root_link: Option<String>,
+    spawn_height_mm: Option<f64>,
+) -> Result<String, JsError> {
+    let xml = std::str::from_utf8(data)
+        .map_err(|e| JsError::new(&format!("URDF must be valid UTF-8: {e}")))?;
+    let opts = vcad_kernel_urdf::UrdfReadOptions {
+        floating_base,
+        floating_base_link: root_link,
+        spawn_height_mm: spawn_height_mm.unwrap_or(0.0),
+        ..Default::default()
+    };
+    let doc = vcad_kernel_urdf::read_urdf_from_str_with_options(xml, &opts)
+        .map_err(|e| JsError::new(&format!("URDF parse error: {e}")))?;
+    doc.to_json()
+        .map_err(|e| JsError::new(&format!("Document serialise error: {e}")))
+}
+
+/// Report the name of a floating joint found inside a **commented-out**
+/// region of the URDF, or `undefined` if there is none.
+///
+/// A hit is a strong signal the caller wants `floating_base` — the file's
+/// author wrote the joint and then commented it out for the simulator to
+/// supply.
+#[module("urdf")]
+#[wasm_bindgen(js_name = urdfCommentedFloatingJoint)]
+pub fn urdf_commented_floating_joint(data: &[u8]) -> Option<String> {
+    let xml = std::str::from_utf8(data).ok()?;
+    vcad_kernel_urdf::commented_out_floating_joint(xml)
+}
+
 // =========================================================================
 // GPU-Accelerated Geometry Processing
 // =========================================================================

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -543,6 +543,15 @@ export interface KernelModule {
    * robot to first order.
    */
   importUrdfBuffer: (data: Uint8Array) => string;
+  /** As `importUrdfBuffer`, but able to synthesize a floating base. */
+  importUrdfBufferWithOptions?: (
+    data: Uint8Array,
+    floating_base: boolean,
+    root_link: string | undefined,
+    spawn_height_mm: number | undefined,
+  ) => string;
+  /** Name of a floating joint found in a commented-out region, if any. */
+  urdfCommentedFloatingJoint?: (data: Uint8Array) => string | undefined;
   exportProjectedViewToDxf: (view_json: string) => Uint8Array;
   /** Offset (stepped) section of a mesh; null on parse failure. */
   offsetSectionMesh?: (
@@ -1087,6 +1096,8 @@ export class Engine {
       importStepBufferWithReport: (wasmModule as Record<string, unknown>).importStepBufferWithReport as KernelModule["importStepBufferWithReport"],
       documentToStepBuffer: (wasmModule as Record<string, unknown>).documentToStepBuffer as KernelModule["documentToStepBuffer"],
       importUrdfBuffer: (wasmModule as Record<string, unknown>).importUrdfBuffer as KernelModule["importUrdfBuffer"],
+      importUrdfBufferWithOptions: (wasmModule as Record<string, unknown>).importUrdfBufferWithOptions as KernelModule["importUrdfBufferWithOptions"],
+      urdfCommentedFloatingJoint: (wasmModule as Record<string, unknown>).urdfCommentedFloatingJoint as KernelModule["urdfCommentedFloatingJoint"],
       exportProjectedViewToDxf: wasmModule.exportProjectedViewToDxf,
       offsetSectionMesh: (wasmModule as Record<string, unknown>).offsetSectionMesh as KernelModule["offsetSectionMesh"],
       renderTitleBlock: (wasmModule as Record<string, unknown>).renderTitleBlock as KernelModule["renderTitleBlock"],
@@ -1820,14 +1831,48 @@ export class Engine {
    * through unchanged, so simulation behaves like the real robot to
    * first order.
    */
-  importUrdf(data: ArrayBuffer): string {
+  importUrdf(
+    data: ArrayBuffer,
+    opts?: {
+      floatingBase?: boolean;
+      floatingBaseLink?: string;
+      spawnHeightMm?: number;
+    },
+  ): string {
     const bytes = new Uint8Array(data);
+    if (opts?.floatingBase) {
+      if (typeof this.kernel.importUrdfBufferWithOptions !== "function") {
+        throw new Error(
+          "floating-base URDF import not available — kernel WASM predates the " +
+            "importUrdfBufferWithOptions export; rebuild the kernel WASM",
+        );
+      }
+      return this.kernel.importUrdfBufferWithOptions(
+        bytes,
+        true,
+        opts.floatingBaseLink,
+        opts.spawnHeightMm,
+      );
+    }
     if (typeof this.kernel.importUrdfBuffer !== "function") {
       throw new Error(
         "URDF import not available — kernel WASM was built without urdf support",
       );
     }
     return this.kernel.importUrdfBuffer(bytes);
+  }
+
+  /**
+   * Name of a floating joint the URDF declares inside a **commented-out**
+   * region, or `undefined`. Callers use it to suggest `floatingBase` —
+   * a commented-out floating joint means the author expected the simulator
+   * to supply the free base.
+   */
+  urdfCommentedFloatingJoint(data: ArrayBuffer): string | undefined {
+    if (typeof this.kernel.urdfCommentedFloatingJoint !== "function") {
+      return undefined;
+    }
+    return this.kernel.urdfCommentedFloatingJoint(new Uint8Array(data));
   }
 
   /** Export a projected view to DXF format.

--- a/packages/mcp/src/__tests__/import-urdf.test.ts
+++ b/packages/mcp/src/__tests__/import-urdf.test.ts
@@ -93,3 +93,72 @@ describe("import_urdf", () => {
     }
   });
 });
+
+describe("import_urdf floating base", () => {
+  // Shaped like Booster's K1 and the Unitree descriptors: the world link
+  // and its floating joint ship commented out, on the convention that the
+  // simulator supplies the free base.
+  const COMMENTED = `<robot name="k1">
+      <!-- <link name="world"/>
+      <joint name="world_joint" type="floating">
+        <origin xyz="0 0 0"/>
+        <parent link="world"/>
+        <child link="Trunk"/>
+      </joint> -->
+      <link name="Trunk"/>
+      <link name="Thigh"/>
+      <joint name="hip" type="revolute">
+        <parent link="Trunk"/><child link="Thigh"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-1" upper="1" effort="40" velocity="12.5"/>
+      </joint>
+    </robot>`;
+  const b64 = () => Buffer.from(COMMENTED).toString("base64");
+
+  it("warns when a floating joint is only present in a comment", () => {
+    const out = parseResult(importUrdf({ content_base64: b64() }, engine));
+    expect(out.summary.floating_base_warning).toMatch(/world_joint/);
+    expect(out.summary.floating_base_warning).toMatch(/welded to the world/);
+    // Behavior itself is unchanged: root still grounded, no Free joint.
+    expect(out.summary.ground_instance_id).toBe("Trunk_inst");
+    expect(out.summary.joint_list.some((j: { kind: string }) => j.kind === "Free")).toBe(false);
+  });
+
+  it("synthesizes a Free root joint with floating_base", () => {
+    const out = parseResult(
+      importUrdf(
+        { content_base64: b64(), floating_base: true, spawn_height_mm: 620 },
+        engine,
+      ),
+    );
+    expect(out.summary.floating_base.synthesized).toBe(true);
+    expect(out.summary.floating_base.spawn_height_mm).toBe(620);
+    expect(out.summary.floating_base_warning).toBeUndefined();
+    const free = out.summary.joint_list.filter(
+      (j: { kind: string }) => j.kind === "Free",
+    );
+    expect(free).toHaveLength(1);
+    expect(free[0].child_instance_id).toBe("Trunk_inst");
+    // The world link is now the ground, not the Trunk.
+    expect(out.summary.ground_instance_id).not.toBe("Trunk_inst");
+  });
+
+  it("rejects floating-base sub-options without floating_base", () => {
+    expect(() =>
+      importUrdf({ content_base64: b64(), spawn_height_mm: 620 }, engine),
+    ).toThrow(/require floating_base/);
+  });
+
+  it("does not warn on a URDF with no floating joint at all", () => {
+    const xml = `<robot name="arm">
+        <link name="base"/><link name="tip"/>
+        <joint name="j" type="revolute">
+          <parent link="base"/><child link="tip"/><axis xyz="0 0 1"/>
+        </joint>
+      </robot>`;
+    const out = parseResult(
+      importUrdf({ content_base64: Buffer.from(xml).toString("base64") }, engine),
+    );
+    expect(out.summary.floating_base_warning).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -6939,7 +6939,7 @@
   {
     "name": "import_urdf",
     "title": "Import URDF",
-    "description": "Import a URDF (Unified Robot Description Format) robot from a server-local file. Builds the full kinematic tree — one part per link, instances FK-placed from joint origins, joints (revolute/prismatic/fixed) with limits, and a grounded root link — ready for create_robot_env. STL mesh references are resolved against the URDF's directory and optional package_roots and inlined; unresolved meshes fall back to placeholder geometry with an explicit warning.",
+    "description": "Import a URDF (Unified Robot Description Format) robot from a server-local file. Builds the full kinematic tree — one part per link, instances FK-placed from joint origins, joints (revolute/prismatic/fixed) with limits, and a grounded root link — ready for create_robot_env. STL mesh references are resolved against the URDF's directory and optional package_roots and inlined; unresolved meshes fall back to placeholder geometry with an explicit warning. For locomotion, pass floating_base: true — most humanoid/quadruped URDFs leave the world link and floating joint commented out, and without them the robot is welded to the world.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -6961,6 +6961,18 @@
         "name": {
           "type": "string",
           "description": "Robot name (default: filename without extension)"
+        },
+        "floating_base": {
+          "type": "boolean",
+          "description": "Synthesize a floating (6-DOF) base when the URDF declares none. Most humanoid/quadruped URDFs ship the world link and its type=\"floating\" joint commented out, on the convention that the simulator supplies the free base — without this the root link is grounded and the robot is welded to the world, which cannot walk or fall. Set this for any locomotion task. No-op when the URDF already has a floating joint."
+        },
+        "floating_base_link": {
+          "type": "string",
+          "description": "Link to attach the synthesized floating base to (default: the tree's root link, i.e. the one that is never a joint's child). Requires floating_base."
+        },
+        "spawn_height_mm": {
+          "type": "number",
+          "description": "Initial base height in mm for the synthesized floating base (default 0). A Free joint's `state` is a scalar and meaningless for 6 DOF, so this is written as the joint's parentAnchor.z. Spawn just above the settled standing height so the robot drops onto the ground instead of starting interpenetrated (Booster K1: 620 mm against a 549.8 mm stand)."
         }
       }
     },

--- a/packages/mcp/src/tools/import-urdf.ts
+++ b/packages/mcp/src/tools/import-urdf.ts
@@ -35,6 +35,9 @@ interface ImportUrdfInput {
   content_base64?: string;
   package_roots?: string[];
   name?: string;
+  floating_base?: boolean;
+  floating_base_link?: string;
+  spawn_height_mm?: number;
 }
 
 export const importUrdfSchema = {
@@ -67,6 +70,32 @@ export const importUrdfSchema = {
     name: {
       type: "string" as const,
       description: "Robot name (default: filename without extension)",
+    },
+    floating_base: {
+      type: "boolean" as const,
+      description:
+        "Synthesize a floating (6-DOF) base when the URDF declares none. Most " +
+        "humanoid/quadruped URDFs ship the world link and its type=\"floating\" " +
+        "joint commented out, on the convention that the simulator supplies the " +
+        "free base — without this the root link is grounded and the robot is " +
+        "welded to the world, which cannot walk or fall. Set this for any " +
+        "locomotion task. No-op when the URDF already has a floating joint.",
+    },
+    floating_base_link: {
+      type: "string" as const,
+      description:
+        "Link to attach the synthesized floating base to (default: the tree's " +
+        "root link, i.e. the one that is never a joint's child). Requires " +
+        "floating_base.",
+    },
+    spawn_height_mm: {
+      type: "number" as const,
+      description:
+        "Initial base height in mm for the synthesized floating base (default 0). " +
+        "A Free joint's `state` is a scalar and meaningless for 6 DOF, so this " +
+        "is written as the joint's parentAnchor.z. Spawn just above the settled " +
+        "standing height so the robot drops onto the ground instead of starting " +
+        "interpenetrated (Booster K1: 620 mm against a 549.8 mm stand).",
     },
   },
 };
@@ -241,8 +270,21 @@ export function importUrdf(
   input: unknown,
   engine: Engine,
 ): { content: Array<{ type: "text"; text: string }> } {
-  const { path, content_base64, package_roots, name } =
-    input as ImportUrdfInput;
+  const {
+    path,
+    content_base64,
+    package_roots,
+    name,
+    floating_base,
+    floating_base_link,
+    spawn_height_mm,
+  } = input as ImportUrdfInput;
+
+  if (!floating_base && (floating_base_link || spawn_height_mm !== undefined)) {
+    throw new Error(
+      "floating_base_link / spawn_height_mm require floating_base: true",
+    );
+  }
 
   const confineRoot = process.env.VCAD_MCP_EXPORT_DIR ?? process.cwd();
   let fileBuffer: Buffer;
@@ -294,7 +336,20 @@ export function importUrdf(
   // pooled slice).
   const arrayBuffer = new ArrayBuffer(fileBuffer.byteLength);
   new Uint8Array(arrayBuffer).set(fileBuffer);
-  const doc = JSON.parse(engine.importUrdf(arrayBuffer)) as Document;
+  const doc = JSON.parse(
+    engine.importUrdf(arrayBuffer, {
+      floatingBase: floating_base,
+      floatingBaseLink: floating_base_link,
+      spawnHeightMm: spawn_height_mm,
+    }),
+  ) as Document;
+
+  // A floating joint hiding in a comment means the author expected the
+  // simulator to supply the free base — say so rather than silently
+  // handing back a robot welded to the world.
+  const commentedFloating = floating_base
+    ? undefined
+    : engine.urdfCommentedFloatingJoint(arrayBuffer);
 
   const meshes = inlineMeshImports(doc, urdfDir, packageRoots, confineRoot);
 
@@ -322,6 +377,28 @@ export function importUrdf(
     instances: (doc.instances ?? []).length,
     ground_instance_id: doc.groundInstanceId ?? null,
     joint_list: joints,
+    ...(floating_base
+      ? {
+          floating_base: {
+            synthesized: joints.some((j) => j.kind === "Free"),
+            spawn_height_mm: spawn_height_mm ?? 0,
+            note:
+              "The root link hangs off a 6-DOF Free joint; parentAnchor.z is the " +
+              "spawn height. The robot will fall under gravity.",
+          },
+        }
+      : {}),
+    ...(commentedFloating
+      ? {
+          floating_base_warning:
+            `This URDF declares a floating joint (${commentedFloating}) inside a ` +
+            "comment — the usual convention that the simulator supplies the free " +
+            "base. Imported as-is, the root link is grounded and the robot is " +
+            "welded to the world (it cannot walk or fall). Re-import with " +
+            "floating_base: true (and a spawn_height_mm just above standing " +
+            "height) for any locomotion task.",
+        }
+      : {}),
     ...(meshes.inlined > 0 ? { meshes_inlined: meshes.inlined } : {}),
     ...(meshes.unresolved.length > 0
       ? {
@@ -365,7 +442,9 @@ export const toolDefs: ToolDef[] = [
       "origins, joints (revolute/prismatic/fixed) with limits, and a grounded root link — " +
       "ready for create_robot_env. STL mesh references are resolved against the URDF's " +
       "directory and optional package_roots and inlined; unresolved meshes fall back to " +
-      "placeholder geometry with an explicit warning.",
+      "placeholder geometry with an explicit warning. For locomotion, pass " +
+      "floating_base: true — most humanoid/quadruped URDFs leave the world link and " +
+      "floating joint commented out, and without them the robot is welded to the world.",
     inputSchema: importUrdfSchema,
     handler: (a, c) => importUrdf(a, c.engine),
     behavior: behavior({ writesDoc: true, geometry: true, mount: true }),


### PR DESCRIPTION
## The problem

Hit for real in #766. Booster's `robots/K1/K1_22dof.urdf` and `K1_locomotion.urdf` — and this is the norm, not a Booster quirk; the in-repo `examples/unitree-g1.urdf` does it too — ship the world link and floating joint commented out:

```xml
<!-- <link name="world"/>
<joint name="world_joint" type="floating">
  <origin xyz="0 0 0"/>
  <parent link="world"/>
  <child link="Trunk"/>
</joint> -->
```

because the convention is that the simulator supplies the floating base (MuJoCo's MJCF for the same robot has `<joint name="world_joint" type="free"/>`). vcad's importer saw no world joint, made `Trunk` the `groundInstanceId`, and welded the robot to the world — physically pinned, useless for locomotion. Training anything meant hand-editing the XML to uncomment that block: exactly the kind of undocumented ritual that costs an afternoon.

## What changed

**Kernel** (`crates/vcad-kernel-urdf`) — `UrdfReadOptions` gains `floating_base`, `floating_base_link`, and `spawn_height_mm`. When set and the URDF declares no floating joint, `apply_floating_base` injects exactly the commented-out block into the parsed `Robot` before the document build: a geometry-less `world` link plus a `type="floating"` joint to the root link. Everything downstream is untouched — the existing `"floating" => JointKind::Free` mapping, root-link discovery, and ground-instance selection do the rest.

- Names uniquify (`world_1`) if `world`/`world_joint` are already taken.
- An unknown `floating_base_link` is an error.
- A URDF that already declares a floating joint is a no-op (the authored origin wins).

**Spawn height** — a `Free` joint's `state` is a scalar and meaningless for 6 DOF, so `spawn_height_mm` is written as the joint's `parentAnchor.z`. That is what actually sets the initial base height; documented at every layer it's exposed. For the K1, 620 mm spawns it just above its 549.8 mm settled standing height.

**Detection** — `commented_out_floating_joint(xml)` scans comment bodies for `<joint type="floating">` and returns its name. The reader warns on stderr when it hits and `floating_base` wasn't requested; `import_urdf` returns it as a `floating_base_warning`. On the real G1 this fires and names `floating_base_joint`.

**CLI** — `vcad import-urdf --floating-base [--floating-base-link LINK] [--spawn-height-mm MM]`. Also added to `vcad simulate`, whose URDF path had the identical trap.

**MCP** — `import_urdf` gains `floating_base` / `floating_base_link` / `spawn_height_mm`, plumbed through two new WASM exports (`importUrdfBufferWithOptions`, `urdfCommentedFloatingJoint`) and `Engine.importUrdf(data, opts?)`. Sub-options without `floating_base` are rejected rather than silently ignored.

## Testing

- 7 reader unit tests: synthesis, default-off, already-declared no-op, explicit link, unknown link, name collision, comment detection.
- `unitree_g1_floating_base_falls_under_gravity` (`crates/vcad-kernel-physics/tests/unitree.rs`) against the in-repo `examples/unitree-g1.urdf`: exactly one `Free` joint at the requested anchor, base falls >1 m in 1 s under gravity — and the **same URDF imported without the flag stays pinned to within 1e-6**, so default behavior is unchanged.
- 4 `import_urdf` tests covering the MCP surface end to end (warning path, synthesis, sub-option rejection, no-false-positive).
- Tool-surface fixture regenerated (`UPDATE_TOOL_SURFACE=1`); the diff is only the new `import_urdf` fields and description.

## Reviewer note

The two MCP floating-base tests need the new WASM exports, so they fail against the *checked-in* `packages/kernel-wasm` artifacts. They pass against a fresh `wasm-pack` build (verified locally, then reverted per the no-committed-artifacts rule in CLAUDE.md); CI's TypeScript job builds WASM from source before running them. Locally, `npm run build -w @vcad/kernel-wasm` first.

Pre-existing clippy findings in `vcad-cli/src/raycast.rs` and `vcad-kernel-physics/src/gym.rs` are unrelated to this branch (confirmed by stashing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
