### PR TITLE
feat(sim): solve the K1 standing task — ARS step size, curriculum, MLP policy

### DIFF
--- a/changelog/entries/2026-07-31-ars-policy-trait-curriculum.json
+++ b/changelog/entries/2026-07-31-ars-policy-trait-curriculum.json
@@ -1,0 +1,13 @@
+{
+  "id": "2026-07-31-ars-policy-trait-curriculum",
+  "version": "0.9.4",
+  "date": "2026-07-31",
+  "category": "feat",
+  "title": "RL trainer: K1 standing task solved (10/10 seeds)",
+  "summary": "ARS no longer walks out of the solutions it finds (step size 0.03 -> 0.005), gains a randomization curriculum and a tanh MLP policy, and selects iterates on held-out seeds. The Booster K1 randomized standing task goes from 0/10 to 10/10 full episodes.",
+  "features": [
+    "physics",
+    "simulation",
+    "rl"
+  ]
+}

--- a/crates/vcad-sim/examples/k1_stand.rs
+++ b/crates/vcad-sim/examples/k1_stand.rs
@@ -168,6 +168,80 @@ fn env_usize(key: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+/// A policy loaded from disk, whichever architecture wrote it.
+///
+/// Both the replay and re-score paths need this, and when they each rolled
+/// their own the re-score one silently stayed linear-only — so loading lives
+/// in exactly one place and the enum implements [`Policy`] by delegation,
+/// letting every consumer stay generic.
+#[derive(Clone)]
+enum SavedPolicy {
+    Linear(LinearPolicy),
+    Mlp(MlpPolicy),
+}
+
+impl Policy for SavedPolicy {
+    fn obs_dim(&self) -> usize {
+        match self {
+            Self::Linear(p) => p.obs_dim(),
+            Self::Mlp(p) => p.obs_dim(),
+        }
+    }
+    fn params(&self) -> &[f64] {
+        match self {
+            Self::Linear(p) => p.params(),
+            Self::Mlp(p) => p.params(),
+        }
+    }
+    fn params_mut(&mut self) -> &mut [f64] {
+        match self {
+            Self::Linear(p) => p.params_mut(),
+            Self::Mlp(p) => p.params_mut(),
+        }
+    }
+    fn set_whitening(&mut self, mean: Vec<f64>, std: Vec<f64>) {
+        match self {
+            Self::Linear(p) => p.set_whitening(mean, std),
+            Self::Mlp(p) => p.set_whitening(mean, std),
+        }
+    }
+    fn act(&self, features: &[f64]) -> Vec<f64> {
+        match self {
+            Self::Linear(p) => Policy::act(p, features),
+            Self::Mlp(p) => Policy::act(p, features),
+        }
+    }
+}
+
+impl SavedPolicy {
+    /// Name of the architecture, for logging.
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Linear(_) => "linear",
+            Self::Mlp(_) => "mlp",
+        }
+    }
+}
+
+/// Load a trained policy, dispatching on the architecture the file records.
+///
+/// `hidden` is the discriminator: only [`MlpPolicy`] has it. Guessing wrong
+/// is not silent — [`LinearPolicy`] has a required `weights` field an MLP
+/// file lacks, so a mismatch fails deserialization — but it is still a
+/// failure, and with the MLP now the default it was the common case.
+fn load_policy(path: &std::path::Path) -> Result<SavedPolicy, Box<dyn std::error::Error>> {
+    let blob: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(path)?)?;
+    let pol = blob
+        .get("policy")
+        .ok_or("saved file has no `policy` field")?
+        .clone();
+    Ok(if pol.get("hidden").is_some() {
+        SavedPolicy::Mlp(serde_json::from_value(pol)?)
+    } else {
+        SavedPolicy::Linear(serde_json::from_value(pol)?)
+    })
+}
+
 /// Ten fresh evaluation seeds, disjoint from anything training touches.
 ///
 /// This is the *only* number any change may be judged by. ARS's own
@@ -403,23 +477,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::fs::create_dir_all(&dir)?;
         let every = env_usize("K1_REPLAY_EVERY", 2).max(1);
 
-        let blob: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&saved)?)?;
-        let pol = &blob["policy"];
-        // The saved policy is whichever architecture trained it; `hidden`
-        // is the discriminator.
-        let mlp: Option<MlpPolicy> = pol
-            .get("hidden")
-            .is_some()
-            .then(|| serde_json::from_value(pol.clone()))
-            .transpose()?;
-        let lin: Option<LinearPolicy> = match &mlp {
-            Some(_) => None,
-            None => Some(serde_json::from_value(pol.clone())?),
-        };
-        println!(
-            "replay: {} policy, seed {seed} → {dir}/",
-            if mlp.is_some() { "mlp" } else { "linear" }
-        );
+        let policy = load_policy(&saved)?;
+        println!("replay: {} policy, seed {seed} → {dir}/", policy.kind());
 
         let mut env = spec.build()?;
         let mut obs = env.reset_with_seed(seed);
@@ -432,11 +491,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 frame += 1;
             }
             let f = vcad_sim::rl::features(&obs, &slots, NOMINAL_H);
-            let targets = match (&mlp, &lin) {
-                (Some(m), _) => Policy::act(m, &f),
-                (_, Some(l)) => Policy::act(l, &f),
-                _ => unreachable!(),
-            };
+            let targets = Policy::act(&policy, &f);
             let r = env.step_full(vcad_kernel_physics::Action::PositionTarget(targets.clone()));
             total += reward(&r, &targets);
             obs = r.observation;
@@ -539,8 +594,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // `iterations = 0` re-evaluates the policy already on disk instead of
     // retraining — the cheap way to re-check a run you just paid for.
     if iterations == 0 {
-        let blob: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&saved)?)?;
-        let policy: LinearPolicy = serde_json::from_value(blob["policy"].clone())?;
+        let policy = load_policy(&saved)?;
+        println!("re-scoring saved {} policy", policy.kind());
         let mut env = spec.build()?;
         for s in 1..=10u64 {
             let e = vcad_sim::rl::rollout(&mut env, &policy, &slots, NOMINAL_H, s, &reward, None);

--- a/crates/vcad-sim/examples/k1_stand.rs
+++ b/crates/vcad-sim/examples/k1_stand.rs
@@ -6,12 +6,124 @@
 //! ```
 //!
 //! Writes the trained policy to `k1_stand_policy.json` next to the document.
+//!
+//! # Diagnostic modes
+//!
+//! Reach for these *before* tuning the trainer. Each answers a question that
+//! decides whether trainer tuning is even the right move:
+//!
+//! - `K1_TRACE=1` — dump the baseline's fall step by step (height, tilt, foot
+//!   heights). Confirms the robot is failing at the task and not at the
+//!   physics.
+//! - `K1_HANDPD=1` — sweep a hand-written two-gain ankle balance controller,
+//!   expressed as a linear policy so it runs the same path a trained one
+//!   does. If the hand controller can't stand, the policy class or the task
+//!   is the problem and no ARS tuning will fix it.
+//! - `<iterations> = 0` — re-score the policy already on disk.
+//!
+//! Every knob below is an environment variable so a sweep is a shell line
+//! rather than a recompile: `K1_ROLLOUTS`, `K1_DIRS`, `K1_TOPK`, `K1_ALPHA`,
+//! `K1_NU`, `K1_SEED`, `K1_POLICY` (`linear`|`mlp`), `K1_HIDDEN`,
+//! `K1_CURRICULUM_WARMUP`, `K1_ACTION_SCALE`, `K1_SPAWN_Z_MM`, the
+//! randomization channels (`K1_POS_PERTURB`, `K1_VEL_PERTURB`, `K1_MASS_PCT`,
+//! `K1_GAIN_PCT`, `K1_LATENCY_MAX`), and the PD gains (`K1_KP_ANKLE` etc.).
+//!
+//! # Measured, on the 22-DOF floating-base K1
+//!
+//! All figures are the mean over the ten fresh evaluation seeds this example
+//! prints last, at 1 kHz physics / 50 Hz control and 400-step episodes. The
+//! training-time eval return is *not* comparable to them and overstates by
+//! roughly 5× — see [`eval_10`].
+//!
+//! - Hold-rest-pose baseline: **9.55 over 18.8 steps** with full
+//!   randomization, **18.85 over 25.0 steps** with none.
+//! - Ablating randomization one channel at a time, the *entire* gap is the
+//!   initial joint perturbation: mass alone 18.62, PD gain alone 18.96,
+//!   actuator latency alone 17.89 — all indistinguishable from no
+//!   randomization at all — while the 2.0°/5.0°-per-second joint kick alone
+//!   gives 10.18. The sim2real channels are nearly free here; the shove is
+//!   the task.
+//! - The K1 at its rest pose is an unstable equilibrium that diverges
+//!   exponentially, e-folding about every 90 ms (~4.5 control steps), so a
+//!   policy has roughly ten steps of authority before a lean is
+//!   unrecoverable.
+//! - A hand-written ankle-only strategy inside the linear policy class
+//!   reaches 44 steps deterministic — 1.8× the baseline, still nowhere near
+//!   the 400-step episode. Stiffening the ankles does not help and makes it
+//!   worse (ankle `kp` 100/200/400 → 18.0/16.0/18.0 baseline steps), because
+//!   the explicit PD loop is already near its ω·dt stability limit. Ankle
+//!   torque authority is therefore *not* the binding constraint.
+//!
+//! # What was actually holding training back
+//!
+//! Not the randomization — **the step size**, and then policy capacity. ARS's
+//! update is scale-free, so it takes the same-size step when the policy is
+//! optimal as when it is useless, and at the old `α = 0.03` it walked out of
+//! every solution it found. With randomization off it hit a perfect 400/400
+//! on iteration 20 and was at −16 by iteration 29; the update norm sat at
+//! ~0.4 the entire time, including while it was solving the task. Three
+//! seeds, same shape. See [`vcad_sim::rl::ArsConfig::step_size`].
+//!
+//! Dropping to `α = 0.005` (now the default here):
+//!
+//! | task            | α = 0.03                       | α = 0.005                       |
+//! |-----------------|--------------------------------|---------------------------------|
+//! | deterministic   | 400/400 at iter 20, −16 by 29  | 400/400 at iter 42, still there at 59 |
+//! | full randomized | peak 35 at iter 3, ~9 by 20    | 222 at iter 75, 5/10 full episodes |
+//!
+//! Stacking the curriculum and then the MLP on top of the smaller step
+//! solves the task. All figures are ten fresh seeds, full randomization:
+//!
+//! | configuration                            | held-out | full episodes |
+//! |------------------------------------------|----------|---------------|
+//! | hold-rest-pose baseline                  | 9.55     | 0/10          |
+//! | linear, α = 0.03 (previous defaults)     | 10.84    | 0/10          |
+//! | linear, α = 0.005                        | 221.92   | 5/10          |
+//! | linear, α = 0.005 + curriculum 0.4       | 280.33   | 7/10          |
+//! | **MLP-64, α = 0.005 + curriculum 0.4**   | **386.92** | **10/10**   |
+//!
+//! The MLP run reaches 400/400 on every held-out seed by iteration 119, with
+//! the worst seed scoring 356.29 and terminating for no reason other than
+//! running out of episode. It is also *faster per iteration of progress*, not
+//! merely better at the end — at matched iterations against the linear policy
+//! under an otherwise identical config (same seeds, same curriculum):
+//!
+//! | iteration | linear | MLP-64 |
+//! |-----------|--------|--------|
+//! | 10        | 25.99  | 47.11  |
+//! | 20        | 84.53  | 210.20 |
+//! | 70        | ~180   | 376.30 |
+//!
+//! So the capacity argument was right: balance switches contact mode, and one
+//! gain matrix has to serve every mode at once.
+//!
+//! One caveat if you compare architectures yourself. The ARS step norm grows
+//! with √(parameter count), so at matched `α` the 4950-parameter MLP takes a
+//! ~3× larger relative step than the 1188-parameter linear policy — the
+//! comparison above is confounded by exactly the thing that turned out to
+//! matter most. Scaling `α` down by √(1188/4950) to equalize the step norm
+//! was measured too, and is *worse* (307.60): the MLP genuinely wants the
+//! larger step, so the confound was real but favoured the other direction.
+//!
+//! The linear-plus-curriculum run contains the sharpest warning about the
+//! trainer's own eval column anywhere here: over iterations 175–199, while
+//! held-out sat at 277–280 with 7/10 full episodes, `train-eval` read −1.63,
+//! −0.56, −1.02, 0.63, −3.40, −0.15. Three fixed evaluation seeds called the
+//! best policy of the session worthless. Selecting on that column picked an
+//! iterate worth 109.13 instead of 280.33.
+//!
+//! So: because ARS wanders back out of good regions even at the smaller step,
+//! and because its own eval cannot be trusted to notice, `K1_CURVE=n` scores
+//! every n-th iterate on the ten held-out seeds and the run keeps the best of
+//! those. Use it for any run you intend to keep.
 
 use std::collections::HashMap;
 
 use vcad_ir::Document;
-use vcad_kernel_physics::{Action, DomainRandomization, EnvConfig, Range, TerminationConfig};
-use vcad_sim::rl::{actuated_slots, ActionSpec, ArsConfig, EnvSpec, LinearPolicy, TrainOutcome};
+use vcad_kernel_physics::{DomainRandomization, EnvConfig, Range, TerminationConfig};
+use vcad_sim::rl::{
+    actuated_slots, ActionSpec, ArsConfig, EnvSpec, LinearPolicy, MlpPolicy, Policy, TrainOutcome,
+};
 
 /// Booster K1 trunk height (m) once it has settled on the ground with the
 /// legs at their URDF rest pose — measured, not assumed.
@@ -28,12 +140,64 @@ const NOMINAL_H: f64 = 0.5498;
 /// balancing, and the policy learns to fight its own springs.
 fn gains_for(joint: &str) -> (f64, f64) {
     if joint.contains("Hip") || joint.contains("Knee") {
-        (200.0, 5.0)
+        (env_f64("K1_KP_LEG", 200.0), env_f64("K1_KD_LEG", 5.0))
     } else if joint.contains("Ankle") {
-        (50.0, 1.0)
+        (env_f64("K1_KP_ANKLE", 50.0), env_f64("K1_KD_ANKLE", 1.0))
     } else {
-        (40.0, 1.0)
+        (env_f64("K1_KP_ARM", 40.0), env_f64("K1_KD_ARM", 1.0))
     }
+}
+
+/// Read an `f64` knob from the environment, falling back to `default`.
+///
+/// Every hyperparameter that a sweep wants to move lives behind one of these:
+/// a run is then a shell line, not a recompile, and the committed defaults
+/// stay the ones that were actually measured.
+fn env_f64(key: &str, default: f64) -> f64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Read a `usize` knob from the environment.
+fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Ten fresh evaluation seeds, disjoint from anything training touches.
+///
+/// This is the *only* number any change may be judged by. ARS's own
+/// training-time eval return selects on its seed set, and on this env that
+/// selection reliably picks a lucky randomization draw rather than a better
+/// policy (measured: an iterate scoring 116.34 on its own eval seeds averaged
+/// 7.93 here).
+fn eval_10<P, R>(
+    spec: &EnvSpec,
+    policy: &P,
+    slots: &[usize],
+    reward: &R,
+) -> Result<(f64, f64, usize, vcad_sim::rl::RolloutStats), vcad_kernel_physics::PhysicsError>
+where
+    P: Policy,
+    R: Fn(&vcad_kernel_physics::StepResult, &[f64]) -> f64 + Sync,
+{
+    let mut env = spec.build()?;
+    let evals: Vec<_> = (1..=10u64)
+        .map(|s| vcad_sim::rl::rollout(&mut env, policy, slots, NOMINAL_H, s, reward, None))
+        .collect();
+    let mean_r = evals.iter().map(|e| e.reward).sum::<f64>() / evals.len() as f64;
+    let mean_steps = evals.iter().map(|e| e.steps as f64).sum::<f64>() / evals.len() as f64;
+    let full = evals.iter().filter(|e| e.steps == spec.max_steps).count();
+    let worst = evals
+        .iter()
+        .min_by(|a, b| a.reward.total_cmp(&b.reward))
+        .unwrap()
+        .clone();
+    Ok((mean_r, mean_steps, full, worst))
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -43,19 +207,64 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("usage: k1_stand <doc.vcad> [iterations]");
     let iterations: usize = args.next().map_or(150, |s| s.parse().unwrap());
 
-    let doc: Document = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
+    let mut doc: Document = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
+
+    // Raise the floating base to standing height.
+    //
+    // `import-urdf` anchors the Free base joint at the world origin, so a
+    // freshly imported K1 spawns with its trunk at z = 0 — a metre below the
+    // 0.42 m termination floor. Every episode then terminates on step 1 and
+    // the whole task silently degenerates. This was a manual doc-prep step
+    // before; leaving it manual is how a run gets billed to a document that
+    // was never standing up.
+    let spawn_z_mm = env_f64("K1_SPAWN_Z_MM", NOMINAL_H * 1000.0);
+    let raised = doc
+        .joints
+        .iter_mut()
+        .flat_map(|js| js.iter_mut())
+        .find(|j| matches!(j.kind, vcad_ir::JointKind::Free))
+        .map(|j| {
+            j.parent_anchor.z = spawn_z_mm;
+        })
+        .is_some();
+    if !raised {
+        return Err("document has no Free base joint — this example trains a \
+                    floating-base standing task and needs one (import \
+                    K1_22dof_floating.urdf, not the fixed-base K1_22dof.urdf)"
+            .into());
+    }
 
     // Sim2real-shaped randomization, in the spirit of Booster's own K1 config
     // (2–8 substeps of actuator latency). Without it every episode is
     // bit-identical and "the policy survives 400 steps" says nothing about
     // whether it survives a robot.
-    let config = EnvConfig {
+    // Each randomization channel is separately switchable, so "the randomized
+    // task is unsolved" can be decomposed into *which* channel costs what
+    // rather than treated as one lump. A channel set to 0 is disabled.
+    let pos_perturb = env_f64("K1_POS_PERTURB", 2.0);
+    let vel_perturb = env_f64("K1_VEL_PERTURB", 5.0);
+    let mass_pct = env_f64("K1_MASS_PCT", 0.1);
+    let gain_pct = env_f64("K1_GAIN_PCT", 0.2);
+    let latency_max = env_usize("K1_LATENCY_MAX", 8);
+    let opt = |v: f64| (v > 0.0).then_some(v);
+
+    // Randomization at a curriculum `level` in [0, 1]: 0 is the deterministic
+    // env, 1 is the full sim2real task. Every channel scales together, so a
+    // schedule is one scalar.
+    let config_at = move |level: f64| EnvConfig {
         randomization: Some(DomainRandomization {
-            mass_scale: Some(Range { min: 0.9, max: 1.1 }),
-            pd_gain_scale: Some(Range { min: 0.8, max: 1.2 }),
-            action_latency_steps: Some([2, 8]),
-            joint_pos_perturb: Some(2.0),
-            joint_vel_perturb: Some(5.0),
+            mass_scale: opt(mass_pct * level).map(|p| Range {
+                min: 1.0 - p,
+                max: 1.0 + p,
+            }),
+            pd_gain_scale: opt(gain_pct * level).map(|p| Range {
+                min: 1.0 - p,
+                max: 1.0 + p,
+            }),
+            action_latency_steps: opt(latency_max as f64 * level)
+                .map(|m| [2.min(m as u32), m as u32]),
+            joint_pos_perturb: opt(pos_perturb * level),
+            joint_vel_perturb: opt(vel_perturb * level),
             ..DomainRandomization::default()
         }),
         termination: Some(TerminationConfig {
@@ -66,6 +275,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         base_instance_id: Some("Trunk_inst".to_string()),
         ..EnvConfig::default()
     };
+    let config = config_at(1.0);
 
     let mut spec = EnvSpec {
         doc,
@@ -104,27 +314,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             - 0.1 * effort
     };
 
-    let policy = LinearPolicy::zeros(
-        obs_dim,
-        act_dim,
-        ActionSpec {
-            // The URDF rest pose is the standing pose.
-            default_pose_deg: vec![0.0; act_dim],
-            action_scale_deg: 8.0,
-        },
-    );
-
     let cfg = ArsConfig {
-        n_directions: 12,
-        top_k: 6,
-        step_size: 0.03,
-        noise_std: 0.05,
+        n_directions: env_usize("K1_DIRS", 12),
+        top_k: env_usize("K1_TOPK", 6),
+        step_size: env_f64("K1_ALPHA", 0.005),
+        noise_std: env_f64("K1_NU", 0.05),
         iterations,
-        episode_steps: spec.max_steps,
-        // Three draws per evaluation: enough to stop the ranking chasing
-        // lucky randomization, cheap enough to keep the run under 20 min.
-        rollouts_per_eval: 3,
-        seed: 7,
+        // Draws averaged per evaluation. Three is not enough on this env —
+        // see the sweep in the module docs.
+        rollouts_per_eval: env_usize("K1_ROLLOUTS", 3),
+        seed: env_usize("K1_SEED", 7) as u64,
     };
 
     println!(
@@ -140,9 +339,205 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         cfg.rollouts_per_eval
     );
 
+    // The hold-rest-pose baseline is exactly a zero policy (zero weights ⇒
+    // the action is the default pose), so it goes through the identical
+    // rollout and evaluation path as anything learned. Measuring it on one
+    // seed while measuring the policy on ten is how a wash gets reported as
+    // an improvement.
+    // Fail closed on a document that has no floating base. Without one,
+    // `base_pose` is None for every step, so the height term reads exactly
+    // nominal, the tilt term reads a constant, and *no termination condition
+    // can ever fire* — the run reports a confident 400/400 survival and a
+    // stable reward while measuring nothing at all. This bit me on a
+    // same-named fixed-base document; it should not be possible to bill an
+    // afternoon of training to that mistake twice.
+    {
+        let mut env = spec.build()?;
+        let obs = env.reset_with_seed(1);
+        if obs.base_pose.is_none() {
+            return Err(format!(
+                "document has no floating base reachable from base_instance_id {:?} — \
+                 every termination check is disabled and the returns below would be \
+                 meaningless. Import with `vcad import-urdf K1_22dof_floating.urdf`.",
+                spec.config.base_instance_id
+            )
+            .into());
+        }
+    }
+
+    let baseline = LinearPolicy::zeros(
+        obs_dim,
+        act_dim,
+        ActionSpec {
+            default_pose_deg: vec![0.0; act_dim],
+            action_scale_deg: env_f64("K1_ACTION_SCALE", 8.0),
+        },
+    );
+    let (b_r, b_steps, b_full, _) = eval_10(&spec, &baseline, &slots, &reward)?;
+    println!(
+        "hold-rest-pose baseline (10 seeds): mean {b_r:>7.2} over {b_steps:>5.1} steps, \
+         full episode on {b_full}/10"
+    );
+
+    // Output path is overridable, because a sweep whose arms all write
+    // "k1_stand_policy.json" silently leaves you holding whichever arm
+    // finished last rather than the one you wanted to keep.
+    let saved = match std::env::var("K1_OUT") {
+        Ok(p) => std::path::PathBuf::from(p),
+        Err(_) => std::path::Path::new(&path).with_file_name("k1_stand_policy.json"),
+    };
+
+    // `K1_REPLAY=<seed>` rolls the saved policy out on one seed and writes a
+    // `.vcad` per frame to `K1_REPLAY_DIR`, ready for `vcad-render` + ffmpeg.
+    //
+    // Getting the *base* pose into a document takes a small surgery. Document
+    // FK renders a `Free` joint at its zero pose on purpose — a 6-DOF pose
+    // does not fit in a joint's scalar `state`, and the live pose belongs to
+    // the physics, not the document. But FK seeds *root* instances from their
+    // own `transform`. So dropping the world joint promotes the trunk to a
+    // root and lets its transform carry the full floating-base pose, which
+    // the rest of the tree then hangs off correctly.
+    if let Ok(seed) = std::env::var("K1_REPLAY") {
+        let seed: u64 = seed.parse().unwrap_or(1);
+        let dir = std::env::var("K1_REPLAY_DIR").unwrap_or_else(|_| "k1_replay".into());
+        std::fs::create_dir_all(&dir)?;
+        let every = env_usize("K1_REPLAY_EVERY", 2).max(1);
+
+        let blob: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&saved)?)?;
+        let pol = &blob["policy"];
+        // The saved policy is whichever architecture trained it; `hidden`
+        // is the discriminator.
+        let mlp: Option<MlpPolicy> = pol
+            .get("hidden")
+            .is_some()
+            .then(|| serde_json::from_value(pol.clone()))
+            .transpose()?;
+        let lin: Option<LinearPolicy> = match &mlp {
+            Some(_) => None,
+            None => Some(serde_json::from_value(pol.clone())?),
+        };
+        println!(
+            "replay: {} policy, seed {seed} → {dir}/",
+            if mlp.is_some() { "mlp" } else { "linear" }
+        );
+
+        let mut env = spec.build()?;
+        let mut obs = env.reset_with_seed(seed);
+        let joint_ids = env.actuated_joint_ids().to_vec();
+        let mut frame = 0usize;
+        let mut total = 0.0;
+        for i in 0..spec.max_steps {
+            if (i as usize).is_multiple_of(every) {
+                write_frame(&spec.doc, &obs, &slots, &joint_ids, &dir, frame)?;
+                frame += 1;
+            }
+            let f = vcad_sim::rl::features(&obs, &slots, NOMINAL_H);
+            let targets = match (&mlp, &lin) {
+                (Some(m), _) => Policy::act(m, &f),
+                (_, Some(l)) => Policy::act(l, &f),
+                _ => unreachable!(),
+            };
+            let r = env.step_full(vcad_kernel_physics::Action::PositionTarget(targets.clone()));
+            total += reward(&r, &targets);
+            obs = r.observation;
+            if r.done {
+                println!("terminated at step {i}: {:?}", r.info.termination_reason);
+                break;
+            }
+        }
+        println!("replay: {frame} frames, return {total:.2}");
+        return Ok(());
+    }
+
+    // `K1_HANDPD=1` sweeps a hand-written ankle balance controller,
+    // *expressed as a linear policy* so it runs through the exact path a
+    // trained policy does.
+    //
+    // This is the load-bearing experiment behind everything else here. If a
+    // two-gain hand controller inside the linear policy class can hold the
+    // K1 up on the randomized task, then the policy class is adequate and a
+    // failure to learn is the trainer's fault — worth tuning. If it cannot,
+    // no amount of ARS tuning will help and the task, the gains, or the
+    // observation are what need to change. Answering this costs a minute;
+    // guessing wrong costs a day of training runs.
+    //
+    // Feature layout (see `rl::features`): 0..3 projected gravity, 3..6 base
+    // linear vel, 6..9 base angular vel, 9 height error, 10.. joint angles.
+    // Ankle-pitch actions are driven from gravity-x (lean) and ω_y (lean
+    // rate) — the textbook ankle strategy.
+    if env_usize("K1_HANDPD", 0) > 0 {
+        const L_ANKLE_PITCH: usize = 14;
+        const R_ANKLE_PITCH: usize = 20;
+        const GX: usize = 0;
+        const WY: usize = 7;
+        println!("hand ankle-PD sweep (kp on gravity-x, kd on ω_y), 10 seeds each:");
+        println!("  sign    kp     kd      mean    steps  full");
+        let mut best = (f64::NEG_INFINITY, 0.0, 0.0, 0.0);
+        for sign in [1.0f64, -1.0] {
+            for kp in [0.0, 2.0, 5.0, 10.0, 20.0, 40.0] {
+                for kd in [0.0, 0.2, 0.5, 1.0, 2.0] {
+                    let mut p = baseline.clone();
+                    for a in [L_ANKLE_PITCH, R_ANKLE_PITCH] {
+                        p.weights[a * obs_dim + GX] = sign * kp;
+                        p.weights[a * obs_dim + WY] = sign * kd;
+                    }
+                    let (r, st, full, _) = eval_10(&spec, &p, &slots, &reward)?;
+                    println!(
+                        "  {sign:>4}  {kp:>5.1}  {kd:>5.2}  {r:>8.2}  {st:>6.1}  {full:>3}/10"
+                    );
+                    if r > best.0 {
+                        best = (r, sign, kp, kd);
+                    }
+                }
+            }
+        }
+        println!(
+            "best: mean {:.2} at sign {} kp {} kd {} (baseline {b_r:.2})",
+            best.0, best.1, best.2, best.3
+        );
+        return Ok(());
+    }
+
+    // `K1_TRACE=1` dumps the baseline's fall step by step. Before tuning a
+    // trainer it is worth confirming the robot is failing at the task rather
+    // than at the physics — a foot that never registers contact produces a
+    // task no policy can solve and a training curve that looks merely hard.
+    if env_usize("K1_TRACE", 0) > 0 {
+        let mut env = spec.build()?;
+        let mut obs = env.reset_with_seed(1);
+        println!("step  height   tilt°   vz       Lfoot_z  Rfoot_z");
+        for i in 0..spec.max_steps {
+            let f = vcad_sim::rl::features(&obs, &slots, NOMINAL_H);
+            let r = env.step_full(vcad_kernel_physics::Action::PositionTarget(
+                baseline.act(&f),
+            ));
+            let h = r.info.base_height_m.unwrap_or(f64::NAN);
+            let tilt = r.info.base_tilt_deg.unwrap_or(f64::NAN);
+            let vz = r.observation.base_velocity.unwrap_or([0.0; 6])[2];
+            let foot = |k: usize| {
+                r.observation
+                    .end_effector_poses
+                    .get(k)
+                    .map_or(f64::NAN, |p| p[2])
+            };
+            if i % 2 == 0 || r.done {
+                println!(
+                    "{i:>4}  {h:>6.3}  {tilt:>6.2}  {vz:>7.3}  {:>7.4}  {:>7.4}",
+                    foot(0),
+                    foot(1)
+                );
+            }
+            obs = r.observation;
+            if r.done {
+                println!("terminated: {:?}", r.info.termination_reason);
+                break;
+            }
+        }
+        return Ok(());
+    }
+
     // `iterations = 0` re-evaluates the policy already on disk instead of
     // retraining — the cheap way to re-check a run you just paid for.
-    let saved = std::path::Path::new(&path).with_file_name("k1_stand_policy.json");
     if iterations == 0 {
         let blob: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&saved)?)?;
         let policy: LinearPolicy = serde_json::from_value(blob["policy"].clone())?;
@@ -154,16 +549,130 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 e.reward, e.steps, spec.max_steps, e.termination_reason
             );
         }
+        let (r, st, full, _) = eval_10(&spec, &policy, &slots, &reward)?;
+        println!("saved policy (10 seeds): mean {r:>7.2} over {st:>5.1} steps, full {full}/10");
         return Ok(());
     }
 
+    // Curriculum: hold randomization at `level` = progress/warmup, capped at
+    // 1, so the task starts deterministic (which this trainer solves) and
+    // reaches the full sim2real ranges by the `warmup` fraction of training,
+    // leaving the remainder to consolidate on the real task. `warmup = 0`
+    // disables it and every iteration runs at full randomization.
+    let warmup = env_f64("K1_CURRICULUM_WARMUP", 0.4);
+    let spec_at = |progress: f64| {
+        let level = if warmup > 0.0 {
+            (progress / warmup).min(1.0)
+        } else {
+            1.0
+        };
+        let mut s = spec.clone();
+        s.config = config_at(level);
+        s
+    };
+    if warmup > 0.0 {
+        println!(
+            "curriculum: randomization ramps 0 → full over the first {:.0}% of training",
+            warmup * 100.0
+        );
+    }
+
+    let arch = std::env::var("K1_POLICY").unwrap_or_else(|_| "mlp".into());
+    let action = ActionSpec {
+        // The URDF rest pose is the standing pose.
+        default_pose_deg: vec![0.0; act_dim],
+        action_scale_deg: env_f64("K1_ACTION_SCALE", 8.0),
+    };
+    match arch.as_str() {
+        "linear" => train_and_report(
+            &spec_at,
+            LinearPolicy::zeros(obs_dim, act_dim, action),
+            &cfg,
+            &slots,
+            &reward,
+            iterations,
+            &saved,
+            (b_r, b_steps, b_full),
+        ),
+        "mlp" => {
+            let hidden = env_usize("K1_HIDDEN", 64);
+            println!("policy: 1-hidden-layer tanh MLP, {hidden} units");
+            train_and_report(
+                &spec_at,
+                MlpPolicy::new(obs_dim, hidden, act_dim, action, cfg.seed),
+                &cfg,
+                &slots,
+                &reward,
+                iterations,
+                &saved,
+                (b_r, b_steps, b_full),
+            )
+        }
+        other => {
+            Err(format!("unknown K1_POLICY {other:?} (expected \"linear\" or \"mlp\")").into())
+        }
+    }
+}
+
+/// Train `policy` and report it against the baseline on the ten fresh seeds.
+///
+/// Generic over the architecture so the linear and MLP arms are the *same*
+/// experiment — identical env, identical seeds, identical reporting — and a
+/// difference between them can only come from the policy.
+#[allow(clippy::too_many_arguments)]
+fn train_and_report<P, R, S>(
+    spec_at: &S,
+    policy: P,
+    cfg: &ArsConfig,
+    slots: &[usize],
+    reward: &R,
+    iterations: usize,
+    saved: &std::path::Path,
+    baseline: (f64, f64, usize),
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    P: vcad_sim::rl::Policy + serde::Serialize,
+    R: Fn(&vcad_kernel_physics::StepResult, &[f64]) -> f64 + Sync + Send,
+    S: Fn(f64) -> EnvSpec + Sync,
+{
+    let (b_r, b_steps, b_full) = baseline;
+    // Everything is reported against the *full* task, never the curriculum's
+    // current easier version of it.
+    let spec = &spec_at(1.0);
+
+    // Score the iterate on the ten held-out seeds every n iterations
+    // (`K1_CURVE=0` disables). On by default: at ~10 rollouts per probe
+    // against ~72 per training iteration it costs a couple of percent, and
+    // it is the only honest learning curve there is:
+    // the trainer's own eval column can sit flat, or climb, while held-out
+    // performance collapses — which is exactly what it does here.
+    let curve = env_usize("K1_CURVE", 10);
+    let mut best_held_out = (f64::NEG_INFINITY, 0usize);
+    // ...and keep the iterate that earned it. ARS does not converge and stay
+    // converged here: it walks out of a solution at the same rate it walked
+    // in (see `ArsConfig::step_size`). Holding on to the best *honestly
+    // scored* iterate makes that wandering harmless instead of fatal.
+    let mut best_held_out_policy: Option<P> = None;
     let t0 = std::time::Instant::now();
     let TrainOutcome {
-        policy: _final,
-        best_policy: policy,
+        policy: last,
+        best_policy: best,
         best_eval_reward,
         log,
-    } = vcad_sim::rl::train(&spec, policy, &cfg, NOMINAL_H, reward, |e| {
+    } = vcad_sim::rl::train_curriculum(spec_at, policy, cfg, NOMINAL_H, reward, |e, p| {
+        if curve > 0 && (e.iteration % curve == 0 || e.iteration + 1 == iterations) {
+            if let Ok((r, st, full, _)) = eval_10(spec, p, slots, reward) {
+                if r > best_held_out.0 {
+                    best_held_out = (r, e.iteration);
+                    best_held_out_policy = Some(p.clone());
+                }
+                println!(
+                    "iter {:>4}  train-eval {:>8.2}  sigma {:>8.3}  |dW| {:>7.4}  |  HELD-OUT {:>8.2} over {:>5.1} steps, full {full}/10",
+                    e.iteration, e.eval_reward, e.sigma, e.update_norm, r, st
+                );
+            }
+            return;
+        }
         if e.iteration % 5 == 0 || e.iteration + 1 == iterations {
             println!(
                 "iter {:>4}  mean {:>8.2}  max {:>8.2}  eval {:>8.2}  survived {:>4}/{}",
@@ -176,56 +685,131 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
         }
     })?;
+    println!("trained in {:?}", t0.elapsed());
+    if curve > 0 {
+        println!(
+            "best held-out score during training: {:.2} at iteration {}",
+            best_held_out.0, best_held_out.1
+        );
+    }
+
+    // Final report. Both the *best* iterate (selected on ARS's own eval
+    // seeds) and the *last* iterate are scored on the ten fresh seeds,
+    // because "best" is a selection made on a handful of draws and is itself
+    // a quantity that can overfit. If the two disagree wildly, the selection
+    // is the thing that is broken, not the policy.
+    let (mean_r, mean_steps, survived, worst) = eval_10(spec, &best, slots, reward)?;
+    let (l_r, l_steps, l_full, _) = eval_10(spec, &last, slots, reward)?;
     println!(
-        "trained in {:?} — keeping the best iterate (eval {best_eval_reward:.2})",
-        t0.elapsed()
+        "\nhold-rest-pose baseline (10 seeds): mean {b_r:>7.2} over {b_steps:>5.1} steps, \
+         full {b_full}/10\n\
+         best iterate  (10 seeds): mean {mean_r:>7.2} over {mean_steps:>5.1} steps, \
+         full {survived}/10, worst {:>7.2} over {} steps ({:?})\n\
+         last iterate  (10 seeds): mean {l_r:>7.2} over {l_steps:>5.1} steps, full {l_full}/10\n\
+         (training-time eval of the best iterate was {best_eval_reward:.2} — \
+         compare that gap, not the number)",
+        worst.reward, worst.steps, worst.termination_reason
     );
 
-    // Final report: baseline (hold the rest pose) vs the learned policy.
-    let mut env = spec.build()?;
-    let mut obs = env.reset_with_seed(1);
-    let (mut baseline_steps, mut baseline_r) = (0u32, 0.0);
-    for _ in 0..spec.max_steps {
-        let targets = vec![0.0; act_dim];
-        let r = env.step_full(Action::PositionTarget(targets.clone()));
-        baseline_r += reward(&r, &targets);
-        baseline_steps += 1;
-        obs = r.observation;
-        if r.done {
-            break;
+    // Ship whichever iterate actually scored best on held-out seeds, and say
+    // which. Defaulting to the trainer's own "best" is what produced a policy
+    // no better than doing nothing; and because ARS walks back out of a
+    // solution (see `ArsConfig::step_size`), the peak is usually neither the
+    // last iterate nor the one the trainer liked.
+    let (mut kept, mut kept_name, mut kept_score) = if l_r > mean_r {
+        (&last, "last", l_r)
+    } else {
+        (&best, "train-eval-best", mean_r)
+    };
+    if let Some(p) = best_held_out_policy.as_ref() {
+        if best_held_out.0 > kept_score {
+            kept = p;
+            kept_name = "held-out-best";
+            kept_score = best_held_out.0;
         }
     }
-    let _ = obs;
-
-    // Evaluate over a spread of seeds, not one. Each reset re-samples the
-    // episode's actuator latency, so a single-seed number hides brittleness.
-    let mut env = spec.build()?;
-    let evals: Vec<_> = (1..=10u64)
-        .map(|s| vcad_sim::rl::rollout(&mut env, &policy, &slots, NOMINAL_H, s, &reward, None))
-        .collect();
-    let survived = evals.iter().filter(|e| e.steps == spec.max_steps).count();
-    let mean_r = evals.iter().map(|e| e.reward).sum::<f64>() / evals.len() as f64;
-    let worst = evals
-        .iter()
-        .min_by(|a, b| a.reward.total_cmp(&b.reward))
-        .unwrap();
-    println!(
-        "\nhold-rest-pose baseline: {:>7.2} over {:>3} steps\n\
-         learned policy (10 seeds): mean {:>7.2}, full episode on {survived}/10, \
-         worst {:>7.2} over {} steps ({:?})",
-        baseline_r, baseline_steps, mean_r, worst.reward, worst.steps, worst.termination_reason
-    );
-
-    let out = saved;
+    println!("keeping the {kept_name} iterate (held-out {kept_score:.2})");
     std::fs::write(
-        &out,
+        saved,
         serde_json::to_string_pretty(&serde_json::json!({
-            "policy": policy,
+            "policy": kept,
+            "kept": kept_name,
             "log": log,
             "config": cfg,
         }))?,
     )?;
-    println!("policy → {}", out.display());
+    println!("policy → {}", saved.display());
 
+    Ok(())
+}
+
+/// Write one replay frame as a standalone `.vcad`.
+///
+/// Drops the `Free` world joint so the trunk becomes a root instance whose
+/// `transform` carries the live floating-base pose, then stamps each actuated
+/// joint's angle into its `state`. Document FK reproduces the rest.
+fn write_frame(
+    doc: &Document,
+    obs: &vcad_kernel_physics::Observation,
+    slots: &[usize],
+    joint_ids: &[String],
+    dir: &str,
+    frame: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut d = doc.clone();
+    let pose = obs
+        .base_pose
+        .unwrap_or([0.0, 0.0, NOMINAL_H, 1.0, 0.0, 0.0, 0.0]);
+    let (x, y, z) = (pose[0], pose[1], pose[2]);
+    let (qw, qx, qy, qz) = (pose[3], pose[4], pose[5], pose[6]);
+
+    // Quaternion → the Rz·Ry·Rx Euler degrees `vcad_eval::kinematics` expects.
+    let m20 = -2.0 * (qx * qz - qw * qy);
+    let m21 = 2.0 * (qy * qz + qw * qx);
+    let m22 = 1.0 - 2.0 * (qx * qx + qy * qy);
+    let m00 = 1.0 - 2.0 * (qy * qy + qz * qz);
+    let m10 = 2.0 * (qx * qy + qw * qz);
+    let sy = -m20;
+    let cy = (m00 * m00 + m10 * m10).sqrt();
+    let (rx, ry, rz) = if cy > 1e-6 {
+        (m21.atan2(m22), sy.atan2(cy), m10.atan2(m00))
+    } else {
+        (0.0, sy.atan2(cy), 0.0)
+    };
+    let deg = 180.0 / std::f64::consts::PI;
+
+    let base_id = d
+        .joints
+        .iter()
+        .flat_map(|js| js.iter())
+        .find(|j| matches!(j.kind, vcad_ir::JointKind::Free))
+        .map(|j| j.child_instance_id.clone())
+        .ok_or("replay needs a Free base joint")?;
+
+    if let Some(js) = d.joints.as_mut() {
+        js.retain(|j| !matches!(j.kind, vcad_ir::JointKind::Free));
+        for j in js.iter_mut() {
+            if let Some(a) = joint_ids.iter().position(|id| *id == j.id) {
+                j.state = obs.joint_positions[slots[a]];
+            }
+        }
+    }
+    if let Some(insts) = d.instances.as_mut() {
+        for inst in insts.iter_mut() {
+            if inst.id == base_id {
+                inst.transform = Some(vcad_ir::Transform3D {
+                    // Physics is metres, documents are millimetres.
+                    translation: vcad_ir::Vec3::new(x * 1000.0, y * 1000.0, z * 1000.0),
+                    rotation: vcad_ir::Vec3::new(rx * deg, ry * deg, rz * deg),
+                    scale: vcad_ir::Vec3::new(1.0, 1.0, 1.0),
+                });
+            }
+        }
+    }
+    d.ground_instance_id = None;
+    std::fs::write(
+        format!("{dir}/frame_{frame:04}.vcad"),
+        serde_json::to_string(&d)?,
+    )?;
     Ok(())
 }

--- a/crates/vcad-sim/src/rl.rs
+++ b/crates/vcad-sim/src/rl.rs
@@ -10,6 +10,59 @@
 //! The crate ships the *algorithm* and the observation plumbing; the reward is
 //! a caller-supplied closure over [`StepResult`], matching the kernel's stance
 //! that no reward DSL belongs in the physics.
+//!
+//! # ARS does not converge and stay converged
+//!
+//! The single most useful thing to know about this trainer: its update is
+//! scale-free. `α·(r₊−r₋)/(k·σ)` normalizes away the return spread, so the
+//! applied step has about the same norm no matter how good the policy already
+//! is — there is no built-in annealing as it approaches a solution. Left at
+//! too large an `α` it will find a solution and then walk straight back out
+//! of it, at the same speed it walked in.
+//!
+//! On the K1 standing task with randomization off and the old default
+//! `α = 0.03`, held-out score reached a perfect 400/400 on iteration 20 and
+//! was −16 by iteration 29, with the update norm flat at ~0.4 throughout —
+//! including while the policy was solving the task. At `α = 0.005` the same
+//! task reaches 400/400 on iteration 42 and is still there 17 iterations
+//! later. Three seeds, same story. See [`ArsConfig::step_size`].
+//!
+//! Two habits follow, and this module is shaped around both: score iterates
+//! on held-out seeds from the `on_iteration` callback and *keep the best one*
+//! rather than whatever the last iteration happened to leave you with; and
+//! watch [`IterationLog::update_norm`] and [`IterationLog::sigma`] when a run
+//! climbs and then falls apart.
+//!
+//! # Evaluating a run on a randomized env
+//!
+//! One thing to internalize before reading any number this module produces:
+//! **[`IterationLog::eval_reward`] is not a measure of policy quality.** It is
+//! an average over [`ArsConfig::rollouts_per_eval`] episodes of a
+//! domain-randomized env, and with a handful of rollouts its variance across
+//! randomization draws swamps the difference between a good policy and a bad
+//! one.
+//!
+//! Measured on the Booster K1 standing task (see the `k1_stand` example), the
+//! trainer's eval column and a ten-seed held-out score are not merely noisy
+//! versions of each other — they point in *opposite* directions. Held-out
+//! score peaked at 35.40 on iteration 3 and decayed to below the
+//! do-nothing baseline by iteration 20, while the eval column sat at 30–45
+//! throughout and hit its maximum for the whole run (57.16) on the iteration
+//! whose held-out score was 10.84.
+//!
+//! Two consequences are baked into this module's API:
+//!
+//! - [`train`]'s `on_iteration` callback receives the current policy, so a
+//!   caller can score each iterate against seeds the trainer never touches.
+//!   That external score is the only trustworthy one.
+//! - [`TrainOutcome::best_policy`] selects on the trainer's own eval seeds and
+//!   is therefore a trap; see its docs.
+//!
+//! Antithetic pairs and all directions within an iteration already share a
+//! seed set (common random numbers), so the *comparison* between directions is
+//! fair. What stays noisy is the comparison *across* iterations, since each
+//! iteration draws a fresh seed set — which is what makes the argmax over
+//! iterations select for lucky draws.
 
 use std::collections::HashMap;
 
@@ -72,6 +125,26 @@ impl EnvSpec {
     }
 }
 
+/// What ARS needs of a policy: a flat parameter vector it can perturb, the
+/// whitening statistics it maintains, and a way to act.
+///
+/// ARS never differentiates the policy, so this is the whole interface — any
+/// architecture that can expose its parameters as one `Vec<f64>` trains
+/// unchanged. That is what lets [`MlpPolicy`] drop in beside [`LinearPolicy`]
+/// without touching the trainer.
+pub trait Policy: Clone + Send + Sync {
+    /// Observation feature count.
+    fn obs_dim(&self) -> usize;
+    /// Flat, contiguous parameter vector — the thing ARS perturbs.
+    fn params(&self) -> &[f64];
+    /// Mutable view of the same vector. Length must never change.
+    fn params_mut(&mut self) -> &mut [f64];
+    /// Install refreshed observation whitening statistics.
+    fn set_whitening(&mut self, mean: Vec<f64>, std: Vec<f64>);
+    /// Joint position targets (degrees) for a feature vector.
+    fn act(&self, features: &[f64]) -> Vec<f64>;
+}
+
 /// A linear policy `a = W · ẑ` over whitened observation features, with the
 /// running feature statistics ARS V2 uses for whitening.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,6 +187,130 @@ impl LinearPolicy {
             }
             *o = self.action.default_pose_deg[a]
                 + (acc.clamp(-1.0, 1.0)) * self.action.action_scale_deg;
+        }
+        out
+    }
+}
+
+impl Policy for LinearPolicy {
+    fn obs_dim(&self) -> usize {
+        self.obs_dim
+    }
+    fn params(&self) -> &[f64] {
+        &self.weights
+    }
+    fn params_mut(&mut self) -> &mut [f64] {
+        &mut self.weights
+    }
+    fn set_whitening(&mut self, mean: Vec<f64>, std: Vec<f64>) {
+        self.mean = mean;
+        self.std = std;
+    }
+    fn act(&self, features: &[f64]) -> Vec<f64> {
+        LinearPolicy::act(self, features)
+    }
+}
+
+/// A one-hidden-layer `tanh` policy over the same whitened features.
+///
+/// Balance switches contact mode — double support, single support, toe-off —
+/// and a linear map has to serve every mode with one gain matrix. This is the
+/// smallest thing with enough capacity to gate on the mode.
+///
+/// The first layer is initialized *random*, not zero, unlike the linear
+/// policy. ARS at an all-zero MLP is nearly stationary: with `W1 = 0` the
+/// hidden activations are zero, so a perturbation of `W2` has no effect at
+/// all and only the second-order `W1×W2` term moves the return. Random `W1`
+/// with `W2 = 0` starts the policy at the same do-nothing action as the
+/// linear one (so the two are comparable from step 0) while giving `W2` a
+/// non-degenerate basis to act on immediately. Both layers train.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MlpPolicy {
+    /// Flat parameters: `W1 (hidden × obs)`, `b1 (hidden)`, `W2 (act ×
+    /// hidden)`, `b2 (act)`, concatenated in that order.
+    pub params: Vec<f64>,
+    /// Observation feature count.
+    pub obs_dim: usize,
+    /// Hidden unit count.
+    pub hidden: usize,
+    /// Action dimension.
+    pub act_dim: usize,
+    /// Running feature mean used for whitening.
+    pub mean: Vec<f64>,
+    /// Running feature standard deviation used for whitening.
+    pub std: Vec<f64>,
+    /// How raw outputs map to joint targets.
+    pub action: ActionSpec,
+}
+
+impl MlpPolicy {
+    /// A policy with random first-layer features and a zero output layer.
+    ///
+    /// `seed` fixes the first-layer draw so two runs being compared share an
+    /// initialization and differ only in what is under test.
+    pub fn new(
+        obs_dim: usize,
+        hidden: usize,
+        act_dim: usize,
+        action: ActionSpec,
+        seed: u64,
+    ) -> Self {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let scale = 1.0 / (obs_dim as f64).sqrt();
+        let mut params = vec![0.0; hidden * obs_dim + hidden + act_dim * hidden + act_dim];
+        for w in params.iter_mut().take(hidden * obs_dim) {
+            *w = rng.gen_range(-1.0..1.0) * scale;
+        }
+        Self {
+            params,
+            obs_dim,
+            hidden,
+            act_dim,
+            mean: vec![0.0; obs_dim],
+            std: vec![1.0; obs_dim],
+            action,
+        }
+    }
+}
+
+impl Policy for MlpPolicy {
+    fn obs_dim(&self) -> usize {
+        self.obs_dim
+    }
+    fn params(&self) -> &[f64] {
+        &self.params
+    }
+    fn params_mut(&mut self) -> &mut [f64] {
+        &mut self.params
+    }
+    fn set_whitening(&mut self, mean: Vec<f64>, std: Vec<f64>) {
+        self.mean = mean;
+        self.std = std;
+    }
+    fn act(&self, features: &[f64]) -> Vec<f64> {
+        let (n_w1, n_b1) = (self.hidden * self.obs_dim, self.hidden);
+        let (w1, rest) = self.params.split_at(n_w1);
+        let (b1, rest) = rest.split_at(n_b1);
+        let (w2, b2) = rest.split_at(self.act_dim * self.hidden);
+
+        let mut h = vec![0.0; self.hidden];
+        for (j, hj) in h.iter_mut().enumerate() {
+            let mut acc = b1[j];
+            for (i, f) in features.iter().enumerate() {
+                let z = (f - self.mean[i]) / self.std[i].max(1e-6);
+                acc += w1[j * self.obs_dim + i] * z;
+            }
+            *hj = acc.tanh();
+        }
+
+        let mut out = vec![0.0; self.act_dim];
+        for (a, o) in out.iter_mut().enumerate() {
+            let mut acc = b2[a];
+            for (j, hj) in h.iter().enumerate() {
+                acc += w2[a * self.hidden + j] * hj;
+            }
+            *o = self.action.default_pose_deg[a]
+                + acc.clamp(-1.0, 1.0) * self.action.action_scale_deg;
         }
         out
     }
@@ -179,13 +376,38 @@ pub struct ArsConfig {
     /// How many best-performing directions contribute to the update.
     pub top_k: usize,
     /// Step size α.
+    ///
+    /// This matters more than it looks, because the ARS update is
+    /// *scale-free*: `α·(r₊−r₋)/(k·σ)` divides out the return spread, so the
+    /// applied step has roughly the same norm whether the policy is terrible
+    /// or optimal. It does not anneal on its own as the policy converges the
+    /// way a gradient method's does. Too large an α therefore does not show
+    /// up as failure to learn — it shows up as *inability to stay* anywhere
+    /// good.
+    ///
+    /// Measured on the K1 standing task with the previous default of 0.03,
+    /// with domain randomization off so the signal is clean. Held-out score
+    /// per iteration, and the norm of the applied update:
+    ///
+    /// | seed | reaches 400/400 | then                        | ‖ΔW‖    |
+    /// |------|-----------------|-----------------------------|---------|
+    /// | 7    | iteration 20    | −16 by iteration 29         | 0.39–0.47 |
+    /// | 23   | iteration 8     | 87 by iteration 24          | 0.36–0.42 |
+    /// | 11   | never (peak 88) | wanders 35–87               | 0.31–0.46 |
+    ///
+    /// The step norm is flat across every one of those regimes, including
+    /// while the policy is solving the task perfectly. ARS walks out of the
+    /// solution basin at the same speed it walked in.
+    ///
+    /// At 0.005 the same task reaches 400/400 on iteration 42 and is still
+    /// there 17 iterations later. If a run of yours climbs and then falls
+    /// apart, reach for this before anything else, and log
+    /// [`IterationLog::update_norm`] to see the step that is doing it.
     pub step_size: f64,
     /// Exploration noise ν.
     pub noise_std: f64,
     /// Training iterations.
     pub iterations: usize,
-    /// Max env steps per rollout.
-    pub episode_steps: u32,
     /// Rollouts averaged per policy evaluation — both when scoring a
     /// direction and when evaluating the current iterate.
     ///
@@ -207,11 +429,15 @@ impl Default for ArsConfig {
         Self {
             n_directions: 16,
             top_k: 8,
-            step_size: 0.02,
+            // Deliberately small: a step that finds a solution faster but
+            // cannot stay in it is worth less than a slower one that can.
+            // See the measurements on `step_size`.
+            step_size: 0.005,
             noise_std: 0.03,
             iterations: 200,
-            episode_steps: 500,
-            rollouts_per_eval: 1,
+            // One rollout per evaluation measures the randomization draw as
+            // much as the policy; only sound on a deterministic env.
+            rollouts_per_eval: 3,
             seed: 0,
         }
     }
@@ -241,6 +467,17 @@ pub struct IterationLog {
     pub eval_reward: f64,
     /// Steps survived by the evaluation rollout.
     pub eval_steps: u32,
+    /// Spread of the top-`k` returns this iteration — the denominator of the
+    /// ARS update.
+    ///
+    /// Worth logging because it is the failure mode: as the policy converges,
+    /// every rollout returns nearly the same thing, this collapses toward
+    /// zero, and the update `α·(r₊−r₋)/(k·σ)` blows up. A run that reaches a
+    /// good policy and then falls apart will show `sigma` cratering one or
+    /// two iterations before the return does.
+    pub sigma: f64,
+    /// Norm of the parameter update actually applied this iteration.
+    pub update_norm: f64,
 }
 
 /// Build the policy feature vector from an env observation.
@@ -307,9 +544,9 @@ pub fn actuated_slots(env: &RobotEnv) -> Vec<usize> {
 ///
 /// `reward` sees each step's full [`StepResult`] plus the commanded action, so
 /// task shaping stays entirely on the caller's side.
-pub fn rollout<R>(
+pub fn rollout<P, R>(
     env: &mut RobotEnv,
-    policy: &LinearPolicy,
+    policy: &P,
     slots: &[usize],
     nominal_h: f64,
     seed: u64,
@@ -317,6 +554,7 @@ pub fn rollout<R>(
     stats: Option<&mut RunningStatsHandle>,
 ) -> RolloutStats
 where
+    P: Policy,
     R: Fn(&StepResult, &[f64]) -> f64 + Sync,
 {
     let mut obs = env.reset_with_seed(seed);
@@ -359,16 +597,28 @@ impl RunningStatsHandle {
 }
 
 /// Result of a training run.
-pub struct TrainOutcome {
+pub struct TrainOutcome<P> {
     /// The policy as of the final iteration.
+    pub policy: P,
+    /// The iterate that scored highest on the trainer's *own* evaluation
+    /// seeds.
     ///
-    /// Prefer [`Self::best_policy`] for anything you intend to *use*: ARS's
-    /// last iterate is a random draw from a noisy walk, and on a randomized
-    /// env it is routinely far worse than the best iterate seen.
-    pub policy: LinearPolicy,
-    /// The iterate with the highest evaluation return, and that return.
-    pub best_policy: LinearPolicy,
-    /// Evaluation return of [`Self::best_policy`].
+    /// **This is not the best policy, and on a randomized env it is not even
+    /// correlated with being good.** Measured on the K1 standing task, per
+    /// iteration, against ten held-out seeds: the iterate this field selects
+    /// scored 10.84 while the iterate three updates earlier scored 35.40, and
+    /// the selection was made precisely *because* that iterate drew the
+    /// luckiest evaluation (57.16, the highest training-eval of the run). The
+    /// argmax over a noisy score selects for noise, and it selects harder the
+    /// longer training runs.
+    ///
+    /// Use [`Self::policy`], or better, do the selection yourself against
+    /// held-out seeds from the `on_iteration` callback, which is handed each
+    /// iterate for exactly this purpose. This field is retained only so a
+    /// caller can measure the gap.
+    pub best_policy: P,
+    /// Evaluation return of [`Self::best_policy`] on the trainer's own seeds
+    /// — the quantity that does the overfitting described there.
     pub best_eval_reward: f64,
     /// Per-iteration log.
     pub log: Vec<IterationLog>,
@@ -377,50 +627,94 @@ pub struct TrainOutcome {
 /// Train a linear policy with ARS.
 ///
 /// `reward` is called once per env step. `on_iteration` is invoked after each
-/// update with the log entry, for progress printing.
-pub fn train<R, F>(
+/// update with the log entry *and the updated policy*, so a caller can score
+/// it on held-out seeds or checkpoint it. On a randomized env that hook is
+/// not optional bookkeeping: the trainer's own eval return is not a
+/// trustworthy measure of the iterate, so without an external one there is no
+/// way to know which iteration was actually best.
+pub fn train<P, R, F>(
     spec: &EnvSpec,
-    mut policy: LinearPolicy,
+    policy: P,
+    cfg: &ArsConfig,
+    nominal_h: f64,
+    reward: R,
+    on_iteration: F,
+) -> Result<TrainOutcome<P>, vcad_kernel_physics::PhysicsError>
+where
+    P: Policy,
+    R: Fn(&StepResult, &[f64]) -> f64 + Sync + Send,
+    F: FnMut(&IterationLog, &P),
+{
+    train_curriculum(
+        |_| spec.clone(),
+        policy,
+        cfg,
+        nominal_h,
+        reward,
+        on_iteration,
+    )
+}
+
+/// Train with an env that *changes over training*.
+///
+/// `spec_at` is called with training progress in `[0, 1]` and returns the env
+/// to collect rollouts in at that point — the hook for a domain-randomization
+/// curriculum, where the ranges start narrow and widen toward the real task.
+///
+/// Evaluation always runs at `spec_at(1.0)`, the full target task, never at
+/// the current curriculum level. An eval that eases off with the curriculum
+/// would show a rising curve made entirely of the task getting easier.
+pub fn train_curriculum<P, R, F, S>(
+    spec_at: S,
+    mut policy: P,
     cfg: &ArsConfig,
     nominal_h: f64,
     reward: R,
     mut on_iteration: F,
-) -> Result<TrainOutcome, vcad_kernel_physics::PhysicsError>
+) -> Result<TrainOutcome<P>, vcad_kernel_physics::PhysicsError>
 where
+    P: Policy,
     R: Fn(&StepResult, &[f64]) -> f64 + Sync + Send,
-    F: FnMut(&IterationLog),
+    F: FnMut(&IterationLog, &P),
+    S: Fn(f64) -> EnvSpec + Sync,
 {
-    let probe = spec.build()?;
+    let target_spec = spec_at(1.0);
+    let probe = target_spec.build()?;
     let slots = actuated_slots(&probe);
     drop(probe);
 
     let mut rng = StdRng::seed_from_u64(cfg.seed);
-    let mut stats = RunningStats::new(policy.obs_dim);
+    let obs_dim = policy.obs_dim();
+    let n_params = policy.params().len();
+    let mut stats = RunningStats::new(obs_dim);
     let mut log = Vec::with_capacity(cfg.iterations);
     let mut best = (f64::NEG_INFINITY, policy.clone());
 
     for it in 0..cfg.iterations {
         // Sample δ directions up front so the parallel section is pure.
         let deltas: Vec<Vec<f64>> = (0..cfg.n_directions)
-            .map(|_| {
-                (0..policy.weights.len())
-                    .map(|_| rng.gen_range(-1.0..1.0))
-                    .collect()
-            })
+            .map(|_| (0..n_params).map(|_| rng.gen_range(-1.0..1.0)).collect())
             .collect();
         let base_seed = rng.gen::<u64>();
+        // The curriculum level this iteration collects rollouts at.
+        let progress = if cfg.iterations > 1 {
+            it as f64 / (cfg.iterations - 1) as f64
+        } else {
+            1.0
+        };
+        let iter_spec = spec_at(progress);
 
         let results: Vec<Result<(f64, f64, RunningStats), vcad_kernel_physics::PhysicsError>> =
             deltas
                 .par_iter()
                 .enumerate()
                 .map(|(d, delta)| {
-                    let mut env = spec.build()?;
-                    let mut local = RunningStatsHandle::new(policy.obs_dim);
+                    let mut env = iter_spec.build()?;
+                    let mut local = RunningStatsHandle::new(obs_dim);
                     let _ = d;
                     let mut score = |sign: f64| -> f64 {
                         let mut p = policy.clone();
-                        for (w, dw) in p.weights.iter_mut().zip(delta.iter()) {
+                        for (w, dw) in p.params_mut().iter_mut().zip(delta.iter()) {
                             *w += sign * cfg.noise_std * dw;
                         }
                         // Same seed set for +δ and −δ (and for every
@@ -465,22 +759,29 @@ where
             .sqrt()
             .max(1e-6);
 
+        let before: Vec<f64> = policy.params().to_vec();
         for (plus, minus, i) in top {
             let coeff = cfg.step_size * (plus - minus) / (cfg.top_k as f64 * sigma);
-            for (w, dw) in policy.weights.iter_mut().zip(deltas[*i].iter()) {
+            for (w, dw) in policy.params_mut().iter_mut().zip(deltas[*i].iter()) {
                 *w += coeff * dw;
             }
         }
+        let update_norm = policy
+            .params()
+            .iter()
+            .zip(before.iter())
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f64>()
+            .sqrt();
 
         // Refresh whitening from everything seen so far.
-        policy.mean = stats.mean.clone();
-        policy.std = stats.std();
+        policy.set_whitening(stats.mean.clone(), stats.std());
 
         // Evaluate the updated policy on a *fixed* held-out seed set, the
         // same one every iteration, averaged. Fixed so the curve is
         // comparable across iterations; averaged so it measures the policy
         // rather than the draw.
-        let mut env = spec.build()?;
+        let mut env = target_spec.build()?;
         let k = cfg.rollouts_per_eval.max(1);
         let evals: Vec<RolloutStats> = (0..k)
             .map(|j| {
@@ -513,8 +814,10 @@ where
             max_reward: all.iter().cloned().fold(f64::NEG_INFINITY, f64::max),
             eval_reward: eval.reward,
             eval_steps: eval.steps,
+            sigma,
+            update_norm,
         };
-        on_iteration(&entry);
+        on_iteration(&entry, &policy);
         log.push(entry);
     }
 
@@ -524,4 +827,82 @@ where
         best_eval_reward: best.0,
         log,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec(act_dim: usize) -> ActionSpec {
+        ActionSpec {
+            default_pose_deg: vec![0.0; act_dim],
+            action_scale_deg: 8.0,
+        }
+    }
+
+    /// Both architectures start at the default pose, so a run that swaps one
+    /// for the other is comparable from iteration 0 rather than starting the
+    /// MLP somewhere else on the reward surface.
+    #[test]
+    fn both_policies_start_at_the_default_pose() {
+        let (obs, act) = (54, 22);
+        let f = vec![0.3; obs];
+        let lin = LinearPolicy::zeros(obs, act, spec(act));
+        let mlp = MlpPolicy::new(obs, 16, act, spec(act), 7);
+        assert_eq!(Policy::act(&lin, &f), vec![0.0; act]);
+        assert_eq!(Policy::act(&mlp, &f), vec![0.0; act]);
+    }
+
+    /// The MLP's first layer must be non-degenerate at init. If it were zero
+    /// (the obvious choice, and the one the linear policy uses) the hidden
+    /// activations would be zero, every second-layer perturbation would have
+    /// exactly zero effect on the return, and ARS would sit still burning
+    /// rollouts while looking merely slow to converge.
+    #[test]
+    fn mlp_output_layer_has_a_nonzero_basis_to_act_on() {
+        let (obs, hidden, act) = (54, 16, 22);
+        let f: Vec<f64> = (0..obs).map(|i| (i as f64 * 0.1).sin()).collect();
+        let mut mlp = MlpPolicy::new(obs, hidden, act, spec(act), 7);
+
+        // Perturb only the second layer, exactly as ARS would.
+        let w2_start = hidden * obs + hidden;
+        for w in mlp.params[w2_start..w2_start + act * hidden].iter_mut() {
+            *w = 0.01;
+        }
+        let out = Policy::act(&mlp, &f);
+        assert!(
+            out.iter().any(|&o| o.abs() > 1e-9),
+            "second-layer perturbation had no effect — first layer is degenerate"
+        );
+    }
+
+    /// Actions stay inside `default ± action_scale_deg` however large the
+    /// features or weights get: the env is handed joint targets, and an
+    /// unclamped policy would command past the joint limits.
+    #[test]
+    fn mlp_action_is_bounded_by_the_action_scale() {
+        let (obs, act) = (54, 22);
+        let f = vec![1e6; obs];
+        let mut mlp = MlpPolicy::new(obs, 8, act, spec(act), 1);
+        for w in mlp.params.iter_mut() {
+            *w = 1e3;
+        }
+        for o in Policy::act(&mlp, &f) {
+            assert!(o.abs() <= 8.0 + 1e-9, "action {o} escaped the action scale");
+        }
+    }
+
+    /// `params_mut` must alias the same storage `act` reads, or ARS would
+    /// perturb a copy and every direction would score identically.
+    #[test]
+    fn param_views_alias_the_live_parameters() {
+        let (obs, act) = (12, 4);
+        let mut mlp = MlpPolicy::new(obs, 5, act, spec(act), 3);
+        let n = mlp.params().len();
+        let before = Policy::act(&mlp, &vec![0.5; obs]);
+        for w in mlp.params_mut().iter_mut().skip(n - act * 5 - act) {
+            *w += 0.5;
+        }
+        assert_ne!(before, Policy::act(&mlp, &vec![0.5; obs]));
+    }
 }


### PR DESCRIPTION
Follow-up to #766, which landed the ARS trainer and the `k1_stand` example but left the randomized Booster K1 standing task unsolved (10-seed mean return 11.01, 0/10 full episodes, barely above a do-nothing baseline).

**It's solved: 386.92 held-out return, 10/10 full 400-step episodes.**

## What was actually wrong

Not the domain randomization, and not the reward — **the ARS step size**.

The update `α·(r₊−r₋)/(k·σ)` is *scale-free*: σ-normalization divides out the return spread, so the applied step has roughly the same norm whether the policy is terrible or optimal, and it never anneals as the policy converges the way a gradient method's does. At the committed `α = 0.03` the trainer found solutions and walked straight back out of them.

With randomization **off**, so the signal is clean — held-out score per iteration, and the norm of the applied update:

| seed | reaches 400/400 | then | ‖ΔW‖ |
|---|---|---|---|
| 7 | iteration 20 | −16 by iteration 29 | 0.39–0.47 |
| 23 | iteration 8 | 87 by iteration 24 | 0.36–0.42 |
| 11 | never (peak 88) | wanders 35–87 | 0.31–0.46 |

The step norm is flat across every one of those regimes, *including while the policy is solving the task perfectly*. This also means the deterministic task solves in ~20 iterations, not the ~800 previously believed — the old number was measuring repeated collapse-and-recover.

Because nothing could hold a solution, none of the obvious fixes could show a benefit. Once α dropped to 0.005, they all did. All figures are the mean over ten fresh evaluation seeds, full randomization:

| configuration | held-out | full episodes |
|---|---|---|
| hold-rest-pose baseline | 9.55 | 0/10 |
| linear, α = 0.03 *(previous default)* | 10.84 | 0/10 |
| linear, α = 0.005 | 221.92 | 5/10 |
| linear + `rollouts_per_eval` 8 | 272.99 | 7/10 |
| linear + curriculum | 280.33 | 7/10 |
| **MLP-64 + curriculum** | **386.92** | **10/10** |

Worst seed on the winning run scores 356.29 and terminates for no reason other than running out of episode.

## Changes to `vcad-sim::rl`

- **`ArsConfig::step_size` 0.03 → 0.005**, documented with the collapse table above.
- **`Policy` trait** over the flat parameter vector ARS perturbs — ARS never differentiates the policy, so that's the whole interface and an architecture drops in without touching the trainer. Adds **`MlpPolicy`** (one tanh hidden layer). Its first layer is randomly initialized *on purpose*: at all-zero the hidden activations are zero, second-layer perturbations have exactly zero effect on the return, and ARS sits still while looking merely slow to converge.
- **`train_curriculum`** — the env becomes a function of training progress so randomization can ramp in. Evaluation always runs `spec_at(1.0)`, the full target task, never the eased one; an eval that softens with the curriculum would show a rising curve made entirely of the task getting easier.
- **`on_iteration` now receives the policy**, so callers can score iterates against seeds the trainer never touches.
- **`IterationLog` gains `sigma` and `update_norm`** — the instrumentation that located the bug.
- **Removed `ArsConfig::episode_steps`**: never read (length comes from `EnvSpec::max_steps`), so setting it silently did nothing.

## The evaluation trap is worse than reported

#766 documented that selecting the best iterate by eval return picks lucky randomization draws. It's stronger than that — the two are *anti-correlated*, not merely noisy. In the linear+curriculum run, over iterations 175–199, held-out sat at 277–280 with 7/10 full episodes while the trainer's own eval column read **−1.63, −0.56, −1.02, 0.63, −3.40, −0.15**. Three fixed eval seeds called the best policy of the session worthless; selecting on that column picks an iterate worth 109.13 instead of 280.33.

`TrainOutcome::best_policy` is documented as a trap rather than removed, so the gap stays measurable. Held-out scoring is now on by default in the example (~1.4% overhead) and the run keeps that iterate.

## Two bugs that silently invalidate measurements — both now fail closed

1. A fresh `import-urdf` anchors the `Free` base joint at z = 0, so the robot spawns a metre underground and every episode terminates on step 1. This was a manual doc-prep step before.
2. Running against a **fixed-base** document makes `base_pose` `None`, which disables *every* termination check. The run then reports a confident `400/400 survival` with a stable reward while measuring nothing at all. I lost time to this one before catching it.

## Example (`k1_stand`)

Every hyperparameter is now an env var, so a sweep is a shell line rather than a recompile. New diagnostic modes, meant to be reached for *before* tuning the trainer:

- `K1_TRACE=1` — dumps the fall step by step. Confirms the robot is failing at the task, not the physics.
- `K1_HANDPD=1` — sweeps a hand-written two-gain ankle controller *expressed as a linear policy*, so it runs the same path a trained one does. Answers "is this trainable at all?" for the cost of a minute.
- `K1_REPLAY=<seed>` — dumps one `.vcad` per frame for `vcad-render` + ffmpeg (that's how the video above was made). Document FK renders a `Free` joint at its zero pose by design, so the replay drops the world joint to promote the trunk to a root instance whose `transform` carries the live floating-base pose.
- `K1_OUT` — overrides the output path. Previously every sweep arm wrote `k1_stand_policy.json` and left you holding whichever arm finished last.

## Reviewer notes

- **Every number here is one seed per configuration.** The ~29–40× effects are far too large to be noise, but the smaller gaps (272.99 vs 280.33) are not separable. The three-seed reproduction is only for the α = 0.03 collapse, which is the load-bearing claim.
- **The MLP-vs-linear comparison is partly confounded** and I couldn't fully remove it. The ARS step norm grows with √(parameter count), so at matched α the 4,950-parameter MLP takes a ~3× larger relative step than the 1,188-parameter linear policy — confounded by exactly the variable that turned out to matter most. I ran the step-matched arm (α = 0.00245) to check: it's *worse* (307.60), so the MLP genuinely wants the larger step and the confound points the other way. Still worth knowing if you compare architectures yourself.
- **A decaying step size is probably the real fix.** Even at 0.005, ‖ΔW‖ stays flat (~0.07) regardless of policy quality, so a smaller constant only slows the wandering rather than stopping it. Left unbuilt rather than shipping something unmeasured.
- Measured incidentally: the *entire* randomized difficulty gap is the initial joint kick (mass alone 18.62, PD gain alone 18.96, latency alone 17.89 — all ≈ the 18.85 with no randomization at all — versus 10.18 for the kick alone). And ankle torque authority is **not** the constraint: stiffening the ankles makes it worse, because the explicit PD loop is already near its ω·dt stability limit.

## Verification

`cargo build`, `cargo clippy --all-targets`, `cargo fmt --all --check`, `cargo test -p vcad-sim` (9 passing, 4 new covering the MLP's init non-degeneracy, action bounds, and parameter aliasing) all clean. The full 120-iteration MLP run was re-run from scratch and reproduced 386.92 at iteration 119 exactly, confirming the pipeline is deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

