### PR TITLE
feat(sim): GPU batch path — real model, PD position targets, ARS step decay, fail-closed base termination

### DIFF
--- a/changelog/entries/2026-08-01-ars-step-decay-failclosed-base.json
+++ b/changelog/entries/2026-08-01-ars-step-decay-failclosed-base.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-08-01-ars-step-decay-failclosed-base",
+  "version": "0.9.4",
+  "date": "2026-08-01",
+  "category": "feat",
+  "title": "ARS step-size decay + fail-closed base termination",
+  "summary": "The RL trainer gains an optional cosine step-size schedule, and robot envs now refuse base-pose termination conditions that could never fire (fixed-base or mistyped base instance).",
+  "features": ["simulation", "rl", "physics"]
+}

--- a/crates/vcad-kernel-physics/src/error.rs
+++ b/crates/vcad-kernel-physics/src/error.rs
@@ -38,6 +38,23 @@ pub enum PhysicsError {
     #[error("No ground instance specified in document")]
     NoGroundInstance,
 
+    /// Termination conditions reference a base pose no instance provides.
+    ///
+    /// Fail-closed guard: with `base_height_below` / `base_tilt_above_deg`
+    /// configured but no observable base pose, those checks would silently
+    /// never fire and every episode would run to `max_steps` — a run that
+    /// reports confident survival while measuring nothing.
+    #[error(
+        "termination config sets base-pose conditions, but base instance {base_instance_id:?} \
+         has no observable pose — the checks would silently never fire. Point \
+         `EnvConfig::base_instance_id` at the floating-base instance (or import the \
+         floating-base variant of the robot)"
+    )]
+    UnobservableBase {
+        /// The configured (or defaulted) base instance id, if any.
+        base_instance_id: Option<String>,
+    },
+
     /// Evaluation error.
     #[error("Failed to evaluate geometry: {0}")]
     Evaluation(String),

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -363,6 +363,24 @@ impl RobotEnv {
             ground,
             joint_gains: std::collections::HashMap::new(),
         };
+        // Fail closed on base-pose termination conditions that can never
+        // fire. A fixed-base document (or a typo'd `base_instance_id`) makes
+        // `Observation::base_pose` None on every step, which silently
+        // disables `base_height_below` / `base_tilt_above_deg` — the episode
+        // then always runs to `max_steps` and an RL run reports confident
+        // survival while measuring nothing. That mistake has cost a real
+        // afternoon of training; it should be a constructor error, not a
+        // property of the numbers.
+        let wants_base_termination = env
+            .config
+            .termination
+            .as_ref()
+            .is_some_and(|t| t.base_height_below.is_some() || t.base_tilt_above_deg.is_some());
+        if wants_base_termination && env.observe().base_pose.is_none() {
+            return Err(PhysicsError::UnobservableBase {
+                base_instance_id: env.base_instance_id.clone(),
+            });
+        }
         // Apply episode-0 randomization to the freshly built world so the
         // very first rollout (before any explicit reset) is randomized too.
         // Unlike `reset`, this doesn't clear `pending_actions` first — it is
@@ -1711,9 +1729,8 @@ mod tests {
         )
         .unwrap();
         env.reset_with_seed(3);
-        let result = env.step_full(Action::Torque(vec![0.0, 0.0]));
         // Any draw in range is acceptable; not panicking is the assertion.
-        assert!(result.info.action_latency_substeps <= u32::MAX);
+        let _ = env.step_full(Action::Torque(vec![0.0, 0.0]));
 
         // The degenerate range Choji named is a width of 1, always exact.
         let doc2 = create_simple_robot();
@@ -1961,6 +1978,40 @@ mod tests {
         assert_eq!(
             result.info.termination_reason.as_deref(),
             Some("base_height")
+        );
+    }
+
+    /// Base-pose termination conditions that can never fire must be a
+    /// constructor error, not a silent no-op. With `base_pose` None every
+    /// step, `base_height_below`/`base_tilt_above_deg` never fire, episodes
+    /// always run to `max_steps`, and a training run reports confident
+    /// survival while measuring nothing — measured on a fixed-base K1 doc.
+    #[test]
+    fn base_termination_without_observable_base_fails_closed() {
+        let doc = create_simple_robot();
+        let cfg = EnvConfig {
+            termination: Some(TerminationConfig {
+                base_height_below: Some(0.42),
+                ..Default::default()
+            }),
+            // A typo'd (or grounded-away) base id: no pose is observable.
+            base_instance_id: Some("no_such_instance".to_string()),
+            ..Default::default()
+        };
+        let err = RobotEnv::new_with_config(
+            doc,
+            vec!["link2_inst".to_string()],
+            None,
+            None,
+            Some(GroundConfig::disabled()),
+            cfg,
+        );
+        let Err(e) = err.map(|_| ()) else {
+            panic!("expected UnobservableBase, construction succeeded");
+        };
+        assert!(
+            matches!(e, PhysicsError::UnobservableBase { .. }),
+            "got {e:?}"
         );
     }
 

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -635,6 +635,25 @@ impl PhysicsWorld {
         Ok(world)
     }
 
+    /// The underlying phyz model, as built from the document — authored
+    /// inertials, joint frames, limits, the lot.
+    ///
+    /// This is the seam batched backends build on: clone it into a
+    /// `phyz_gpu::GpuBatchSimulator` or a `phyz_env::BatchEnv` and every
+    /// environment inherits exactly the physics this world runs, instead of a
+    /// re-derived approximation. (An earlier GPU pipeline rebuilt the model
+    /// from the document with density-guessed box inertias; keeping a single
+    /// builder is the fix.)
+    pub fn model(&self) -> &Model {
+        &self.model
+    }
+
+    /// The current phyz state (q, v) — pair of [`Self::model`] for seeding a
+    /// batched backend with this world's exact initial conditions.
+    pub fn phyz_state(&self) -> &State {
+        &self.state
+    }
+
     /// Configure the ground plane. Takes effect on the next [`Self::step`].
     pub fn set_ground(&mut self, ground: GroundConfig) {
         self.ground = ground;

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -654,6 +654,23 @@ impl PhysicsWorld {
         &self.state
     }
 
+    /// A joint's (q offset, v offset, dof count) in the flat phyz state, plus
+    /// its authored effort limit (N·m or N) when it has one.
+    ///
+    /// This is the addressing a batched backend needs to servo the same
+    /// joints this world servos — a GPU PD pass indexes `q`/`v` directly and
+    /// cannot go through vcad joint ids.
+    pub fn joint_addressing(&self, joint_id: &str) -> Option<(usize, usize, usize, Option<f64>)> {
+        let q = *self.joint_q_offsets.get(joint_id)?;
+        let v = *self.joint_v_offsets.get(joint_id)?;
+        let ndof = self.joint_dof_count(joint_id);
+        let effort = self
+            .joint_kinds
+            .get(joint_id)
+            .and_then(Self::joint_effort_limit);
+        Some((q, v, ndof, effort))
+    }
+
     /// Configure the ground plane. Takes effect on the next [`Self::step`].
     pub fn set_ground(&mut self, ground: GroundConfig) {
         self.ground = ground;

--- a/crates/vcad-sim/examples/k1_gpu_bench.rs
+++ b/crates/vcad-sim/examples/k1_gpu_bench.rs
@@ -18,10 +18,11 @@
 //!    (`phyz_gpu::GpuBatchSimulator::interop`): once observations stay on
 //!    device, only the submit column matters.
 //!
-//! What this deliberately does **not** measure yet: contact (the GPU penalty
-//! pipeline needs collision geometry the model doesn't carry yet) and PD
-//! actuation (the GPU path is torque-only today). Both are listed gaps for
-//! M1; this benchmark exists so their cost is measurable when they land.
+//! What this deliberately does **not** measure yet: contact — the GPU
+//! penalty pipeline needs collision geometry the model doesn't carry yet.
+//! PD actuation landed (`BatchSimPipeline::enable_pd`) and is sanity-checked
+//! at the bottom: all 22 servoed K1 joints track a 0.3 rad command while the
+//! base free-falls.
 
 use vcad_ir::Document;
 use vcad_sim::BatchSimPipeline;
@@ -125,6 +126,54 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "falling — gravity OK"
         } else {
             "NOT falling — GPU path is broken, numbers above are meaningless"
+        }
+    );
+
+    // --- PD sanity: servos track a commanded pose while the base
+    // free-falls. ---
+    //
+    // Zero targets would prove nothing (in uniform free fall the joints stay
+    // at rest with or without servos), so command 0.3 rad on every servoed
+    // joint and require the tracking error to shrink. A sign error diverges;
+    // wrong DOF indexing leaves some joint untouched at 0.3 rad of error.
+    // (No contact geometry yet, so the robot falls forever; joint tracking
+    // is the thing under test.)
+    let mut batch = BatchSimPipeline::from_document(&doc, 4)?;
+    let gains: std::collections::HashMap<String, (f64, f64)> = batch
+        .servo_joint_ids()
+        .iter()
+        .map(|id| {
+            let g = if id.contains("Hip") || id.contains("Knee") {
+                (200.0, 5.0)
+            } else if id.contains("Ankle") {
+                (50.0, 1.0)
+            } else {
+                (40.0, 1.0)
+            };
+            (id.to_string(), g)
+        })
+        .collect();
+    batch.enable_pd(&gains, (40.0, 1.0))?;
+    let n_servo = batch.servo_joint_ids().len();
+    batch.batch_reset();
+    let cmd = 0.3f64;
+    for _ in 0..200 {
+        batch.batch_step_targets(&vec![vec![cmd; n_servo]; 4])?;
+    }
+    let obs = batch.batch_observe();
+    // Worst tracking error over the servoed slots, at their true offsets:
+    let servo_offsets = batch.servo_q_offsets();
+    let worst = servo_offsets
+        .iter()
+        .map(|&s| (obs[0].joint_positions[s] - cmd).abs())
+        .fold(0.0f64, f64::max);
+    println!(
+        "PD sanity: worst |q - {cmd}| after 200 ticks commanding {cmd} rad: \
+         {worst:.4} rad ({})",
+        if worst < 0.15 {
+            "tracking — PD pass OK"
+        } else {
+            "NOT tracking — PD pass broken"
         }
     );
     Ok(())

--- a/crates/vcad-sim/examples/k1_gpu_bench.rs
+++ b/crates/vcad-sim/examples/k1_gpu_bench.rs
@@ -1,0 +1,131 @@
+//! Bring-up + throughput benchmark for the GPU batch path on the Booster K1.
+//!
+//! ```bash
+//! cargo run --release -p vcad-sim --example k1_gpu_bench -- k1.vcad
+//! ```
+//!
+//! Measures three things, in order of what they tell you:
+//!
+//! 1. **Does the K1 construct and step on the GPU at all** — 22 revolute DOF
+//!    plus a 7-position/6-velocity Free base through the batched ABA shader.
+//!    A wrong answer here is a correctness bug, not a performance number.
+//! 2. **CPU reference throughput** — one `RobotEnv` stepped exactly the way
+//!    ARS rollouts step it (20 substeps at 1 kHz per control step). This is
+//!    the number the GPU has to beat *per environment × environment count*.
+//! 3. **GPU batch throughput** across environment counts, with and without
+//!    per-step host readback. The gap between those two columns is the
+//!    argument for the zero-copy tensor contract
+//!    (`phyz_gpu::GpuBatchSimulator::interop`): once observations stay on
+//!    device, only the submit column matters.
+//!
+//! What this deliberately does **not** measure yet: contact (the GPU penalty
+//! pipeline needs collision geometry the model doesn't carry yet) and PD
+//! actuation (the GPU path is torque-only today). Both are listed gaps for
+//! M1; this benchmark exists so their cost is measurable when they land.
+
+use vcad_ir::Document;
+use vcad_sim::BatchSimPipeline;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: k1_gpu_bench <doc.vcad>");
+    let mut doc: Document = serde_json::from_str(&std::fs::read_to_string(&path)?)?;
+
+    // Raise the floating base like k1_stand does — import anchors it at z=0.
+    for j in doc.joints.iter_mut().flat_map(|js| js.iter_mut()) {
+        if matches!(j.kind, vcad_ir::JointKind::Free) {
+            j.parent_anchor.z = 549.8;
+        }
+    }
+
+    // --- CPU reference: one env, the exact ARS rollout configuration. ---
+    let mut env = vcad_kernel_physics::RobotEnv::new(
+        doc.clone(),
+        vec![],
+        Some(1.0 / 1000.0),
+        Some(20),
+        None,
+    )?;
+    env.set_max_steps(u32::MAX);
+    let act_dim = env.action_dim();
+    let cpu_steps = 200u32;
+    let t0 = std::time::Instant::now();
+    for _ in 0..cpu_steps {
+        env.step(vcad_kernel_physics::Action::Torque(vec![0.0; act_dim]));
+    }
+    let cpu_dt = t0.elapsed();
+    let cpu_rate = cpu_steps as f64 / cpu_dt.as_secs_f64();
+    println!(
+        "CPU RobotEnv (1 env, 20 substeps/step): {cpu_rate:.0} env-steps/s \
+         ({:.0} substeps/s)",
+        cpu_rate * 20.0
+    );
+
+    // --- GPU batch: same document, growing environment counts. ---
+    // The GPU pipeline steps a single physics tick per call (no substep
+    // batching yet), so its numbers are *substeps*/s — compare against the
+    // CPU substep column, and divide by 20 for control-step terms.
+    println!(
+        "\n{:>7}  {:>16}  {:>16}  {:>10}",
+        "envs", "submit substeps/s", "readback substeps/s", "vs CPU"
+    );
+    for n_envs in [64usize, 256, 1024, 4096] {
+        let mut batch = match BatchSimPipeline::from_document(&doc, n_envs) {
+            Ok(b) => b,
+            Err(e) => {
+                println!("{n_envs:>7}  construction failed: {e}");
+                continue;
+            }
+        };
+        let nv = batch.action_dim();
+        let actions = vec![0.0f64; n_envs * nv];
+        let iters = 200usize;
+
+        batch.batch_reset();
+        // Warmup: shader compilation and first-submit costs land here.
+        for _ in 0..10 {
+            batch.batch_step_submit(&actions)?;
+        }
+        let _ = batch.batch_observe(); // sync
+
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters {
+            batch.batch_step_submit(&actions)?;
+        }
+        let _ = batch.batch_observe(); // block until the queue drains
+        let submit_rate = (n_envs * iters) as f64 / t0.elapsed().as_secs_f64();
+
+        batch.batch_reset();
+        let t0 = std::time::Instant::now();
+        for _ in 0..iters {
+            let _ = batch.batch_step(&actions)?;
+        }
+        let readback_rate = (n_envs * iters) as f64 / t0.elapsed().as_secs_f64();
+
+        println!(
+            "{n_envs:>7}  {submit_rate:>16.0}  {readback_rate:>16.0}  {:>9.1}x",
+            submit_rate / (cpu_rate * 20.0)
+        );
+    }
+
+    // --- Sanity: gravity acts. A zero-torque K1 must be falling. ---
+    let mut batch = BatchSimPipeline::from_document(&doc, 4)?;
+    batch.batch_reset();
+    let z0 = batch.batch_observe()[0].joint_positions[2];
+    let nv = batch.action_dim();
+    for _ in 0..100 {
+        batch.batch_step_submit(&vec![0.0; 4 * nv])?;
+    }
+    let z1 = batch.batch_observe()[0].joint_positions[2];
+    println!(
+        "\nsanity: base z {z0:.3} -> {z1:.3} after 100 ticks of free fall \
+         ({})",
+        if z1 < z0 - 1e-3 {
+            "falling — gravity OK"
+        } else {
+            "NOT falling — GPU path is broken, numbers above are meaningless"
+        }
+    );
+    Ok(())
+}

--- a/crates/vcad-sim/examples/k1_stand.rs
+++ b/crates/vcad-sim/examples/k1_stand.rs
@@ -23,6 +23,7 @@
 //!
 //! Every knob below is an environment variable so a sweep is a shell line
 //! rather than a recompile: `K1_ROLLOUTS`, `K1_DIRS`, `K1_TOPK`, `K1_ALPHA`,
+//! `K1_ALPHA_FINAL` (cosine step-size decay target; 0 = constant α),
 //! `K1_NU`, `K1_SEED`, `K1_POLICY` (`linear`|`mlp`), `K1_HIDDEN`,
 //! `K1_CURRICULUM_WARMUP`, `K1_ACTION_SCALE`, `K1_SPAWN_Z_MM`, the
 //! randomization channels (`K1_POS_PERTURB`, `K1_VEL_PERTURB`, `K1_MASS_PCT`,
@@ -392,6 +393,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         n_directions: env_usize("K1_DIRS", 12),
         top_k: env_usize("K1_TOPK", 6),
         step_size: env_f64("K1_ALPHA", 0.005),
+        // Cosine decay target; 0 disables the schedule (constant α). ARS
+        // never anneals on its own — see `ArsConfig::step_size_final`.
+        step_size_final: match env_f64("K1_ALPHA_FINAL", 0.0) {
+            f if f > 0.0 => Some(f),
+            _ => None,
+        },
         noise_std: env_f64("K1_NU", 0.05),
         iterations,
         // Draws averaged per evaluation. Three is not enough on this env —

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -16,6 +16,11 @@ pub struct BatchSimPipeline {
     n_envs: usize,
     nv: usize,
     initial_state: State,
+    /// Single-DOF joints in document order: (joint id, q offset, v offset,
+    /// authored effort limit). The PD action interface indexes against this.
+    servo_joints: Vec<(String, usize, usize, Option<f64>)>,
+    /// Number of servoed DOFs once [`Self::enable_pd`] has run.
+    pd_dofs: usize,
 }
 
 impl BatchSimPipeline {
@@ -35,6 +40,19 @@ impl BatchSimPipeline {
         let initial_state = world.phyz_state().clone();
         let nv = model.nv;
 
+        // Single-DOF joints in document order — the servo-able set, matching
+        // the CPU gym env's actuated_joint_ids minus multi-DOF joints (which
+        // have no scalar position target; the K1's floating base is the
+        // canonical example).
+        let servo_joints = world
+            .joint_ids()
+            .into_iter()
+            .filter_map(|id| {
+                let (q, v, ndof, effort) = world.joint_addressing(&id)?;
+                (ndof == 1).then_some((id, q, v, effort))
+            })
+            .collect();
+
         let gpu_sim = GpuBatchSimulator::new(model, n_envs).map_err(SimError::Gpu)?;
 
         Ok(Self {
@@ -42,7 +60,91 @@ impl BatchSimPipeline {
             n_envs,
             nv,
             initial_state,
+            servo_joints,
+            pd_dofs: 0,
         })
+    }
+
+    /// Enable GPU PD position servos on every single-DOF joint.
+    ///
+    /// `gains` supplies per-joint `(kp, kd)` by joint id; joints not in the
+    /// map fall back to `default_gains`. The torque clamp is the joint's
+    /// authored effort limit when it has one, else the CPU servo's `kp·π`
+    /// fallback — the same law `RobotEnv` runs, minus its inertia-scaled
+    /// defaults (a batched caller supplies real gains; guessing them
+    /// per-joint on the GPU would hide the difference from the CPU env).
+    ///
+    /// After this, [`Self::set_position_targets`] is the action interface.
+    pub fn enable_pd(
+        &mut self,
+        gains: &std::collections::HashMap<String, (f64, f64)>,
+        default_gains: (f64, f64),
+    ) -> Result<(), SimError> {
+        let dofs: Vec<phyz_gpu::PdDof> = self
+            .servo_joints
+            .iter()
+            .map(|(id, q, v, effort)| {
+                let (kp, kd) = gains.get(id).copied().unwrap_or(default_gains);
+                phyz_gpu::PdDof {
+                    q_index: *q,
+                    v_index: *v,
+                    kp,
+                    kd,
+                    max_force: effort.unwrap_or((kp * std::f64::consts::PI).max(1e-12)),
+                }
+            })
+            .collect();
+        self.gpu_sim
+            .enable_pd_control(&dofs)
+            .map_err(SimError::Gpu)?;
+        self.pd_dofs = dofs.len();
+        Ok(())
+    }
+
+    /// The servoed joints' q offsets in the flat state, in
+    /// [`Self::servo_joint_ids`] order — for reading joint angles out of
+    /// [`Self::batch_observe`] without re-deriving the model's layout.
+    pub fn servo_q_offsets(&self) -> Vec<usize> {
+        self.servo_joints.iter().map(|(_, q, ..)| *q).collect()
+    }
+
+    /// Ids of the servoed joints, in the order
+    /// [`Self::set_position_targets`] expects its per-env target vectors.
+    pub fn servo_joint_ids(&self) -> Vec<&str> {
+        self.servo_joints
+            .iter()
+            .map(|(id, ..)| id.as_str())
+            .collect()
+    }
+
+    /// Upload per-environment position targets (radians / meters) for the
+    /// PD servos and step all environments, without host readback.
+    ///
+    /// The RL rollout hot path: PD torque computation happens on the GPU, so
+    /// nothing crosses the bus but the targets themselves.
+    pub fn batch_step_targets(&mut self, targets: &[Vec<f64>]) -> Result<(), SimError> {
+        if self.pd_dofs == 0 {
+            return Err(SimError::Gpu(
+                "PD control not enabled — call enable_pd first".into(),
+            ));
+        }
+        if targets.len() != self.n_envs {
+            return Err(SimError::ActionMismatch {
+                expected: self.n_envs,
+                got: targets.len(),
+            });
+        }
+        if let Some(bad) = targets.iter().find(|t| t.len() != self.pd_dofs) {
+            return Err(SimError::ActionMismatch {
+                expected: self.pd_dofs,
+                got: bad.len(),
+            });
+        }
+        self.gpu_sim
+            .set_position_targets(targets)
+            .map_err(SimError::Gpu)?;
+        self.gpu_sim.step();
+        Ok(())
     }
 
     /// Step all environments with per-environment actions.

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -1,7 +1,7 @@
 //! GPU batch simulation pipeline.
 
 use phyz_gpu::GpuBatchSimulator;
-use phyz_model::{Model, State};
+use phyz_model::State;
 use vcad_ir::Document;
 
 use crate::error::SimError;
@@ -24,8 +24,15 @@ impl BatchSimPipeline {
     /// Builds the phyz Model from the assembly, then initializes `n_envs`
     /// parallel GPU environments.
     pub fn from_document(doc: &Document, n_envs: usize) -> Result<Self, SimError> {
-        let model = Self::build_model(doc)?;
-        let initial_state = model.default_state();
+        // One model builder for the whole stack: `PhysicsWorld::from_document`
+        // is what the CPU gym env runs, with authored inertials, collider
+        // masses, joint frames and limits. The GPU batch inherits it verbatim
+        // — an earlier version of this pipeline re-derived the model here with
+        // density-guessed box inertias, which silently trained against the
+        // wrong robot.
+        let world = vcad_kernel_physics::PhysicsWorld::from_document(doc)?;
+        let model = world.model().clone();
+        let initial_state = world.phyz_state().clone();
         let nv = model.nv;
 
         let gpu_sim = GpuBatchSimulator::new(model, n_envs).map_err(SimError::Gpu)?;
@@ -71,6 +78,28 @@ impl BatchSimPipeline {
         }
 
         Ok(results)
+    }
+
+    /// Step all environments without reading state back to the host.
+    ///
+    /// The throughput path: `batch_step` pays a GPU→CPU readback every call,
+    /// which dominates once the physics itself is cheap. A rollout loop that
+    /// only needs observations every k-th control step (or never — see
+    /// `phyz_gpu::GpuBatchSimulator::interop` for the zero-copy tensor
+    /// contract) submits with this and reads back explicitly via
+    /// [`Self::batch_observe`] when it wants eyes.
+    pub fn batch_step_submit(&mut self, actions: &[f64]) -> Result<(), SimError> {
+        let expected = self.n_envs * self.nv;
+        if actions.len() != expected {
+            return Err(SimError::ActionMismatch {
+                expected,
+                got: actions.len(),
+            });
+        }
+        let ctrls: Vec<Vec<f64>> = actions.chunks(self.nv).map(|c| c.to_vec()).collect();
+        self.gpu_sim.set_controls(&ctrls);
+        self.gpu_sim.step();
+        Ok(())
     }
 
     /// Observe all environments without stepping.
@@ -121,238 +150,4 @@ impl BatchSimPipeline {
     pub fn action_dim(&self) -> usize {
         self.nv
     }
-
-    /// Build a phyz Model from a vcad Document.
-    fn build_model(doc: &Document) -> Result<Model, SimError> {
-        use phyz_math::{Mat3, SpatialInertia, SpatialTransform, Vec3};
-        use phyz_model::ModelBuilder;
-        use std::collections::{HashMap, HashSet};
-
-        let instances = doc.instances.as_ref().ok_or(SimError::NoAssembly)?;
-        let joints = doc.joints.as_ref().ok_or(SimError::NoAssembly)?;
-        let part_defs = doc.part_defs.as_ref().ok_or(SimError::NoAssembly)?;
-        let ground_id = doc
-            .ground_instance_id
-            .as_ref()
-            .ok_or(SimError::NoAssembly)?;
-
-        let mut builder = ModelBuilder::new()
-            .gravity(Vec3::new(0.0, 0.0, -9.81))
-            .dt(1.0 / 240.0);
-
-        let mut instance_to_body: HashMap<String, usize> = HashMap::new();
-        // Per-body part→body rotation `R_b` (`p_body = R_b * p_part`). phyz
-        // body frames coincide with the joint frame, so a child hung off a
-        // non-Z revolute has a rotated body frame — and its own children's
-        // `parent_to_joint` is measured from that rotated frame. Identity for
-        // ground and free bodies.
-        let mut body_rotations: Vec<Mat3> = Vec::new();
-        let mut body_count = 0usize;
-
-        // Compute box inertia from a primitive node
-        let compute_inertia = |node_id: u64| -> (f64, SpatialInertia) {
-            let node = doc.nodes.get(&node_id);
-            let (dx, dy, dz) = match node.map(|n| &n.op) {
-                Some(vcad_ir::CsgOp::Cube { size }) => {
-                    (size.x / 1000.0, size.y / 1000.0, size.z / 1000.0)
-                }
-                Some(vcad_ir::CsgOp::Cylinder { radius, height, .. }) => {
-                    let d = 2.0 * radius / 1000.0;
-                    (d, d, height / 1000.0)
-                }
-                Some(vcad_ir::CsgOp::Sphere { radius, .. }) => {
-                    let d = 2.0 * radius / 1000.0;
-                    (d, d, d)
-                }
-                _ => (0.01, 0.01, 0.01),
-            };
-            let density = 1000.0; // kg/m³
-            let mass = density * dx * dy * dz;
-            let ixx = mass / 12.0 * (dy * dy + dz * dz);
-            let iyy = mass / 12.0 * (dx * dx + dz * dz);
-            let izz = mass / 12.0 * (dx * dx + dy * dy);
-            let inertia_mat = Mat3::new(ixx, 0.0, 0.0, 0.0, iyy, 0.0, 0.0, 0.0, izz);
-            (mass, SpatialInertia::new(mass, Vec3::zeros(), inertia_mat))
-        };
-
-        let instance_transform = |inst: &vcad_ir::Instance| -> SpatialTransform {
-            inst.transform
-                .as_ref()
-                .map(|t| {
-                    let translation = Vec3::new(
-                        t.translation.x / 1000.0,
-                        t.translation.y / 1000.0,
-                        t.translation.z / 1000.0,
-                    );
-                    SpatialTransform::new(Mat3::identity(), translation)
-                })
-                .unwrap_or(SpatialTransform::identity())
-        };
-
-        // 1. Ground body (fixed)
-        let ground_inst = instances
-            .iter()
-            .find(|i| i.id == *ground_id)
-            .ok_or(SimError::NoAssembly)?;
-        {
-            let part = part_defs
-                .get(&ground_inst.part_def_id)
-                .ok_or(SimError::NoAssembly)?;
-            let (_, inertia) = compute_inertia(part.root);
-            let xform = instance_transform(ground_inst);
-            builder = builder.add_fixed_body(&ground_inst.id, -1, xform, inertia);
-            instance_to_body.insert(ground_inst.id.clone(), body_count);
-            body_rotations.push(Mat3::identity());
-            body_count += 1;
-        }
-
-        // 2. BFS from ground through joints
-        let mut queue = vec![ground_id.clone()];
-        let mut visited: HashSet<String> = HashSet::new();
-        visited.insert(ground_id.clone());
-
-        while let Some(parent_id) = queue.pop() {
-            for joint in joints {
-                let joint_parent = joint.parent_instance_id.as_deref().unwrap_or(ground_id);
-                if joint_parent != parent_id || visited.contains(&joint.child_instance_id) {
-                    continue;
-                }
-
-                let child_inst = instances
-                    .iter()
-                    .find(|i| i.id == joint.child_instance_id)
-                    .ok_or(SimError::NoAssembly)?;
-
-                let parent_body_idx = *instance_to_body
-                    .get(&parent_id)
-                    .ok_or(SimError::NoAssembly)?;
-
-                let part = part_defs
-                    .get(&child_inst.part_def_id)
-                    .ok_or(SimError::NoAssembly)?;
-                let (_, mut inertia) = compute_inertia(part.root);
-
-                // Body frame = joint frame, so the part-axis-aligned box
-                // inertia has to be rotated into it.
-                let r_part_to_body = joint_frame_rotation(&joint.kind).transpose();
-                inertia.inertia = r_part_to_body
-                    .mul_mat(&inertia.inertia)
-                    .mul_mat(&r_part_to_body.transpose());
-
-                let phyz_joint = build_phyz_model_joint(joint, &body_rotations[parent_body_idx])?;
-
-                builder =
-                    builder.add_body(&child_inst.id, parent_body_idx as i32, phyz_joint, inertia);
-
-                instance_to_body.insert(child_inst.id.clone(), body_count);
-                body_rotations.push(r_part_to_body);
-                body_count += 1;
-                visited.insert(child_inst.id.clone());
-                queue.push(child_inst.id.clone());
-            }
-        }
-
-        Ok(builder.build())
-    }
-}
-
-/// Convert a vcad `Joint` into a `phyz_model::Joint`.
-///
-/// Mirrors `vcad_kernel_physics::joints::vcad_joint_to_phyz`, but targets the
-/// `phyz_model` crate's `Joint` type (required by `phyz-gpu`'s `ModelBuilder`),
-/// which is a separate Rust type from `phyz::model::Joint`.
-///
-/// `r_parent` is the parent body's part→body rotation: `parent_to_joint` is
-/// measured from the parent *body* frame, which is itself rotated whenever
-/// the parent hangs off a non-Z joint axis. Composing it out here is what
-/// keeps the axis-alignment rotation from compounding down a serial chain.
-fn build_phyz_model_joint(
-    joint: &vcad_ir::Joint,
-    r_parent: &phyz_math::Mat3,
-) -> Result<phyz_model::Joint, SimError> {
-    use phyz_math::{SpatialTransform, Vec3};
-    use phyz_model::Joint as PhyzJoint;
-    use vcad_ir::JointKind;
-
-    // parent_anchor is in the parent *part*'s mm coordinates; phyz wants the
-    // joint origin in the parent *body* frame, in meters.
-    let anchor = r_parent.mul_vec(Vec3::new(
-        joint.parent_anchor.x / 1000.0,
-        joint.parent_anchor.y / 1000.0,
-        joint.parent_anchor.z / 1000.0,
-    ));
-
-    // Plücker parent→joint coordinate map: the transpose of the joint frame's
-    // axes expressed in the parent body frame.
-    let rot = r_parent
-        .mul_mat(&joint_frame_rotation(&joint.kind))
-        .transpose();
-    let xform = SpatialTransform::new(rot, anchor);
-
-    match &joint.kind {
-        JointKind::Fixed => Ok(PhyzJoint::fixed(xform)),
-        JointKind::Revolute { limits, .. } => {
-            let mut phyz_joint = PhyzJoint::revolute(xform);
-
-            if let Some((lower, upper)) = limits {
-                phyz_joint.limits = Some([lower.to_radians(), upper.to_radians()]);
-            }
-
-            Ok(phyz_joint)
-        }
-        JointKind::Slider { axis, limits, .. } => {
-            // Slider joint frames are part-aligned, so the axis carries over
-            // unchanged.
-            let axis_vec = Vec3::new(axis.x, axis.y, axis.z).normalize();
-            let mut phyz_joint = PhyzJoint::prismatic(xform, axis_vec);
-
-            if let Some((lower, upper)) = limits {
-                phyz_joint.limits = Some([*lower / 1000.0, *upper / 1000.0]);
-            }
-
-            Ok(phyz_joint)
-        }
-        JointKind::Cylindrical { .. } => Ok(PhyzJoint::revolute(xform)),
-        JointKind::Ball => Ok(PhyzJoint::spherical(xform)),
-        JointKind::Free => Ok(PhyzJoint::free(xform)),
-    }
-}
-
-/// Rotation whose columns are the joint frame's axes in the part frame:
-/// phyz revolute joints spin about the joint frame's Z, so that frame is
-/// oriented to put Z on the declared axis.
-fn joint_frame_rotation(kind: &vcad_ir::JointKind) -> phyz_math::Mat3 {
-    use vcad_ir::JointKind;
-    match kind {
-        JointKind::Revolute { axis, .. } | JointKind::Cylindrical { axis } => {
-            rotation_aligning_z_to(phyz_math::Vec3::new(axis.x, axis.y, axis.z).normalize())
-        }
-        JointKind::Slider { .. } | JointKind::Fixed | JointKind::Ball | JointKind::Free => {
-            phyz_math::Mat3::identity()
-        }
-    }
-}
-
-/// Compute a rotation matrix that maps the Z unit vector to the given axis.
-fn rotation_aligning_z_to(target: phyz_math::Vec3) -> phyz_math::Mat3 {
-    use phyz_math::{Mat3, Vec3};
-
-    let z = Vec3::new(0.0, 0.0, 1.0);
-    let dot = z.dot(target);
-
-    if dot > 0.9999 {
-        return Mat3::identity();
-    }
-    if dot < -0.9999 {
-        // 180° rotation about X
-        return Mat3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0);
-    }
-
-    let cross = z.cross(target);
-    let s = cross.norm();
-    let c = dot;
-    let vx = phyz_math::skew(&cross.normalize());
-
-    // Rodrigues: R = I + sin(θ) * [v]× + (1 - cos(θ)) * [v]×²
-    Mat3::identity() + vx * s + vx * vx * (1.0 - c)
 }

--- a/crates/vcad-sim/src/rl.rs
+++ b/crates/vcad-sim/src/rl.rs
@@ -404,6 +404,20 @@ pub struct ArsConfig {
     /// apart, reach for this before anything else, and log
     /// [`IterationLog::update_norm`] to see the step that is doing it.
     pub step_size: f64,
+    /// Final step size at the end of training, reached by cosine decay from
+    /// [`Self::step_size`]. `None` keeps the step constant.
+    ///
+    /// This exists because shrinking the *constant* only slows the wandering
+    /// described on `step_size` — it never stops it. The ARS update is
+    /// scale-free, so at any constant α the trainer keeps taking full-size
+    /// steps after it has found a solution; a schedule is the only way to
+    /// actually anneal. Decay follows training progress
+    /// (`α(t) = final + (initial − final)·½(1 + cos(π·t))`), so early
+    /// iterations explore at full step and late ones consolidate. The
+    /// effective value each iteration is logged as
+    /// [`IterationLog::step_size`].
+    #[serde(default)]
+    pub step_size_final: Option<f64>,
     /// Exploration noise ν.
     pub noise_std: f64,
     /// Training iterations.
@@ -433,6 +447,7 @@ impl Default for ArsConfig {
             // cannot stay in it is worth less than a slower one that can.
             // See the measurements on `step_size`.
             step_size: 0.005,
+            step_size_final: None,
             noise_std: 0.03,
             iterations: 200,
             // One rollout per evaluation measures the randomization draw as
@@ -440,6 +455,21 @@ impl Default for ArsConfig {
             rollouts_per_eval: 3,
             seed: 0,
         }
+    }
+}
+
+/// Effective ARS step size at training `progress` in `[0, 1]`.
+///
+/// Cosine decay from `step_size` to `step_size_final` when the latter is
+/// set; constant otherwise. Public so a caller reporting or sweeping the
+/// schedule computes exactly what the trainer applies.
+pub fn step_size_at(cfg: &ArsConfig, progress: f64) -> f64 {
+    match cfg.step_size_final {
+        Some(f) => {
+            let t = progress.clamp(0.0, 1.0);
+            f + (cfg.step_size - f) * 0.5 * (1.0 + (std::f64::consts::PI * t).cos())
+        }
+        None => cfg.step_size,
     }
 }
 
@@ -478,6 +508,11 @@ pub struct IterationLog {
     pub sigma: f64,
     /// Norm of the parameter update actually applied this iteration.
     pub update_norm: f64,
+    /// Effective step size α this iteration, after any decay schedule
+    /// ([`ArsConfig::step_size_final`]). Equals [`ArsConfig::step_size`] when
+    /// the schedule is off.
+    #[serde(default)]
+    pub step_size: f64,
 }
 
 /// Build the policy feature vector from an env observation.
@@ -785,9 +820,10 @@ where
             .sqrt()
             .max(1e-6);
 
+        let alpha = step_size_at(cfg, progress);
         let before: Vec<f64> = policy.params().to_vec();
         for (plus, minus, i) in top {
-            let coeff = cfg.step_size * (plus - minus) / (cfg.top_k as f64 * sigma);
+            let coeff = alpha * (plus - minus) / (cfg.top_k as f64 * sigma);
             for (w, dw) in policy.params_mut().iter_mut().zip(deltas[*i].iter()) {
                 *w += coeff * dw;
             }
@@ -842,6 +878,7 @@ where
             eval_steps: eval.steps,
             sigma,
             update_norm,
+            step_size: alpha,
         };
         on_iteration(&entry, &policy);
         log.push(entry);
@@ -864,6 +901,31 @@ mod tests {
             default_pose_deg: vec![0.0; act_dim],
             action_scale_deg: 8.0,
         }
+    }
+
+    /// The decay schedule must hit its endpoints exactly, shrink
+    /// monotonically between them, and be the identity when disabled — a
+    /// schedule that undershoots its endpoints silently changes what
+    /// "α = 0.005" means in every result table.
+    #[test]
+    fn step_size_schedule_endpoints_and_monotonicity() {
+        let mut cfg = ArsConfig::default();
+        assert_eq!(step_size_at(&cfg, 0.0), cfg.step_size);
+        assert_eq!(step_size_at(&cfg, 0.5), cfg.step_size);
+        assert_eq!(step_size_at(&cfg, 1.0), cfg.step_size);
+
+        cfg.step_size = 0.005;
+        cfg.step_size_final = Some(0.0005);
+        assert!((step_size_at(&cfg, 0.0) - 0.005).abs() < 1e-12);
+        assert!((step_size_at(&cfg, 1.0) - 0.0005).abs() < 1e-12);
+        let mut prev = f64::INFINITY;
+        for i in 0..=20 {
+            let a = step_size_at(&cfg, i as f64 / 20.0);
+            assert!(a <= prev + 1e-12, "schedule not monotone at {i}");
+            prev = a;
+        }
+        // Out-of-range progress clamps instead of overshooting.
+        assert!((step_size_at(&cfg, 1.5) - 0.0005).abs() < 1e-12);
     }
 
     /// Both architectures start at the default pose, so a run that swaps one


### PR DESCRIPTION
Follow-ups to #770 (the K1 standing solve), in two groups: trainer/env hardening, and the GPU batch path bring-up.

## Trainer + env hardening

**`ArsConfig::step_size_final`** — optional cosine step-size decay. The ARS update is scale-free, so at any *constant* alpha the trainer keeps taking full-size steps after it has found a solution; shrinking the constant only slows the wandering. Ships **opt-in, default `None`**, because the measurement says it doesn't help here:

| arm | seed 7 | seed 23 |
|---|---|---|
| constant alpha = 0.005 | 395.01, 10/10 | 395.12, 10/10 |
| cosine decay to 0.0005 | 377.51, 10/10 | 394.45, 10/10 |

Decay never wins and hurts seed 7 — annealing bites just as the curriculum reaches full randomization and the policy still needs step authority. Held-out-best selection already neutralizes the wandering, and the task is saturated (~395 against a ~400 ceiling), so there is no headroom for a schedule to buy. The knob stays because it will matter on a task with a real optimum to settle into.

That matrix also closes the open question from #770: **a second training seed reproduces 10/10** (395.12 vs the original 386.92), so the solved-task claim is not a lucky draw.

**Fail-closed base termination.** `RobotEnv::new_with_config` now errors (`PhysicsError::UnobservableBase`) when `base_height_below` / `base_tilt_above_deg` are configured but no base pose is observable. A fixed-base document or a typo'd `base_instance_id` previously disabled *every* termination check silently, so a run reported a confident 400/400 survival while measuring nothing at all. The `k1_stand` example had this guard privately; every `RobotEnv` caller now gets it.

## GPU batch path

**The batch pipeline now runs the real physics model.** `BatchSimPipeline::from_document` builds through `PhysicsWorld::from_document` and clones its model — authored inertials, collider masses, joint frames, limits. It previously re-derived the model with density-1000 box inertias, i.e. it trained against a different robot than the CPU env simulated. Same family as the placeholder-cube bug.

**PD position targets on device.** `enable_pd` maps every single-DOF vcad joint onto the new `phyz-gpu` servo pass (ecto/phyz#35) with per-joint gains and the authored effort limit as the torque clamp; `batch_step_targets` is the rollout hot path, so only targets cross the bus. `PhysicsWorld::joint_addressing` exposes each joint's `(q offset, v offset, ndof, effort limit)` so batched backends index the flat state without re-deriving the layout.

**Measured on the K1** (M2 Mac, Metal, 22 DOF + floating base):

| envs | submit substeps/s | readback substeps/s | vs CPU |
|---|---|---|---|
| 64 | 38.5k | 24.8k | 18x |
| 256 | 153.5k | 97.6k | 72x |
| 1024 | 614k | 358k | 289x |
| 4096 | **2.17M** | 1.07M | 1022x |

CPU reference is one `RobotEnv` at the exact ARS rollout configuration: 2.1k substeps/s. The 4096-env submit column is ~85x the whole 12-core machine's rayon-parallel throughput. The submit/readback gap is the argument for the zero-copy tensor contract (`phyz_gpu::GpuBatchSimulator::interop`).

Sanity checks in `k1_gpu_bench`: a zero-torque K1 falls (gravity + floating base through the batched ABA shader), and all 22 servoed joints track a 0.3 rad command to <1e-4 while the base free-falls. The PD check deliberately commands a *nonzero* target — a zero-target version passes vacuously, since uniform free fall holds the joints at rest with or without servos.

## Known gaps (next milestone)

- No collision geometry on the model, so the GPU penalty-contact pipeline has nothing to touch. This is the last blocker to actually training on the GPU path.
- f32 drift over full episodes is unquantified; `phyz-env::BatchEnv` is the f64 CPU oracle to assert against.
- One submit per substep — folding the substep loop into the shader multiplies the submit column again.

Depends on ecto/phyz#35 for the PD pass.

Generated with [Claude Code](https://claude.com/claude-code)