### PR TITLE
fix(booleans): don't judge chain crossing on clamped extrapolation

### DIFF
--- a/crates/vcad-kernel-booleans/src/cyl_band.rs
+++ b/crates/vcad-kernel-booleans/src/cyl_band.rs
@@ -703,9 +703,27 @@ fn try_parse_two_chain(uvs: &[(f64, f64)], policy: TiePolicy) -> Option<CylBand>
     let full_wrap = (span - 2.0 * PI).abs() < 1e-6;
 
     // Chains must not cross (a band has a well-defined lower/upper chain).
-    // Compare on the union of both chains' sample angles.
+    // Compare on the union of both chains' sample angles — but ONLY where
+    // both are actually defined. The chains may legitimately differ by up to
+    // the end slack the range check above allows, and `chain_interp` CLAMPS
+    // outside a chain's range, so probing past the shorter chain's end
+    // compares a real value against a flat extrapolation. That manufactures
+    // a crossing out of nothing: a tangent blade wedge on a cylinder wall
+    // whose chains ended 0.31° apart read as "chains cross", the face came
+    // back unsplit, and the boolean over-trimmed. The end-slack close below
+    // is what reconciles the ends; it just runs after this test, because it
+    // needs the lo/hi answer this test produces.
+    let common_lo = chain_a[0].0.max(chain_b[0].0);
+    let common_hi = chain_a[chain_a.len() - 1]
+        .0
+        .min(chain_b[chain_b.len() - 1].0);
+    if common_hi < common_lo - U_EPS {
+        band_dbg!("parse_band: chains share no u-interval");
+        return None;
+    }
     let mut probe_us: Vec<f64> = chain_a.iter().map(|p| p.0).collect();
     probe_us.extend(chain_b.iter().map(|p| p.0));
+    probe_us.retain(|&u| u >= common_lo - U_EPS && u <= common_hi + U_EPS);
     probe_us.sort_by(|x, y| x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal));
     probe_us.dedup_by(|x, y| (*x - *y).abs() < U_EPS);
     let a_below = probe_us


### PR DESCRIPTION
## What

`parse_band` rejects a loop whose two chains cross, since a band needs a well-defined lower and upper chain. It probed that at the union of both chains' angles — **including angles past the shorter chain's end**, where `chain_interp` clamps to that chain's last value. Comparing a real value against a flat extrapolation manufactures a crossing out of nothing.

The chains are *allowed* to differ at their ends: the range check just above tolerates roughly one column of slack, and the end-slack close just below reconciles it (it runs after this test because it needs the lo/hi answer this test produces). So the very slack the parser is built to accept was being read as a crossing.

On the doc10 catalogue case, a tangent blade wedge on the r45 wall was refused:

```
chain_a  160.435° -> 161.483°
chain_b  160.435° -> 161.172°
probe at 161.483°: a = 110.852 real, b = 110.665 CLAMPED  -> "chains cross"
```

The face then came back unsplit from `split_cylindrical_face_by_sampled`, logging *"returning face unsplit. Downstream boolean result may be incorrect for this face."* That was the last such bailout in the case; there are now none (1 → 0).

Fix: probe only where both chains are defined.

## Testing

- `vcad-kernel-booleans` + `vcad-kernel-tessellate`: green, 126 tests.
- Torture corpus: 643 pass, **no regressions** vs baseline.
- `torr_boolean_catalogue`: unchanged at 24 passed / 2 failed / 6 ignored.
- `clippy -D warnings` clean.

**Scope honesty:** this removes a silently-wrong path but does **not** move either failing catalogue case — the refused wedge is only ~0.6 mm² of wall. CI stays red on doc10 and c2.

## What I learned about doc10 (not fixed here)

I went in to fix doc10 as a "tangent trim" problem. **It isn't one** — that characterization, from my earlier PR, was wrong:

- A **single** blade clips correctly: err −0.004 mm³.
- Each of the 23 instances clipped **individually** at its own angle: sum err −0.09 mm³, not one instance off by >0.05.
- All 23 clipped **together**: err −19.2 mm³.

So no angle is bad and tangency isn't the issue — material vanishes only when the instances are differenced as one compound. The error is erratic in instance count, which rules out accumulation:

| n | 17 | 18 | 19 | 20 | 21 | 22 | 23 | 24 | 25 | 26 |
|---|---|---|---|---|---|---|---|---|---|---|
| err | −0.05 | **−33.2** | −0.06 | −0.05 | −4.5 | −7.6 | **−19.2** | −0.07 | **−213** | −15.6 |

Bisected to `split_edges_at_interior_vertices_boundary` (the coarse seam-snap round, radius 1.5e-3) in `repair.rs`: `VCAD_NO_SNAP` makes doc10 pass. It attracts splits from vertices belonging to a *different* feature that merely passes within the radius, and the collapse/weld that follow then fuse them.

**Not fixable by simply removing it** — that costs 8 torture regressions (incl. the whole `sliv-cyl-graze-*` family) and 3 `zz_seam_probe` failures. **Not fixable by a collinearity guard** either: requiring the candidate vertex's unpaired edges to run along the edge being split changes nothing at cos 8°, with `any()` or `all()` — the harmful attractions are between nearly-parallel edges too. A correct fix needs topological provenance (is this vertex from the same crack?) rather than a geometric proximity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)