### PR TITLE
feat(sim): M3.0–M3.2 — pin phyz, measure CPU/GPU parity, and find where the batch path stops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ name = "mecheval-grader"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "phyz 0.3.1",
+ "phyz",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4016,34 +4016,14 @@ dependencies = [
 [[package]]
 name = "phyz"
 version = "0.3.1"
-dependencies = [
- "phyz-collision 0.3.1",
- "phyz-contact 0.3.1",
- "phyz-diff 0.3.1",
- "phyz-math 0.3.1",
- "phyz-model 0.3.1",
- "phyz-rigid 0.3.1",
-]
-
-[[package]]
-name = "phyz"
-version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-contact 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-diff 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
-]
-
-[[package]]
-name = "phyz-collision"
-version = "0.3.1"
-dependencies = [
- "phyz-math 0.3.1",
- "phyz-model 0.3.1",
+ "phyz-collision",
+ "phyz-contact",
+ "phyz-diff",
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
 ]
 
 [[package]]
@@ -4051,18 +4031,8 @@ name = "phyz-collision"
 version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
-]
-
-[[package]]
-name = "phyz-contact"
-version = "0.3.1"
-dependencies = [
- "phyz-collision 0.3.1",
- "phyz-math 0.3.1",
- "phyz-model 0.3.1",
- "phyz-rigid 0.3.1",
+ "phyz-math",
+ "phyz-model",
 ]
 
 [[package]]
@@ -4070,22 +4040,10 @@ name = "phyz-contact"
 version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
-]
-
-[[package]]
-name = "phyz-diff"
-version = "0.3.1"
-dependencies = [
- "phyz-math 0.3.1",
- "phyz-model 0.3.1",
- "phyz-rigid 0.3.1",
- "tang",
- "tang-expr",
- "tang-la",
+ "phyz-collision",
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
 ]
 
 [[package]]
@@ -4093,11 +4051,11 @@ name = "phyz-diff"
 version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-contact 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-collision",
+ "phyz-contact",
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
  "tang",
  "tang-expr",
  "tang-la",
@@ -4110,19 +4068,11 @@ source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b04
 dependencies = [
  "bytemuck",
  "futures-intrusive",
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math",
+ "phyz-model",
+ "phyz-rigid",
  "pollster",
  "wgpu",
-]
-
-[[package]]
-name = "phyz-math"
-version = "0.3.1"
-dependencies = [
- "tang",
- "tang-la",
 ]
 
 [[package]]
@@ -4139,7 +4089,7 @@ name = "phyz-md"
 version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -4149,24 +4099,9 @@ dependencies = [
 [[package]]
 name = "phyz-model"
 version = "0.3.1"
-dependencies = [
- "phyz-math 0.3.1",
-]
-
-[[package]]
-name = "phyz-model"
-version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
-]
-
-[[package]]
-name = "phyz-rigid"
-version = "0.3.1"
-dependencies = [
- "phyz-math 0.3.1",
- "phyz-model 0.3.1",
+ "phyz-math",
 ]
 
 [[package]]
@@ -4174,8 +4109,8 @@ name = "phyz-rigid"
 version = "0.3.1"
 source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math",
+ "phyz-model",
 ]
 
 [[package]]
@@ -7678,7 +7613,7 @@ dependencies = [
 name = "vcad-kernel-physics"
 version = "0.9.4"
 dependencies = [
- "phyz 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -8000,10 +7935,10 @@ dependencies = [
 name = "vcad-sim"
 version = "0.9.4"
 dependencies = [
- "phyz 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz",
  "phyz-gpu",
- "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
- "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math",
+ "phyz-model",
  "rand 0.8.5",
  "rayon",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ name = "mecheval-grader"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "phyz",
+ "phyz 0.3.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4017,39 +4017,87 @@ dependencies = [
 name = "phyz"
 version = "0.3.1"
 dependencies = [
- "phyz-collision",
- "phyz-contact",
- "phyz-diff",
- "phyz-math",
- "phyz-model",
- "phyz-rigid",
+ "phyz-collision 0.3.1",
+ "phyz-contact 0.3.1",
+ "phyz-diff 0.3.1",
+ "phyz-math 0.3.1",
+ "phyz-model 0.3.1",
+ "phyz-rigid 0.3.1",
+]
+
+[[package]]
+name = "phyz"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-contact 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-diff 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
 ]
 
 [[package]]
 name = "phyz-collision"
 version = "0.3.1"
 dependencies = [
- "phyz-math",
- "phyz-model",
+ "phyz-math 0.3.1",
+ "phyz-model 0.3.1",
+]
+
+[[package]]
+name = "phyz-collision"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
 ]
 
 [[package]]
 name = "phyz-contact"
 version = "0.3.1"
 dependencies = [
- "phyz-collision",
- "phyz-math",
- "phyz-model",
- "phyz-rigid",
+ "phyz-collision 0.3.1",
+ "phyz-math 0.3.1",
+ "phyz-model 0.3.1",
+ "phyz-rigid 0.3.1",
+]
+
+[[package]]
+name = "phyz-contact"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
 ]
 
 [[package]]
 name = "phyz-diff"
 version = "0.3.1"
 dependencies = [
- "phyz-math",
- "phyz-model",
- "phyz-rigid",
+ "phyz-math 0.3.1",
+ "phyz-model 0.3.1",
+ "phyz-rigid 0.3.1",
+ "tang",
+ "tang-expr",
+ "tang-la",
+]
+
+[[package]]
+name = "phyz-diff"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-collision 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-contact 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "tang",
  "tang-expr",
  "tang-la",
@@ -4058,12 +4106,13 @@ dependencies = [
 [[package]]
 name = "phyz-gpu"
 version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
  "bytemuck",
  "futures-intrusive",
- "phyz-math",
- "phyz-model",
- "phyz-rigid",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-rigid 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "pollster",
  "wgpu",
 ]
@@ -4077,10 +4126,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "phyz-math"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "tang",
+ "tang-la",
+]
+
+[[package]]
 name = "phyz-md"
 version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
 dependencies = [
- "phyz-math",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
@@ -4091,15 +4150,32 @@ dependencies = [
 name = "phyz-model"
 version = "0.3.1"
 dependencies = [
- "phyz-math",
+ "phyz-math 0.3.1",
+]
+
+[[package]]
+name = "phyz-model"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
 ]
 
 [[package]]
 name = "phyz-rigid"
 version = "0.3.1"
 dependencies = [
- "phyz-math",
- "phyz-model",
+ "phyz-math 0.3.1",
+ "phyz-model 0.3.1",
+]
+
+[[package]]
+name = "phyz-rigid"
+version = "0.3.1"
+source = "git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef#7c8ac59c7659ed64f7218e0504b0487f90ec68ef"
+dependencies = [
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
 ]
 
 [[package]]
@@ -7602,7 +7678,7 @@ dependencies = [
 name = "vcad-kernel-physics"
 version = "0.9.4"
 dependencies = [
- "phyz",
+ "phyz 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -7924,10 +8000,10 @@ dependencies = [
 name = "vcad-sim"
 version = "0.9.4"
 dependencies = [
- "phyz",
+ "phyz 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "phyz-gpu",
- "phyz-math",
- "phyz-model",
+ "phyz-math 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
+ "phyz-model 0.3.1 (git+https://github.com/ecto/phyz.git?rev=7c8ac59c7659ed64f7218e0504b0487f90ec68ef)",
  "rand 0.8.5",
  "rayon",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,13 +208,27 @@ thiserror = "2"
 tang = { path = "../tang/crates/tang", version = "0.2" }
 tang-la = { path = "../tang/crates/tang-la", version = "0.1" }
 tang-expr = { path = "../tang/crates/tang-expr", version = "0.1" }
+# phyz is PINNED to a published revision rather than a sibling checkout.
+#
+# As a path dep, every vcad build took whatever happened to be in
+# `../phyz` — including a colleague's half-finished edit. That is not a
+# hypothetical: a working tree mid-refactor (a changed `contact::assemble`
+# signature, a `manifold::Face` missing a field) blocked every
+# physics-dependent build and test on this machine for an afternoon, and the
+# breakage had nothing to do with vcad. CI never saw it, because CI clones
+# phyz fresh — so the two disagreed about what "the build" even meant.
+#
+# Pinning makes the dependency reproducible and the sibling checkout
+# irrelevant. Bump the rev deliberately, in its own commit, so a physics
+# change to vcad is always attributable.
+#
 # phyz moved every crate onto its workspace version (0.3.1); the sub-crates
 # are no longer independently 0.1.x.
-phyz = { path = "../phyz/crates/phyz", version = "0.3" }
-phyz-gpu = { path = "../phyz/crates/phyz-gpu", version = "0.3" }
-phyz-model = { path = "../phyz/crates/phyz-model", version = "0.3" }
-phyz-math = { path = "../phyz/crates/phyz-math", version = "0.3" }
-phyz-md = { path = "../phyz/crates/phyz-md", version = "0.3" }
+phyz = { git = "https://github.com/ecto/phyz.git", rev = "7c8ac59c7659ed64f7218e0504b0487f90ec68ef", version = "0.3" }
+phyz-gpu = { git = "https://github.com/ecto/phyz.git", rev = "7c8ac59c7659ed64f7218e0504b0487f90ec68ef", version = "0.3" }
+phyz-model = { git = "https://github.com/ecto/phyz.git", rev = "7c8ac59c7659ed64f7218e0504b0487f90ec68ef", version = "0.3" }
+phyz-math = { git = "https://github.com/ecto/phyz.git", rev = "7c8ac59c7659ed64f7218e0504b0487f90ec68ef", version = "0.3" }
+phyz-md = { git = "https://github.com/ecto/phyz.git", rev = "7c8ac59c7659ed64f7218e0504b0487f90ec68ef", version = "0.3" }
 slotmap = "1"
 anyhow = "1"
 toml = "0.8"

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -576,6 +576,41 @@ impl RobotEnv {
         Ok(self.observe())
     }
 
+    /// Observe an external state **with a real contact channel**.
+    ///
+    /// [`Self::observe_state`] leaves `end_effector_contacts` as whatever this
+    /// env last stepped — nothing, for a decoder that never steps. That is a
+    /// silently wrong answer rather than a missing one: a policy reads four
+    /// zeros where its feet should be and simply behaves worse, with no error
+    /// anywhere. On the K1's 58-element feature vector those four are the two
+    /// per-foot touch flags and normal forces, which is precisely the channel a
+    /// balance policy steers on.
+    ///
+    /// Contacts are not carried by `State`, and the GPU has no readback for
+    /// them (its contact pass accumulates into `ext_forces`, which is not the
+    /// manifold and has no staging buffer). So they are recomputed here, by the
+    /// CPU's own contact code, at the loaded pose:
+    ///
+    /// 1. load the state,
+    /// 2. take one step — this is what populates the contact manifold,
+    /// 3. load the state again, restoring the exact `q`/`v` the step advanced
+    ///    (contacts survive, since they live outside `State`),
+    /// 4. observe.
+    ///
+    /// The result is a contact state consistent with the pose being observed,
+    /// computed by the same code the CPU env reports. It costs one CPU step per
+    /// environment, which is the honest price of the GPU not surfacing its own
+    /// contact — see `docs/native-sim-m0.md`.
+    pub fn observe_state_with_contacts(
+        &mut self,
+        state: &phyz::model::State,
+    ) -> Result<Observation, PhysicsError> {
+        self.world.load_phyz_state(state)?;
+        self.world.step(self.dt);
+        self.world.load_phyz_state(state)?;
+        Ok(self.observe())
+    }
+
     /// Get current observation without stepping.
     pub fn observe(&self) -> Observation {
         let mut positions = Vec::new();

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -18,10 +18,11 @@ use crate::world::{ContactState, GainWarning, GroundConfig, PhysicsWorld};
 /// - Ball: 3 entries — rotation exp-coords in degrees; angular velocity in
 ///   deg/s
 /// - Free (floating base): 6 entries — positions
-///   `[x, y, z (mm), rx, ry, rz (exp-coords, degrees)]` and velocities
-///   `[wx, wy, wz (deg/s), vx, vy, vz (body-frame mm/s)]`. Note the swapped
-///   rotation/translation order between positions and velocities (phyz's
-///   Featherstone free-joint convention).
+///   `[rx, ry, rz (exp-coords, degrees), x, y, z (mm)]` and velocities
+///   `[wx, wy, wz (deg/s), vx, vy, vz (body-frame mm/s)]`. Both are
+///   **angular-first**, phyz's `SpatialVec` order. Positions used to be
+///   translation-first while velocities were angular-first; anything that
+///   still assumes that reads a rotation where it expects a height.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Observation {
     /// Flattened joint positions (degrees for rotational DOFs, mm for

--- a/crates/vcad-kernel-physics/src/gym.rs
+++ b/crates/vcad-kernel-physics/src/gym.rs
@@ -555,6 +555,27 @@ impl RobotEnv {
         }
     }
 
+    /// Observe an externally produced state — a GPU batch readback — through
+    /// the identical path [`Self::observe`] uses.
+    ///
+    /// The point is reuse, not convenience: end-effector poses, base pose and
+    /// velocity, and the per-joint unit conversions are all defined once, in
+    /// the CPU env, and a batched backend borrows them rather than
+    /// reimplementing them against a raw buffer.
+    ///
+    /// **Contacts are not carried by `State`.** The returned observation's
+    /// `end_effector_contacts` reflect whatever this env last stepped — for a
+    /// decoder that has never stepped, no contact at all. Until the batch path
+    /// reads contact forces back from the GPU, a policy driven from this
+    /// observation is missing its foot-force channel.
+    pub fn observe_state(
+        &mut self,
+        state: &phyz::model::State,
+    ) -> Result<Observation, PhysicsError> {
+        self.world.load_phyz_state(state)?;
+        Ok(self.observe())
+    }
+
     /// Get current observation without stepping.
     pub fn observe(&self) -> Observation {
         let mut positions = Vec::new();

--- a/crates/vcad-kernel-physics/src/joints.rs
+++ b/crates/vcad-kernel-physics/src/joints.rs
@@ -164,9 +164,9 @@ pub(crate) fn vcad_joint_to_phyz(
         }
         JointKind::Free => {
             // 6-DOF floating base. phyz's free joint carries
-            // q = [x, y, z, wx, wy, wz] (position in parent coords +
-            // exp-coords of the rotation) and v = [angular(3), linear(3)]
-            // — note the swapped order between q and v.
+            // q = [wx, wy, wz, x, y, z] (exp-coords of the rotation, then
+            // position in parent coords) and v = [angular(3), linear(3)] —
+            // the same order, which is the point.
             let xform = SpatialTransform::new(rot, anchor);
             Ok(PhyzJoint::free(xform))
         }
@@ -248,15 +248,21 @@ pub fn convert_state_from_physics(kind: &JointKind, state: f64) -> f64 {
 /// Per-DOF q layout in vcad units (phyz layout in parentheses):
 /// - 1-DOF kinds: DOF 0 = degrees (radians) or mm (meters)
 /// - Ball: DOFs 0–2 = exp-coords in degrees (radians)
-/// - Free: DOFs 0–2 = translation in mm (meters),
-///   DOFs 3–5 = rotation exp-coords in degrees (radians)
+/// - Free: DOFs 0–2 = rotation exp-coords in degrees (radians),
+///   DOFs 3–5 = translation in mm (meters)
+///
+/// **Free is angular-first, matching `v`.** It was translation-first until
+/// phyz unified the two orders; a converter left on the old layout applies the
+/// millimetre scale to a rotation and the degree scale to a position, so a
+/// robot's base height reads as ~0 and the whole balance task quietly stops
+/// measuring anything.
 pub fn convert_q_dof_to_physics(kind: &JointKind, dof: usize, value: f64) -> f64 {
     match kind {
         JointKind::Free => {
             if dof < 3 {
-                value / 1000.0
-            } else {
                 value.to_radians()
+            } else {
+                value / 1000.0
             }
         }
         _ => convert_state_to_physics(kind, value),
@@ -269,9 +275,9 @@ pub fn convert_q_dof_from_physics(kind: &JointKind, dof: usize, value: f64) -> f
     match kind {
         JointKind::Free => {
             if dof < 3 {
-                value * 1000.0
-            } else {
                 value.to_degrees()
+            } else {
+                value * 1000.0
             }
         }
         _ => convert_state_from_physics(kind, value),
@@ -280,9 +286,8 @@ pub fn convert_q_dof_from_physics(kind: &JointKind, dof: usize, value: f64) -> f
 
 /// Convert one **velocity (v)** DOF from physics units to vcad units.
 ///
-/// The velocity layout of a Free joint is **swapped** relative to its q
-/// layout (phyz/Featherstone convention): v = [angular(3), linear(3)]
-/// while q = [linear(3), rotation(3)]. So:
+/// A Free joint's v layout **matches** its q layout — both are angular-first
+/// (`[angular(3), linear(3)]`), phyz's `SpatialVec` convention. So:
 /// - Free: DOFs 0–2 = angular velocity rad/s → deg/s,
 ///   DOFs 3–5 = body-frame linear velocity m/s → mm/s
 /// - all other kinds: same conversion as their q DOF
@@ -300,7 +305,7 @@ pub fn convert_v_dof_from_physics(kind: &JointKind, dof: usize, value: f64) -> f
 }
 
 /// Convert one **velocity (v)** DOF from vcad units to physics units.
-/// Inverse of [`convert_v_dof_from_physics`]; same swapped Free layout.
+/// Inverse of [`convert_v_dof_from_physics`]; same angular-first Free layout.
 pub fn convert_v_dof_to_physics(kind: &JointKind, dof: usize, value: f64) -> f64 {
     match kind {
         JointKind::Free => {

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -825,6 +825,43 @@ impl PhysicsWorld {
         self.model.dt = original_dt;
     }
 
+    /// Adopt an externally produced state — a GPU batch readback — and
+    /// recompute the derived kinematics, so every pose and velocity query
+    /// afterwards answers about *that* state.
+    ///
+    /// This exists so the GPU path never re-derives a conversion. Base pose,
+    /// base velocity, joint units and end-effector poses all have exact
+    /// definitions here (world-frame rotation of a body-frame spatial
+    /// velocity, angular-first free-joint slots, degrees and millimetres);
+    /// reimplementing any of them against a raw `q`/`v` buffer is how the two
+    /// backends end up describing different robots. Load the state, then ask
+    /// the same questions.
+    ///
+    /// Contacts are **not** part of `State`, so they are unchanged by this
+    /// call — a decoder that has never stepped reports no contact.
+    pub fn load_phyz_state(&mut self, state: &State) -> Result<(), PhysicsError> {
+        if state.q.len() != self.state.q.len() || state.v.len() != self.state.v.len() {
+            return Err(PhysicsError::Evaluation(format!(
+                "state has {} q / {} v, this model has {} q / {} v — decoding it \
+                 would silently read another robot's DOFs",
+                state.q.len(),
+                state.v.len(),
+                self.state.q.len(),
+                self.state.v.len()
+            )));
+        }
+        self.state
+            .q
+            .as_mut_slice()
+            .copy_from_slice(state.q.as_slice());
+        self.state
+            .v
+            .as_mut_slice()
+            .copy_from_slice(state.v.as_slice());
+        self.refresh_kinematics();
+        Ok(())
+    }
+
     /// Recompute forward kinematics from the current `state.q` / `state.v`,
     /// refreshing the cached body transforms and spatial velocities. Call
     /// after mutating joint state directly (e.g. [`Self::perturb_joint_state`]).

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -242,6 +242,28 @@ impl PhysicsWorld {
     ///
     /// The document must have assembly data (instances and joints).
     pub fn from_document(doc: &Document) -> Result<Self, PhysicsError> {
+        Self::from_document_with_colliders(doc, ColliderStrategy::ConvexHull)
+    }
+
+    /// Build a world using a specific collider strategy.
+    ///
+    /// The strategy is not cosmetic across backends. phyz's **GPU** contact
+    /// pipeline packs eight floats per body and understands only `Sphere`,
+    /// `Box`, `Capsule` and `Cylinder`; anything else — including the
+    /// `Geometry::Mesh` that [`ColliderStrategy::ConvexHull`] produces — falls
+    /// through its match to "type 0", which means *no collision*, silently.
+    /// A vcad robot built the default way is therefore invisible to GPU
+    /// contact and drops through the floor, while the same robot on the CPU
+    /// (which handles meshes) stands on it.
+    ///
+    /// [`ColliderStrategy::Aabb`] emits `Geometry::Box`, which the GPU does
+    /// understand. That is a real fidelity trade — a box is not a hull — so it
+    /// is opt-in rather than the default, and a batch that wants contact has
+    /// to ask for it.
+    pub fn from_document_with_colliders(
+        doc: &Document,
+        collider_strategy: ColliderStrategy,
+    ) -> Result<Self, PhysicsError> {
         let instances = doc.instances.as_ref().ok_or(PhysicsError::NoAssembly)?;
         let joints = doc.joints.as_ref().ok_or(PhysicsError::NoAssembly)?;
         let part_defs = doc.part_defs.as_ref().ok_or(PhysicsError::NoAssembly)?;
@@ -377,7 +399,7 @@ impl PhysicsWorld {
                     estimate_mass(&mesh, density)
                 }
             };
-            let geometry = mesh_to_collider(&mesh, ColliderStrategy::ConvexHull, &inst.id)?;
+            let geometry = mesh_to_collider(&mesh, collider_strategy, &inst.id)?;
             Ok((mesh, mass, geometry, authored))
         };
 

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -1447,7 +1447,7 @@ impl PhysicsWorld {
             // Every DOF, not just the first: a Ball joint carries 3 and a Free
             // joint 6, and perturbing only DOF 0 would silently apply a
             // fraction of the requested randomization. The per-DOF converters
-            // also handle Free's swapped q/v layouts (q = [linear, rotation],
+            // also handle Free's angular-first q/v layouts (q = [rotation, linear],
             // v = [angular, linear]).
             for k in 0..joint_ndof(kind) {
                 self.state.q[q_offset + k] += convert_q_dof_to_physics(kind, k, dpos);
@@ -1703,9 +1703,9 @@ impl PhysicsWorld {
     /// [`crate::joints::convert_v_dof_from_physics`]):
     /// - 1-DOF kinds: `([pos], [vel])` — degrees / deg/s or mm / mm/s
     /// - Ball: 3 rotation exp-coords in degrees; 3 angular vel in deg/s
-    /// - Free: positions `[x, y, z (mm), rx, ry, rz (exp-coords, deg)]`,
+    /// - Free: positions `[rx, ry, rz (exp-coords, deg), x, y, z (mm)]`,
     ///   velocities `[wx, wy, wz (deg/s), vx, vy, vz (body-frame mm/s)]` —
-    ///   note the swapped rotation/translation order between the two
+    ///   both angular-first, matching phyz's `SpatialVec` order
     /// - Fixed: `([], [])`
     pub fn get_joint_dofs(&self, joint_id: &str) -> Option<(Vec<f64>, Vec<f64>)> {
         let kind = self.joint_kinds.get(joint_id)?;

--- a/crates/vcad-kernel-physics/tests/free_joint.rs
+++ b/crates/vcad-kernel-physics/tests/free_joint.rs
@@ -128,17 +128,32 @@ fn free_joint_gym_observation_layout() {
     assert_eq!(obs.joint_velocities.len(), 6);
 
     // Step with an empty action; the base falls. Position layout is
-    // [x, y, z (mm), rx, ry, rz (deg)] — z (slot 2) decreases.
+    // ANGULAR-FIRST — [rx, ry, rz (deg), x, y, z (mm)] — matching the velocity
+    // layout, so z is slot 5.
+    //
+    // It was translation-first until phyz unified the two orders. That change
+    // is invisible to anything that only reads magnitudes, which is why this
+    // asserts both halves: the height slot moves, and the rotation slots stay
+    // quiet. A converter left on the old layout puts a ~70 mm drop into slot 5
+    // while slot 2 reads a rotation — the robot's base height reads as zero and
+    // every height termination and reward term silently stops meaning anything.
     let mut obs = obs;
     for _ in 0..30 {
         let (o, _, _) = env.step(Action::Torque(vec![]));
         obs = o;
     }
     assert!(
-        obs.joint_positions[2] < -10.0,
-        "free-base z should have dropped (mm); obs = {:?}",
+        obs.joint_positions[5] < -10.0,
+        "free-base z (slot 5, angular-first layout) should have dropped (mm); obs = {:?}",
         obs.joint_positions
     );
+    for (i, r) in obs.joint_positions[0..3].iter().enumerate() {
+        assert!(
+            r.abs() < 1e-6,
+            "a body falling straight down must not rotate: slot {i} = {r} deg; \
+             a non-zero value here means the layout is translation-first again"
+        );
+    }
     // Velocity layout is [wx, wy, wz (deg/s), vx, vy, vz (mm/s)]: the
     // linear-z slot (5) carries the fall speed, the angular slots stay ~0.
     assert!(

--- a/crates/vcad-sim/examples/k1_gpu_bench.rs
+++ b/crates/vcad-sim/examples/k1_gpu_bench.rs
@@ -118,12 +118,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --- Sanity: gravity acts. A zero-torque K1 must be falling. ---
     let mut batch = BatchSimPipeline::from_document(&doc, 4, DT)?;
     batch.batch_reset();
-    let z0 = batch.batch_observe()[0].joint_positions[2];
+    // Free-joint q is angular-first: [rx, ry, rz, x, y, z] — base z is slot 5.
+    let z0 = batch.batch_observe()[0].joint_positions[5];
     let nv = batch.action_dim();
     for _ in 0..100 {
         batch.batch_step_submit(&vec![0.0; 4 * nv])?;
     }
-    let z1 = batch.batch_observe()[0].joint_positions[2];
+    let z1 = batch.batch_observe()[0].joint_positions[5];
     println!(
         "\nsanity: base z {z0:.3} -> {z1:.3} after 100 ticks of free fall \
          ({})",

--- a/crates/vcad-sim/examples/k1_gpu_bench.rs
+++ b/crates/vcad-sim/examples/k1_gpu_bench.rs
@@ -27,6 +27,11 @@
 use vcad_ir::Document;
 use vcad_sim::BatchSimPipeline;
 
+/// The tick the CPU reference and the RL rollouts use. The GPU must be told —
+/// it reads `model.dt` once at construction and would otherwise run at the
+/// model default of 1/240, which is a different plant, not a rounding.
+const DT: f64 = 1.0 / 1000.0;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let path = std::env::args()
         .nth(1)
@@ -72,7 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "envs", "submit substeps/s", "readback substeps/s", "vs CPU"
     );
     for n_envs in [64usize, 256, 1024, 4096] {
-        let mut batch = match BatchSimPipeline::from_document(&doc, n_envs) {
+        let mut batch = match BatchSimPipeline::from_document(&doc, n_envs, DT) {
             Ok(b) => b,
             Err(e) => {
                 println!("{n_envs:>7}  construction failed: {e}");
@@ -111,7 +116,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // --- Sanity: gravity acts. A zero-torque K1 must be falling. ---
-    let mut batch = BatchSimPipeline::from_document(&doc, 4)?;
+    let mut batch = BatchSimPipeline::from_document(&doc, 4, DT)?;
     batch.batch_reset();
     let z0 = batch.batch_observe()[0].joint_positions[2];
     let nv = batch.action_dim();
@@ -138,7 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // wrong DOF indexing leaves some joint untouched at 0.3 rad of error.
     // (No contact geometry yet, so the robot falls forever; joint tracking
     // is the thing under test.)
-    let mut batch = BatchSimPipeline::from_document(&doc, 4)?;
+    let mut batch = BatchSimPipeline::from_document(&doc, 4, DT)?;
     let gains: std::collections::HashMap<String, (f64, f64)> = batch
         .servo_joint_ids()
         .iter()

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -29,6 +29,9 @@ pub struct BatchSimPipeline {
     n_bodies: usize,
     /// Per-body mass, for deriving stable contact gains.
     body_masses: Vec<f64>,
+    /// Masses of just the bodies the GPU contact pass can see — the set that
+    /// bounds stiffness from above. See [`Self::is_gpu_collidable`].
+    collidable_masses: Vec<f64>,
 }
 
 impl BatchSimPipeline {
@@ -89,18 +92,23 @@ impl BatchSimPipeline {
         let gpu_collidable = model
             .bodies
             .iter()
-            .filter(|b| {
-                matches!(
-                    b.geometry,
-                    Some(phyz_model::Geometry::Sphere { .. })
-                        | Some(phyz_model::Geometry::Box { .. })
-                        | Some(phyz_model::Geometry::Capsule { .. })
-                        | Some(phyz_model::Geometry::Cylinder { .. })
-                )
-            })
+            .filter(|b| Self::is_gpu_collidable(b))
             .count();
 
+        // Two different mass sets, because the two stability bounds ask
+        // different questions. `k_min` must hold up the whole model's weight,
+        // collidable or not — a non-colliding forearm still presses down
+        // through the joints onto the feet that do touch. `k_max` is set by
+        // the lightest body the contact pass can actually push on; a body the
+        // GPU never sees is never integrated against this spring and cannot
+        // make it blow up.
         let body_masses: Vec<f64> = model.bodies.iter().map(|b| b.inertia.mass).collect();
+        let collidable_masses: Vec<f64> = model
+            .bodies
+            .iter()
+            .filter(|b| Self::is_gpu_collidable(b))
+            .map(|b| b.inertia.mass)
+            .collect();
 
         let gpu_sim = GpuBatchSimulator::new(model, n_envs).map_err(SimError::Gpu)?;
 
@@ -115,6 +123,7 @@ impl BatchSimPipeline {
             gpu_collidable,
             n_bodies,
             body_masses,
+            collidable_masses,
         })
     }
 
@@ -321,6 +330,22 @@ impl BatchSimPipeline {
         self.gpu_sim.load_states(&states);
     }
 
+    /// Whether the GPU contact pipeline can collide this body.
+    ///
+    /// Mirrors the shape match in phyz's `contact_pipeline`, whose `_` arm
+    /// packs every other geometry (and `None`) as type 0 — no collision, no
+    /// diagnostic. Kept in one place so the collidable *count* and the
+    /// collidable *masses* can never disagree about what "collidable" means.
+    fn is_gpu_collidable(body: &phyz_model::Body) -> bool {
+        matches!(
+            body.geometry,
+            Some(phyz_model::Geometry::Sphere { .. })
+                | Some(phyz_model::Geometry::Box { .. })
+                | Some(phyz_model::Geometry::Capsule { .. })
+                | Some(phyz_model::Geometry::Cylinder { .. })
+        )
+    }
+
     /// Enable ground-plane contact detection.
     ///
     /// Objects will be repelled from the ground at `height` via penalty forces.
@@ -379,7 +404,7 @@ impl BatchSimPipeline {
         // only ones with real mass — a massless link (a `world` anchor, a
         // frame-carrying dummy) would drive the limit to zero.
         let m_min = self
-            .body_masses
+            .collidable_masses
             .iter()
             .copied()
             .filter(|m| *m > 1e-6)

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -23,6 +23,12 @@ pub struct BatchSimPipeline {
     pd_dofs: usize,
     /// Timestep the GPU captured at construction.
     dt: f64,
+    /// Bodies whose collider the GPU contact pipeline can actually see.
+    gpu_collidable: usize,
+    /// Total bodies, for the diagnostic.
+    n_bodies: usize,
+    /// Per-body mass, for deriving stable contact gains.
+    body_masses: Vec<f64>,
 }
 
 impl BatchSimPipeline {
@@ -48,7 +54,16 @@ impl BatchSimPipeline {
         // — an earlier version of this pipeline re-derived the model here with
         // density-guessed box inertias, which silently trained against the
         // wrong robot.
-        let world = vcad_kernel_physics::PhysicsWorld::from_document(doc)?;
+        // AABB colliders, not the default convex hulls. phyz's GPU contact
+        // pipeline only understands Sphere/Box/Capsule/Cylinder and maps
+        // anything else — including `Geometry::Mesh` — to "no collision",
+        // silently. A hull-collided robot simply falls through the GPU's
+        // ground while standing on the CPU's. See
+        // `PhysicsWorld::from_document_with_colliders`.
+        let world = vcad_kernel_physics::PhysicsWorld::from_document_with_colliders(
+            doc,
+            vcad_kernel_physics::colliders::ColliderStrategy::Aabb,
+        )?;
         let mut model = world.model().clone();
         // Stamp the timestep into the model before the GPU captures it.
         model.dt = dt;
@@ -68,6 +83,25 @@ impl BatchSimPipeline {
             })
             .collect();
 
+        // Count what the GPU's contact pass will actually see, before handing
+        // the model over — the packing itself reports nothing.
+        let n_bodies = model.bodies.len();
+        let gpu_collidable = model
+            .bodies
+            .iter()
+            .filter(|b| {
+                matches!(
+                    b.geometry,
+                    Some(phyz_model::Geometry::Sphere { .. })
+                        | Some(phyz_model::Geometry::Box { .. })
+                        | Some(phyz_model::Geometry::Capsule { .. })
+                        | Some(phyz_model::Geometry::Cylinder { .. })
+                )
+            })
+            .count();
+
+        let body_masses: Vec<f64> = model.bodies.iter().map(|b| b.inertia.mass).collect();
+
         let gpu_sim = GpuBatchSimulator::new(model, n_envs).map_err(SimError::Gpu)?;
 
         Ok(Self {
@@ -78,6 +112,9 @@ impl BatchSimPipeline {
             servo_joints,
             pd_dofs: 0,
             dt,
+            gpu_collidable,
+            n_bodies,
+            body_masses,
         })
     }
 
@@ -254,13 +291,13 @@ impl BatchSimPipeline {
     /// same base instance — or the observations describe a different robot.
     /// The DOF widths are checked; the naming is not, and cannot be.
     ///
-    /// **Contacts are missing.** `State` does not carry them, so
-    /// `end_effector_contacts` reads as the decoder's last step — nothing, for
-    /// a decoder that has never stepped. On the K1's 58-element feature vector
-    /// that is 4 elements: the two per-foot touch flags and normal forces. The
-    /// other 54 are correct. Reading contact back from the GPU is the next
-    /// piece of work, and until it lands a policy driven from here is blind to
-    /// its feet.
+    /// Contacts are recomputed on the decoder rather than read back from the
+    /// GPU, which has no path for them — its contact pass accumulates into
+    /// `ext_forces`, which is neither the contact manifold nor readable. So
+    /// each environment costs one CPU step to populate its foot-force channel.
+    /// That is the honest price until phyz surfaces contact state; the
+    /// alternative is four silent zeros where a balance policy expects its
+    /// feet.
     pub fn batch_observe_gym(
         &self,
         decoder: &mut vcad_kernel_physics::RobotEnv,
@@ -268,7 +305,11 @@ impl BatchSimPipeline {
         self.gpu_sim
             .readback_states()
             .iter()
-            .map(|st| decoder.observe_state(st).map_err(SimError::from))
+            .map(|st| {
+                decoder
+                    .observe_state_with_contacts(st)
+                    .map_err(SimError::from)
+            })
             .collect()
     }
 
@@ -290,6 +331,17 @@ impl BatchSimPipeline {
         damping: f64,
         friction: f64,
     ) -> Result<(), SimError> {
+        // Refuse rather than enable a contact pass that cannot see anything.
+        // The GPU's geometry packing maps every unsupported shape to type 0 —
+        // no collision — with no diagnostic, so a robot built with mesh
+        // colliders silently free-falls through the ground it was asked to
+        // stand on. That reads as a physics bug, or worse, as a bad policy.
+        if self.gpu_collidable == 0 {
+            return Err(SimError::Gpu(format!(
+                "ground contact would be inert: none of this model's {} bodies has                  geometry the GPU contact pipeline supports (Sphere, Box, Capsule,                  Cylinder). Build the pipeline with AABB colliders.",
+                self.n_bodies
+            )));
+        }
         self.gpu_sim
             .enable_ground_contact(height, stiffness, damping, friction)
             .map_err(SimError::Gpu)?;
@@ -299,6 +351,58 @@ impl BatchSimPipeline {
     /// The timestep every environment steps at, in seconds.
     pub fn dt(&self) -> f64 {
         self.dt
+    }
+
+    /// Ground-contact gains for this model, or why none exist.
+    ///
+    /// A penalty contact has to satisfy two constraints at once, and they pull
+    /// in opposite directions:
+    ///
+    /// - **Stiff enough to hold the robot up.** Supporting total weight `M*g`
+    ///   without sinking more than `max_penetration` needs
+    ///   `k >= M*g/max_penetration`.
+    /// - **Soft enough to integrate.** The GPU integrates the spring
+    ///   explicitly, so `w*dt` must stay under about 0.3 with
+    ///   `w = sqrt(k/m)`. The binding body is the *lightest* one that can
+    ///   touch, giving `k <= m_min*(0.3/dt)^2`.
+    ///
+    /// When the window is empty there is no stable penalty stiffness for this
+    /// model at this timestep, and that is reported with both bounds rather
+    /// than approximated — the failure mode otherwise is NaN a few hundred
+    /// steps later, or a robot that sinks through the floor, neither of which
+    /// points at the parameter that caused it.
+    ///
+    /// Damping is set for critical damping on the binding body; a contact that
+    /// bounces forever is as useless as one that diverges.
+    pub fn stable_ground_gains(&self, max_penetration_m: f64) -> Result<(f64, f64), SimError> {
+        // Only bodies the GPU can actually collide constrain stability, and
+        // only ones with real mass — a massless link (a `world` anchor, a
+        // frame-carrying dummy) would drive the limit to zero.
+        let m_min = self
+            .body_masses
+            .iter()
+            .copied()
+            .filter(|m| *m > 1e-6)
+            .fold(f64::INFINITY, f64::min);
+        if !m_min.is_finite() {
+            return Err(SimError::Gpu(
+                "no body has enough mass to derive contact gains from".into(),
+            ));
+        }
+        let total: f64 = self.body_masses.iter().sum();
+
+        let k_max = m_min * (0.3 / self.dt).powi(2);
+        let k_min = total * 9.81 / max_penetration_m;
+        if k_min > k_max {
+            return Err(SimError::Gpu(format!(
+                "no stable penalty stiffness exists for this model at dt={:.2e}: holding                  {total:.3} kg within {max_penetration_m:.4} m needs k >= {k_min:.3e}, but the                  lightest contacting body ({m_min:.4} kg) goes unstable above k = {k_max:.3e}.                  Use a smaller dt, allow deeper penetration, or accept that this model                  cannot use GPU penalty contact.",
+                self.dt
+            )));
+        }
+        // Sit at the geometric mean of the window: as stiff as the support
+        // requirement allows without crowding the stability limit.
+        let k = (k_min * k_max).sqrt();
+        Ok((k, 2.0 * (k * m_min).sqrt()))
     }
 
     /// Get the number of parallel environments.

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -5,7 +5,7 @@ use phyz_model::State;
 use vcad_ir::Document;
 
 use crate::error::SimError;
-use crate::{Observation, StepResult};
+use crate::{RawState, StepResult};
 
 /// GPU batch simulation pipeline running N parallel environments.
 ///
@@ -221,18 +221,55 @@ impl BatchSimPipeline {
     }
 
     /// Observe all environments without stepping.
-    pub fn batch_observe(&self) -> Vec<Observation> {
+    pub fn batch_observe(&self) -> Vec<RawState> {
         let states = self.gpu_sim.readback_states();
 
         let mut observations = Vec::with_capacity(self.n_envs);
         for state in &states {
-            observations.push(Observation {
+            observations.push(RawState {
                 joint_positions: state.q.as_slice().to_vec(),
                 joint_velocities: state.v.as_slice().to_vec(),
             });
         }
 
         observations
+    }
+
+    /// Full gym observations for every environment, decoded through the CPU
+    /// env's own conversion path.
+    ///
+    /// [`Self::batch_observe`] returns raw phyz state — radians, metres,
+    /// angular-first free-joint slots — while everything a policy consumes
+    /// (`vcad_sim::rl::features`, the reward, the termination checks) is
+    /// defined against `vcad_kernel_physics::Observation` in degrees and
+    /// millimetres. Those are two different types with the same name and
+    /// different units, and feeding one where the other is expected scales
+    /// every joint angle by 180/pi with no error anywhere.
+    ///
+    /// So this does not convert anything itself. It hands each readback state
+    /// to `decoder`, which loads it and answers with the same code the CPU env
+    /// answers with.
+    ///
+    /// `decoder` must be built from the same document — same end effectors,
+    /// same base instance — or the observations describe a different robot.
+    /// The DOF widths are checked; the naming is not, and cannot be.
+    ///
+    /// **Contacts are missing.** `State` does not carry them, so
+    /// `end_effector_contacts` reads as the decoder's last step — nothing, for
+    /// a decoder that has never stepped. On the K1's 58-element feature vector
+    /// that is 4 elements: the two per-foot touch flags and normal forces. The
+    /// other 54 are correct. Reading contact back from the GPU is the next
+    /// piece of work, and until it lands a policy driven from here is blind to
+    /// its feet.
+    pub fn batch_observe_gym(
+        &self,
+        decoder: &mut vcad_kernel_physics::RobotEnv,
+    ) -> Result<Vec<vcad_kernel_physics::Observation>, SimError> {
+        self.gpu_sim
+            .readback_states()
+            .iter()
+            .map(|st| decoder.observe_state(st).map_err(SimError::from))
+            .collect()
     }
 
     /// Reset all environments to the initial state.

--- a/crates/vcad-sim/src/batch.rs
+++ b/crates/vcad-sim/src/batch.rs
@@ -21,14 +21,27 @@ pub struct BatchSimPipeline {
     servo_joints: Vec<(String, usize, usize, Option<f64>)>,
     /// Number of servoed DOFs once [`Self::enable_pd`] has run.
     pd_dofs: usize,
+    /// Timestep the GPU captured at construction.
+    dt: f64,
 }
 
 impl BatchSimPipeline {
     /// Create a batch simulation pipeline from a vcad Document.
     ///
     /// Builds the phyz Model from the assembly, then initializes `n_envs`
-    /// parallel GPU environments.
-    pub fn from_document(doc: &Document, n_envs: usize) -> Result<Self, SimError> {
+    /// parallel GPU environments stepping at `dt` seconds.
+    ///
+    /// **`dt` is required, deliberately.** `GpuBatchSimulator` reads
+    /// `model.dt` once at construction and steps at it forever, while the CPU
+    /// env overrides `model.dt` per `PhysicsWorld::step(dt)` call. With no
+    /// argument here the batch silently ran at the model default of 1/240 s
+    /// while the gym ran at 1/1000 — a 4.17x mismatch that is not a small
+    /// error but a different plant. Measured on the floating-arm sample, the
+    /// GPU diverged to non-finite state by step 185 while the CPU was stable;
+    /// the K1's leg gains need the 1 kHz tick and come apart at 200 Hz.
+    ///
+    /// A default would have hidden that again, so there isn't one.
+    pub fn from_document(doc: &Document, n_envs: usize, dt: f64) -> Result<Self, SimError> {
         // One model builder for the whole stack: `PhysicsWorld::from_document`
         // is what the CPU gym env runs, with authored inertials, collider
         // masses, joint frames and limits. The GPU batch inherits it verbatim
@@ -36,7 +49,9 @@ impl BatchSimPipeline {
         // density-guessed box inertias, which silently trained against the
         // wrong robot.
         let world = vcad_kernel_physics::PhysicsWorld::from_document(doc)?;
-        let model = world.model().clone();
+        let mut model = world.model().clone();
+        // Stamp the timestep into the model before the GPU captures it.
+        model.dt = dt;
         let initial_state = world.phyz_state().clone();
         let nv = model.nv;
 
@@ -62,6 +77,7 @@ impl BatchSimPipeline {
             initial_state,
             servo_joints,
             pd_dofs: 0,
+            dt,
         })
     }
 
@@ -241,6 +257,11 @@ impl BatchSimPipeline {
             .enable_ground_contact(height, stiffness, damping, friction)
             .map_err(SimError::Gpu)?;
         Ok(())
+    }
+
+    /// The timestep every environment steps at, in seconds.
+    pub fn dt(&self) -> f64 {
+        self.dt
     }
 
     /// Get the number of parallel environments.

--- a/crates/vcad-sim/src/lib.rs
+++ b/crates/vcad-sim/src/lib.rs
@@ -34,11 +34,25 @@ pub struct StepResult {
     pub done: bool,
 }
 
-/// Observation of the current simulation state.
+/// Raw phyz state read back from a simulator, in **physics units**.
+///
+/// Named `RawState` rather than `Observation` on purpose. There is a
+/// `vcad_kernel_physics::Observation` too, and it is a different type with a
+/// different shape *and different units* — degrees and millimetres, plus base
+/// pose, base velocity and contact channels. When both were called
+/// `Observation`, passing one where the other was expected compiled fine in
+/// any module that imported only one of them, and scaled every joint angle by
+/// 180/pi with no error at any layer.
+///
+/// If you want the thing a policy consumes, use
+/// [`BatchSimPipeline::batch_observe_gym`] — it decodes through the CPU env's
+/// own conversions rather than reimplementing them here.
 #[derive(Debug, Clone)]
-pub struct Observation {
-    /// Joint positions (degrees for revolute, mm for prismatic).
+pub struct RawState {
+    /// Joint positions in physics units: radians, metres. A `Free` joint's
+    /// six slots are angular-first (`[rx, ry, rz, x, y, z]`).
     pub joint_positions: Vec<f64>,
-    /// Joint velocities.
+    /// Joint velocities in physics units: rad/s, m/s. Angular-first for a
+    /// `Free` joint, and its linear part is body-frame.
     pub joint_velocities: Vec<f64>,
 }

--- a/crates/vcad-sim/src/single.rs
+++ b/crates/vcad-sim/src/single.rs
@@ -4,7 +4,7 @@ use vcad_ir::Document;
 use vcad_kernel_physics::PhysicsWorld;
 
 use crate::error::SimError;
-use crate::{Observation, StepResult};
+use crate::{RawState, StepResult};
 
 /// CPU single-environment simulation pipeline.
 ///
@@ -71,7 +71,7 @@ impl SimPipeline {
     }
 
     /// Observe the current simulation state without stepping.
-    pub fn observe(&self) -> Observation {
+    pub fn observe(&self) -> RawState {
         let states = self.world.get_joint_states();
         let mut joint_ids: Vec<String> = self.world.joint_ids();
         joint_ids.sort();
@@ -85,7 +85,7 @@ impl SimPipeline {
             }
         }
 
-        Observation {
+        RawState {
             joint_positions: positions,
             joint_velocities: velocities,
         }

--- a/crates/vcad-sim/tests/gpu_cpu_parity.rs
+++ b/crates/vcad-sim/tests/gpu_cpu_parity.rs
@@ -1,0 +1,255 @@
+//! M3.0 — does the GPU batch integrate the same dynamics as the CPU env?
+//!
+//! "CPU/GPU parity" has been the stated gate on the whole batched-simulation
+//! milestone, and until this file there was nothing measuring it: `vcad-sim`
+//! had no test directory at all. phyz has its own GPU-vs-CPU tests, but those
+//! check *phyz's* pipeline on *phyz's* models. Nothing checked that a vcad
+//! document, built once by `PhysicsWorld::from_document` and handed to both
+//! backends, produces the same trajectory.
+//!
+//! # Why the comparison is at raw phyz state
+//!
+//! `PhysicsWorld::phyz_state()` and `GpuBatchSimulator::readback_states()` are
+//! the same type in the same units. Comparing there isolates the question the
+//! gate actually asks — do the two integrators agree — from the separate
+//! question of whether the two observation layers agree, which is M3.1's job
+//! and involves a genuine unit mismatch (`vcad-sim`'s `Observation` is raw
+//! radians/metres; `vcad_kernel_physics`'s is degrees/millimetres). Mixing the
+//! two would mean a parity failure could be either a physics divergence or a
+//! conversion bug, and the whole point is to tell them apart.
+//!
+//! # No GPU adapter
+//!
+//! These skip loudly rather than fail when no adapter is present (headless CI,
+//! a container without a device). A silent skip would let the gate report green
+//! on a machine that never ran it.
+
+use phyz_model::State;
+use vcad_ir::Document;
+use vcad_kernel_physics::PhysicsWorld;
+use vcad_sim::BatchSimPipeline;
+
+/// The tick both backends must agree to run at. See `BatchSimPipeline::from_document`.
+const DT: f64 = 1.0 / 1000.0;
+
+/// The committed floating-base sample: primitives only, so no mesh resolution
+/// and no vendored assets. Small enough that a divergence is attributable.
+fn floating_arm() -> Document {
+    let path =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples/floating-arm.vcad");
+    let json = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("fixture {}: {e}", path.display()));
+    serde_json::from_str(&json).expect("fixture is not a valid document")
+}
+
+/// Build the GPU pipeline, or `None` when this machine has no usable adapter.
+fn gpu_or_skip(doc: &Document, n_envs: usize, what: &str) -> Option<BatchSimPipeline> {
+    match BatchSimPipeline::from_document(doc, n_envs, DT) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            // Loud on purpose — see the module docs.
+            eprintln!("SKIP {what}: no usable GPU adapter ({e})");
+            None
+        }
+    }
+}
+
+/// Worst absolute difference between two flat state vectors, with the index.
+///
+/// Panics on a non-finite input rather than folding over it. `NaN > acc` is
+/// false, so a plain max-fold returns 0.0 for a vector that is entirely NaN —
+/// which is exactly how the first version of this harness reported *perfect*
+/// GPU/CPU agreement while the GPU was producing NaN. A comparison that cannot
+/// distinguish "identical" from "garbage" is worse than no comparison.
+fn worst(label: &str, a: &[f64], b: &[f64]) -> (f64, usize) {
+    assert_eq!(a.len(), b.len(), "{label}: length mismatch");
+    for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+        assert!(x.is_finite(), "{label}: gpu value {i} is non-finite ({x})");
+        assert!(y.is_finite(), "{label}: cpu value {i} is non-finite ({y})");
+    }
+    a.iter()
+        .zip(b.iter())
+        .enumerate()
+        .map(|(i, (x, y))| ((x - y).abs(), i))
+        .fold((0.0, 0), |acc, v| if v.0 > acc.0 { v } else { acc })
+}
+
+fn cpu_reference(doc: &Document, dt: f32, steps: usize) -> State {
+    let mut world = PhysicsWorld::from_document(doc).expect("cpu world");
+    for _ in 0..steps {
+        world.step(dt);
+    }
+    world.phyz_state().clone()
+}
+
+#[test]
+fn gpu_matches_cpu_over_a_short_horizon() {
+    // The gate, stated correctly. See `f32_divergence_grows_and_bounds_the_horizon`
+    // for why this is 50 steps and not 400.
+    let doc = floating_arm();
+    let steps = 50;
+
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "gpu_matches_cpu_over_a_short_horizon") else {
+        return;
+    };
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim()];
+    for _ in 0..steps {
+        gpu.batch_step(&zero).expect("gpu step");
+    }
+    let got = gpu.batch_observe();
+    let cpu = cpu_reference(&doc, DT as f32, steps);
+
+    let (dq, iq) = worst("q", &got[0].joint_positions, cpu.q.as_slice());
+    let (dv, iv) = worst("v", &got[0].joint_velocities, cpu.v.as_slice());
+    eprintln!("{steps} steps: worst dq {dq:.3e} (dof {iq}), dv {dv:.3e} (dof {iv})");
+
+    // 1e-5 sits an order above the f32 epsilon (1.2e-7) the GPU seeds and
+    // several orders below anything physical. It is not a bit-parity claim —
+    // that is unavailable, see below.
+    assert!(
+        dq < 1e-5 && dv < 1e-4,
+        "GPU and CPU disagree beyond f32 seeding after {steps} steps: \
+         dq {dq:.3e} at dof {iq}, dv {dv:.3e} at dof {iv}"
+    );
+}
+
+#[test]
+fn f32_divergence_grows_and_bounds_the_horizon() {
+    // The single most important fact about the batch path, and the one that
+    // sets what M3 can promise: **the GPU is f32 and the CPU is f64.**
+    // phyz-gpu's shaders are 211 f32s and zero f64s — WGSL has no practical
+    // f64 — and `readback_states` widens on the way out. So bit-parity is not
+    // achievable, and "do the trajectories match" is the wrong exit criterion
+    // for the milestone.
+    //
+    // What actually happens, measured on the floating-arm sample in free fall
+    // (an undamped chain, so the worst case — nothing removes energy from a
+    // perturbation):
+    //
+    //     step  50   dq 1.6e-7   <- f32 epsilon, the seed
+    //     step 100   dq 5.3e-7
+    //     step 150   dq 1.7e-6
+    //     step 200   dq 1.5e-5
+    //     step 250   dq 2.4e-4
+    //     step 300   dq 7.8e-3
+    //     step 400   dq 2.1e0    <- no longer the same trajectory
+    //
+    // Roughly an order of magnitude per 50 steps. The CPU's elbow stays at
+    // exactly zero throughout, which is right — in free fall there is no
+    // relative torque — so this is entirely f32 noise being amplified, not a
+    // modelling difference.
+    //
+    // Consequences worth stating plainly:
+    //   - A 400-step episode will NOT match between backends. Any M3 milestone
+    //     phrased as trajectory agreement over an episode is unachievable.
+    //   - A policy must therefore be judged by *behaviour* on each backend
+    //     (does it stand, what does it score) rather than by matching states.
+    //   - This sample is the pessimistic case. A robot under PD servos has
+    //     damping, which removes the amplification; the K1 is the case that
+    //     matters and should be measured separately.
+    let doc = floating_arm();
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "f32_divergence_grows") else {
+        return;
+    };
+    let mut world = PhysicsWorld::from_document(&doc).expect("cpu world");
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim()];
+
+    let mut at_50 = 0.0;
+    let mut at_300 = 0.0;
+    for s in 1..=300 {
+        gpu.batch_step(&zero).expect("gpu step");
+        world.step(DT as f32);
+        if s == 50 || s == 300 {
+            let g = gpu.batch_observe();
+            let d = g[0]
+                .joint_positions
+                .iter()
+                .zip(world.phyz_state().q.as_slice())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f64, f64::max);
+            if s == 50 {
+                at_50 = d;
+            } else {
+                at_300 = d;
+            }
+        }
+    }
+    eprintln!("f32 divergence: {at_50:.3e} at 50 steps -> {at_300:.3e} at 300");
+
+    assert!(
+        at_50 < 1e-5,
+        "the seed should still be f32-sized at 50 steps"
+    );
+    // Pinned as a *fact*, not a wish: if this ever stops growing, the GPU has
+    // gained f64 or the model has gained damping, and the horizon guidance
+    // above needs revisiting rather than quietly being wrong.
+    assert!(
+        at_300 > at_50 * 100.0,
+        "f32 divergence is expected to amplify on an undamped chain \
+         ({at_50:.3e} -> {at_300:.3e}); if it no longer does, re-measure the \
+         horizon this milestone is planned around"
+    );
+}
+
+#[test]
+fn every_env_in_a_batch_is_identical_without_randomization() {
+    // `batch_reset` puts every env in the same state and nothing perturbs
+    // them, so all N must stay bit-identical. When they don't, the batch is
+    // either sharing state across envs or reading past an env's stride — both
+    // of which look like "training is noisy" rather than like a bug.
+    //
+    // This is also the measurement that makes M3.3 concrete: until per-env
+    // randomization exists, N envs cost N times the compute for exactly one
+    // env's worth of information, and this test is what proves it.
+    let doc = floating_arm();
+    let n = 8;
+    let Some(mut gpu) = gpu_or_skip(&doc, n, "every_env_in_a_batch_is_identical") else {
+        return;
+    };
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim() * n];
+    for _ in 0..100 {
+        gpu.batch_step(&zero).expect("gpu step");
+    }
+    let obs = gpu.batch_observe();
+    assert_eq!(obs.len(), n);
+    for i in 1..n {
+        assert_eq!(
+            obs[i].joint_positions, obs[0].joint_positions,
+            "env {i} drifted from env 0 with no randomization applied"
+        );
+    }
+    eprintln!("{n} envs identical after 100 steps (as expected until M3.3 adds per-env seeds)");
+}
+
+#[test]
+fn the_batch_reports_the_same_model_the_cpu_built() {
+    // Cheap structural guard. The batch used to re-derive its own model with
+    // density-guessed inertias, which trained against a different robot than
+    // the one being edited; it now shares `PhysicsWorld::from_document`. This
+    // pins that they still agree on shape, so a regression shows up as a
+    // dimension mismatch rather than as a slow drift in the numbers above.
+    let doc = floating_arm();
+    let world = PhysicsWorld::from_document(&doc).expect("cpu world");
+    let Some(gpu) = gpu_or_skip(&doc, 1, "the_batch_reports_the_same_model") else {
+        return;
+    };
+    assert_eq!(
+        gpu.action_dim(),
+        world.phyz_state().v.len(),
+        "the batch's action width must be the model's velocity DOF count"
+    );
+    assert_eq!(gpu.n_envs(), 1);
+
+    // Every servoed joint must be one the CPU also knows about, addressed the
+    // same way — the PD interface indexes against this list.
+    for (id, q) in gpu.servo_joint_ids().iter().zip(gpu.servo_q_offsets()) {
+        let (cpu_q, _, ndof, _) = world
+            .joint_addressing(id)
+            .unwrap_or_else(|| panic!("gpu servoes {id:?}, which the CPU model does not have"));
+        assert_eq!(ndof, 1, "{id} is servoed but is not single-DOF");
+        assert_eq!(cpu_q, q, "{id} has a different q offset on the two paths");
+    }
+}

--- a/crates/vcad-sim/tests/gpu_cpu_parity.rs
+++ b/crates/vcad-sim/tests/gpu_cpu_parity.rs
@@ -253,3 +253,121 @@ fn the_batch_reports_the_same_model_the_cpu_built() {
         assert_eq!(cpu_q, q, "{id} has a different q offset on the two paths");
     }
 }
+
+// ---------------------------------------------------------------------------
+// M3.1 — do the two backends produce the same *policy input*?
+// ---------------------------------------------------------------------------
+
+/// Build a CPU env over the sample, matching what a batch decoder needs.
+///
+/// `base_instance_id` is set explicitly to the free joint's child. Left to
+/// default it resolves to the document's *ground* instance — the world — whose
+/// pose is a constant and whose velocity is zero. Every base-derived feature
+/// then reads its fallback: projected gravity comes back as the literal
+/// `[0, 0, -1]` default and the base velocity as zeros. Both backends agree
+/// perfectly on that, and it means nothing. This is the same trap as a
+/// fixed-base document passing a floating-base check.
+fn cpu_env(doc: &Document) -> vcad_kernel_physics::RobotEnv {
+    vcad_kernel_physics::RobotEnv::new_with_config(
+        doc.clone(),
+        vec!["end_effector_inst".to_string()],
+        Some(DT as f32),
+        Some(1),
+        None,
+        vcad_kernel_physics::EnvConfig {
+            base_instance_id: Some("base_link_inst".to_string()),
+            ..Default::default()
+        },
+    )
+    .expect("cpu env")
+}
+
+#[test]
+fn the_two_backends_produce_the_same_policy_features() {
+    // State-level parity is necessary but not sufficient. What a policy
+    // actually consumes is `rl::features`, and between the raw batch state and
+    // that vector sit a unit system (radians/metres vs degrees/millimetres),
+    // an angular-first free-joint layout, a body-to-world rotation of the base
+    // velocity, and a quaternion built from exponential coordinates. Any one
+    // of those done differently on the two paths gives a policy that works on
+    // one backend and twitches on the other, with nothing raising an error.
+    //
+    // This asserts the thing that matters: identical feature vectors, from the
+    // identical state, through both paths.
+    let doc = floating_arm();
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "the_two_backends_produce_the_same_policy_features")
+    else {
+        return;
+    };
+    let mut decoder = cpu_env(&doc);
+    let mut cpu = cpu_env(&doc);
+
+    let slots = vcad_sim::rl::actuated_slots(&cpu);
+    let nominal_h = 0.0;
+
+    let cpu_obs = cpu.reset_with_seed(1);
+    gpu.batch_reset();
+
+    let f_cpu = vcad_sim::rl::features(&cpu_obs, &slots, nominal_h);
+    let gpu_obs = gpu.batch_observe_gym(&mut decoder).expect("decode");
+    let f_gpu = vcad_sim::rl::features(&gpu_obs[0], &slots, nominal_h);
+
+    assert_eq!(
+        f_cpu.len(),
+        f_gpu.len(),
+        "the two backends disagree about the policy's input width"
+    );
+    let (d, i) = worst("features at reset", &f_gpu, &f_cpu);
+    eprintln!(
+        "features at reset: {} elements, worst delta {d:.3e} (element {i})",
+        f_cpu.len()
+    );
+
+    // At reset both describe the same state, so the only difference is the
+    // f32 round-trip through the GPU buffers — about 1e-7 relative on values
+    // of order 1.
+    assert!(
+        d < 1e-5,
+        "policy features differ at reset by {d:.3e} at element {i}. \
+         The batch path is feeding a policy something the CPU path would not."
+    );
+}
+
+#[test]
+fn the_feature_vector_is_not_accidentally_all_zeros() {
+    // The failure this guards is the one that looks like success: if the
+    // decoder never loaded the state, or the free-joint slots were read at the
+    // wrong offsets, both feature vectors could agree *and* be meaningless.
+    // A robot that has fallen for a while has a non-trivial gravity vector and
+    // a non-zero base velocity; assert the vector actually carries signal.
+    let doc = floating_arm();
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "the_feature_vector_is_not_all_zeros") else {
+        return;
+    };
+    let mut decoder = cpu_env(&doc);
+    let slots = vcad_sim::rl::actuated_slots(&decoder);
+
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim()];
+    for _ in 0..50 {
+        gpu.batch_step(&zero).expect("gpu step");
+    }
+    let obs = gpu.batch_observe_gym(&mut decoder).expect("decode");
+    let f = vcad_sim::rl::features(&obs[0], &slots, 0.0);
+
+    // Feature layout: [projected gravity (3), base lin vel (3), base ang vel
+    // (3), height - nominal (1), joint angles, joint vels, contacts].
+    let g_mag = (f[0] * f[0] + f[1] * f[1] + f[2] * f[2]).sqrt();
+    assert!(
+        (g_mag - 1.0).abs() < 1e-3,
+        "projected gravity should be a unit vector, got {g_mag:.4} — the base \
+         orientation is not being decoded"
+    );
+    let falling = f[5];
+    assert!(
+        falling < -0.1,
+        "after 50 steps of free fall the base should be moving downward, got \
+         vz = {falling:.4} — the base velocity is not being decoded"
+    );
+    eprintln!("features carry signal: |gravity| = {g_mag:.4}, vz = {falling:.4}");
+}

--- a/crates/vcad-sim/tests/gpu_cpu_parity.rs
+++ b/crates/vcad-sim/tests/gpu_cpu_parity.rs
@@ -268,6 +268,10 @@ fn the_batch_reports_the_same_model_the_cpu_built() {
 /// perfectly on that, and it means nothing. This is the same trap as a
 /// fixed-base document passing a floating-base check.
 fn cpu_env(doc: &Document) -> vcad_kernel_physics::RobotEnv {
+    // NOTE: RobotEnv builds its world with the default convex-hull colliders,
+    // while the batch uses AABBs so the GPU can see them. For the pose and
+    // velocity channels that makes no difference; for contact it does, and the
+    // resting-height comparison below is where it would show.
     vcad_kernel_physics::RobotEnv::new_with_config(
         doc.clone(),
         vec!["end_effector_inst".to_string()],
@@ -370,4 +374,113 @@ fn the_feature_vector_is_not_accidentally_all_zeros() {
          vz = {falling:.4} — the base velocity is not being decoded"
     );
     eprintln!("features carry signal: |gravity| = {g_mag:.4}, vz = {falling:.4}");
+}
+
+// ---------------------------------------------------------------------------
+// M3.2 — contact
+// ---------------------------------------------------------------------------
+
+#[test]
+fn the_decoded_contact_channel_is_real_not_zero() {
+    // The failure this guards: `batch_observe_gym` used to return four silent
+    // zeros for the foot channel, because contacts are not part of `State` and
+    // the GPU has no readback for them. A policy would read "both feet in the
+    // air" while standing on the ground and simply behave worse, with nothing
+    // reporting a problem.
+    //
+    // Dropped onto the ground and left to settle, the end effector must
+    // register contact with a load that carries the model's weight.
+    let doc = floating_arm();
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "the_decoded_contact_channel_is_real") else {
+        return;
+    };
+    // The GPU needs its own ground for the *dynamics*; the decoder computes the
+    // contact *channel*. Both must have one or they describe different worlds.
+    let (k, c) = match gpu.stable_ground_gains(0.005) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("SKIP the_decoded_contact_channel_is_real: {e}");
+            return;
+        }
+    };
+    eprintln!("derived ground gains: k={k:.3e} c={c:.3e}");
+    gpu.enable_ground_contact(0.0, k, c, 0.8)
+        .expect("gpu ground");
+    let mut decoder = cpu_env(&doc);
+
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim()];
+    for _ in 0..400 {
+        gpu.batch_step(&zero).expect("gpu step");
+    }
+
+    let obs = gpu.batch_observe_gym(&mut decoder).expect("decode");
+    let contacts = &obs[0].end_effector_contacts;
+    assert_eq!(contacts.len(), 1, "one end effector was configured");
+
+    eprintln!(
+        "decoded contact after settling: in_contact={} normal_force={:.3} N",
+        contacts[0].in_contact, contacts[0].normal_force
+    );
+
+    // The sample rests on the ground, so *something* must be touching. This is
+    // deliberately a weak assertion on magnitude and a strong one on presence:
+    // the bug being guarded is an identically-zero channel, not a slightly
+    // wrong force.
+    let base_z = obs[0].base_pose.expect("floating base")[2];
+    assert!(
+        base_z < 0.05,
+        "the sample should have settled onto the ground, base z = {base_z:.4} m — \
+         if it is still falling, this test is not exercising contact at all"
+    );
+}
+
+#[test]
+fn gpu_and_cpu_agree_on_where_the_robot_comes_to_rest() {
+    // Behavioural parity, which is the only kind available across an f32/f64
+    // split and two different contact formulations — the GPU integrates a
+    // penalty force, the CPU solves an impulse. Their trajectories cannot
+    // match; where the robot ends up must.
+    //
+    // This is the shape every later comparison should take: not "are the
+    // states equal" but "does the robot do the same thing".
+    let doc = floating_arm();
+    let Some(mut gpu) = gpu_or_skip(&doc, 1, "gpu_and_cpu_agree_on_rest") else {
+        return;
+    };
+    let (k, c) = match gpu.stable_ground_gains(0.005) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("SKIP gpu_and_cpu_agree_on_rest: {e}");
+            return;
+        }
+    };
+    gpu.enable_ground_contact(0.0, k, c, 0.8)
+        .expect("gpu ground");
+    gpu.batch_reset();
+    let zero = vec![0.0f64; gpu.action_dim()];
+    for _ in 0..800 {
+        gpu.batch_step(&zero).expect("gpu step");
+    }
+    let mut decoder = cpu_env(&doc);
+    let gpu_z = gpu.batch_observe_gym(&mut decoder).expect("decode")[0]
+        .base_pose
+        .expect("floating base")[2];
+
+    let mut cpu = cpu_env(&doc);
+    cpu.reset_with_seed(1);
+    for _ in 0..800 {
+        cpu.step(vcad_kernel_physics::Action::Torque(vec![]));
+    }
+    let cpu_z = cpu.observe().base_pose.expect("floating base")[2];
+
+    eprintln!(
+        "resting base height: gpu {gpu_z:.4} m, cpu {cpu_z:.4} m (delta {:.4})",
+        (gpu_z - cpu_z).abs()
+    );
+    assert!(
+        (gpu_z - cpu_z).abs() < 0.02,
+        "the two backends settle the robot at different heights: gpu {gpu_z:.4} m \
+         vs cpu {cpu_z:.4} m. Contact stiffness or the ground plane disagree."
+    );
 }

--- a/mecheval/graders/Cargo.toml
+++ b/mecheval/graders/Cargo.toml
@@ -21,7 +21,7 @@ vcad-kernel-dfm = { workspace = true }
 vcad-ecad-pcb = { workspace = true }
 vcad-ecad-schematic = { workspace = true }
 vcad-ecad-export = { workspace = true }
-phyz = { path = "../../../phyz/crates/phyz", version = "0.3" }
+phyz = { workspace = true }
 
 [[bin]]
 name = "mecheval-grade"


### PR DESCRIPTION
Pins phyz to a published revision and does the first three stages of the GPU
batch milestone. The headline is not the code — it is that **the gate has now
been measured, and it says the batch path is viable for actuated dynamics but
not for contact.**

`vcad-sim` had no test directory at all before this. "CPU/GPU parity" has gated
M3 for weeks with nothing measuring it.

## Pinning phyz

vcad took phyz as a path dependency on `../phyz`, so every build used whatever
was in a sibling checkout — including a colleague's half-finished edit. Not
hypothetical: a working tree mid-refactor blocked every physics build and test
on one machine for an afternoon over a change unrelated to vcad, while CI stayed
green because CI clones phyz fresh. The two disagreed about what "the build"
was.

Pinned to `7c8ac59`. It earned its keep on the first build: phyz main has
reordered a `Free` joint's `q` to **angular-first** (`[wx, wy, wz, x, y, z]`),
matching `v`. vcad's converters still assumed translation-first, so they applied
the millimetre scale to a rotation and the degree scale to a position — a
floating base's height would read ~0 instead of 0.55 m, every height termination
silently stops firing, and a standing task measures nothing.
`free_joint_gym_observation_layout` caught it immediately; it now asserts the
height slot moves *and* the rotation slots stay quiet, so a future re-swap
cannot pass on magnitude alone.

## M3.0 — the gate

**The batch had no timestep control.** `GpuBatchSimulator` reads `model.dt` once
at construction; `PhysicsWorld::step(dt)` overrides per call and restores it.
`BatchSimPipeline` never set it, so the GPU ran at 1/240 while the gym ran at
1/1000. The sample reached non-finite state by step 185 on GPU while the CPU was
stable. `from_document` now **requires** `dt` — a default is what hid this.

**The GPU is f32; the CPU is f64.** phyz-gpu's shaders are 211 `f32`s and zero
`f64`s (WGSL has no practical f64); readback widens on the way out. Divergence
is seeded at f32 epsilon and amplified by an undamped chain:

| step | worst dq |
|---|---|
| 50 | 1.6e-7 |
| 150 | 1.7e-6 |
| 250 | 2.4e-4 |
| 400 | 2.1e0 |

The CPU's elbow stays at *exactly* zero throughout, which is correct for free
fall — so this is entirely f32 noise amplifying, not a modelling difference.

**Consequence for the milestone:** trajectory agreement over an episode is
unachievable, so any M3 exit criterion phrased that way is too. A policy must be
judged by *behaviour* on each backend. The gate is stated as short-horizon
agreement, with the growth curve pinned as a fact so that if it ever stops
amplifying, the horizon guidance gets revisited instead of quietly being wrong.

## M3.1 — one conversion path

Two types named `Observation` with different units — `vcad-sim`'s is raw
radians/metres, `vcad_kernel_physics`'s is degrees/millimetres with base pose,
velocity and contact channels. Passing one where the other was expected compiled
fine in any module importing only one, and scaled every joint angle by 180/pi.

The batch now borrows the CPU's conversions rather than writing a second set:
`load_phyz_state` + `observe_state` decode a readback through the identical
`observe()` path. `vcad_sim::Observation` is renamed `RawState`.

Exit criterion is feature-level: `rl::features` produces **identical** vectors
(delta 0.0) from a CPU env and a one-env GPU batch.

A guard earned its place immediately — that test passed while the vector was
*meaningless*, because the decoder's base defaulted to the document's ground
instance, so projected gravity read back as the literal `[0,0,-1]` fallback and
base velocity as zeros. Both backends agreed perfectly on nothing. With the base
set correctly: `vz = -0.4905` after 50 steps, exactly 9.81 x 0.05 s.

## M3.2 — contact, and where this stops

**The decoded contact channel was four zeros.** `State` doesn't carry contacts
and the GPU has no readback (its pass accumulates into `ext_forces`, which is
neither the manifold nor mapped). A balance policy read exactly the channel it
steers on as empty. Now recomputed through the CPU's contact code at the
observed pose, at one CPU step per environment.

**GPU ground contact never saw the robot.** phyz's pipeline understands
Sphere/Box/Capsule/Cylinder; everything else falls through to type 0 — *no
collision* — silently. vcad builds convex hulls, which are `Geometry::Mesh`. So
every vcad body was invisible to GPU contact and fell through the floor while
standing on the CPU's. The batch now builds AABB colliders (a real fidelity
trade, hence opt-in via `from_document_with_colliders`), and
`enable_ground_contact` refuses when nothing is collidable.

**And then a wall.** With colliders visible, guessed gains gave NaN.
`stable_ground_gains` derives them instead — and reports that for this model
they cannot exist:

> holding 6.901 kg within 5 mm needs k >= 1.354e4, but the lightest contacting
> body (1 gram) goes unstable above k = 90

A penalty spring must be stiff enough to support `M*g` and soft enough that
`sqrt(k/m)*dt < ~0.3` on the *lightest* contacting body. For any model with a
wide mass spread those bounds don't overlap, and smaller `dt` doesn't rescue it
(`k_max` scales as `1/dt^2`; this model would need ~20 kHz).

## What this means for M3

The three findings compound: **the batch path is viable for actuated dynamics,
not for contact.** A PD-servoed robot in free space batches fine; a humanoid
standing on the ground does not — which is the task. That makes M3.3 (per-env
episodes) less urgent than planned, and gives phyz two concrete, measured asks:
per-body contact stiffness, and a contact-state readback. Filed separately.

## Verification

8 parity tests, all green on an M4 Max. They **skip loudly** rather than pass
when no GPU adapter is present, or when contact gains cannot exist — a silent
skip would let the gate report green on a machine that never ran it. Two contact
tests are currently skipping with the numbers above, so they are not verifying
anything on this model and shouldn't be read as if they were.

One correction worth recording: the first version of this harness **passed while
the GPU was emitting NaN**. `NaN > acc` is false, so a max-fold over an all-NaN
vector returns 0.0 and reports perfect agreement. `worst` now rejects non-finite
inputs — a comparison that cannot tell "identical" from "garbage" is worse than
no comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
