### PR TITLE
fix(tessellate): stitch T-junctions closed, keeping analytic surfaces

### DIFF
--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -667,6 +667,180 @@ fn computed_vertex_normals(vertices: &[f32], indices: &[u32]) -> Vec<f32> {
     acc
 }
 
+/// Distance (mm) within which a vertex counts as lying on a triangle edge.
+///
+/// Matches [`weld_coincident_vertices`]'s 0.001 mm lattice: a point closer
+/// than that to an edge would already have been welded onto its endpoint if
+/// it were meant to be one, so anything still standing off the edge by less
+/// than this is a genuine T-junction rather than a distinct vertex.
+const T_JUNCTION_TOL: f64 = 1e-3;
+
+/// Stitch T-junctions closed.
+///
+/// A T-junction is a vertex sitting in the *interior* of another triangle's
+/// edge. The surface has no actual gap there — the two sides meet exactly —
+/// but the edge is unpaired combinatorially, so every watertightness check
+/// (and every consumer that needs a closed shell: STL for printing, STEP,
+/// ray tracing) reads it as a hole.
+///
+/// They arise wherever the boolean splitters conform one side of a shared
+/// edge and not the other, which is routine on curved faces. Healing them
+/// here rather than in the boolean is what lets the result keep its analytic
+/// surfaces: the alternative — swapping the solid for a re-meshed triangle
+/// soup — closes the same cracks but throws away the cylinders and spheres
+/// downstream code depends on.
+///
+/// The repair is exact, not a tolerance fudge. It only ever inserts a vertex
+/// that already lies on the edge it splits, so no position moves and no
+/// volume changes; only which triangles agree along that edge does.
+///
+/// Triangles that gain edge points are re-emitted as a centroid fan. A fan
+/// from an existing corner would be cheaper, but when the points sit on an
+/// edge adjacent to that corner it emits exactly-degenerate triangles, whose
+/// zero-length normals surface downstream as `DIRECTION((NaN,NaN,NaN))` in
+/// the STEP writer. The centroid lies strictly inside, so every fan triangle
+/// has area; it inherits the interpolated normal and the face-kind tag of the
+/// triangle it replaces.
+fn heal_t_junctions(mesh: &mut TriangleMesh) {
+    // Fast path: a closed mesh has nothing to stitch, and this is the common
+    // case, so it must cost no more than the edge-pairing pass.
+    let open = mesh.boundary_edges();
+    if open.is_empty() || mesh.indices.is_empty() {
+        return;
+    }
+
+    // Only vertices that terminate an open edge can close one, which is a
+    // handful even on a badly cracked mesh — far cheaper than testing every
+    // vertex against every edge.
+    let mut candidates: Vec<u32> = Vec::new();
+    {
+        let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
+        for &(a, b) in &open {
+            for v in [a, b] {
+                if seen.insert(v) {
+                    candidates.push(v);
+                }
+            }
+        }
+    }
+    let pos = |i: u32| -> [f64; 3] {
+        let k = i as usize * 3;
+        [
+            mesh.vertices[k] as f64,
+            mesh.vertices[k + 1] as f64,
+            mesh.vertices[k + 2] as f64,
+        ]
+    };
+
+    let has_normals = mesh.normals.len() == mesh.vertices.len();
+    let has_kinds = mesh.face_kinds.len() == mesh.indices.len() / 3;
+    let mut new_indices: Vec<u32> = Vec::with_capacity(mesh.indices.len());
+    let mut new_kinds: Vec<u8> = Vec::new();
+    let mut added_verts: Vec<f32> = Vec::new();
+    let mut added_normals: Vec<f32> = Vec::new();
+    let base_vert_count = mesh.num_vertices() as u32;
+    let mut healed = 0usize;
+
+    for t in 0..mesh.indices.len() / 3 {
+        let corners = [
+            mesh.indices[t * 3],
+            mesh.indices[t * 3 + 1],
+            mesh.indices[t * 3 + 2],
+        ];
+        let kind = if has_kinds { mesh.face_kinds[t] } else { 0 };
+        let mut loop_idx: Vec<u32> = Vec::with_capacity(3);
+        let mut inserted = false;
+
+        for e in 0..3 {
+            let (ai, bi) = (corners[e], corners[(e + 1) % 3]);
+            loop_idx.push(ai);
+            let (a, b) = (pos(ai), pos(bi));
+            let ab = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let len2 = ab[0] * ab[0] + ab[1] * ab[1] + ab[2] * ab[2];
+            if len2 <= 0.0 {
+                continue;
+            }
+            let mut on_edge: Vec<(f64, u32)> = Vec::new();
+            for &vi in &candidates {
+                if vi == ai || vi == bi {
+                    continue;
+                }
+                let v = pos(vi);
+                let av = [v[0] - a[0], v[1] - a[1], v[2] - a[2]];
+                let s = (av[0] * ab[0] + av[1] * ab[1] + av[2] * ab[2]) / len2;
+                if s <= 0.0 || s >= 1.0 {
+                    continue;
+                }
+                let c = [a[0] + s * ab[0], a[1] + s * ab[1], a[2] + s * ab[2]];
+                let d2 = (v[0] - c[0]).powi(2) + (v[1] - c[1]).powi(2) + (v[2] - c[2]).powi(2);
+                if d2 > T_JUNCTION_TOL * T_JUNCTION_TOL {
+                    continue;
+                }
+                on_edge.push((s, vi));
+            }
+            if on_edge.is_empty() {
+                continue;
+            }
+            on_edge.sort_by(|x, y| x.0.total_cmp(&y.0));
+            on_edge.dedup_by_key(|(_, vi)| *vi);
+            inserted = true;
+            loop_idx.extend(on_edge.into_iter().map(|(_, vi)| vi));
+        }
+
+        if !inserted {
+            new_indices.extend_from_slice(&corners);
+            if has_kinds {
+                new_kinds.push(kind);
+            }
+            continue;
+        }
+        healed += 1;
+
+        // Centroid of the original triangle: strictly interior, so every fan
+        // triangle has area.
+        let (p0, p1, p2) = (pos(corners[0]), pos(corners[1]), pos(corners[2]));
+        let ci = base_vert_count + (added_verts.len() / 3) as u32;
+        for k in 0..3 {
+            added_verts.push(((p0[k] + p1[k] + p2[k]) / 3.0) as f32);
+        }
+        if has_normals {
+            let mut n = [0.0f32; 3];
+            for c in corners {
+                for (k, acc) in n.iter_mut().enumerate() {
+                    *acc += mesh.normals[c as usize * 3 + k];
+                }
+            }
+            let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            for c in n {
+                added_normals.push(if len > 0.0 { c / len } else { 0.0 });
+            }
+        }
+        let n = loop_idx.len();
+        for k in 0..n {
+            let (a, b) = (loop_idx[k], loop_idx[(k + 1) % n]);
+            if a == b {
+                continue;
+            }
+            new_indices.extend_from_slice(&[ci, a, b]);
+            if has_kinds {
+                new_kinds.push(kind);
+            }
+        }
+    }
+
+    if healed == 0 {
+        return;
+    }
+    mesh.vertices.extend_from_slice(&added_verts);
+    if has_normals {
+        mesh.normals.extend_from_slice(&added_normals);
+    }
+    mesh.indices = new_indices;
+    if has_kinds {
+        mesh.face_kinds = new_kinds;
+    }
+}
+
 /// Collapse mesh vertices that share a position to 3 decimal places.
 /// Indices are rewritten; positions kept from the first occurrence.
 /// Normals of the winning vertex are kept as-is — downstream smoothing is
@@ -5192,6 +5366,7 @@ pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
     }
 
     weld_coincident_vertices(&mut mesh);
+    heal_t_junctions(&mut mesh);
     fill_tiny_boundary_loops(&mut mesh, 6, &sphere_vert_keys);
     mesh
 }


### PR DESCRIPTION
Stacked on #789 — **base is `claude/vcad-difference-boolean-bug-0b6b4e`, not `main`.** Review #789 first; this diff is one commit on top of it.

## What this does

`tessellate_brep` now stitches T-junctions closed. A T-junction is a vertex sitting in the *interior* of another triangle's edge: the surface has no actual gap there, the two sides meet exactly, but the edge is unpaired combinatorially, so every watertightness check — and every consumer needing a closed shell (STL for printing, STEP, ray tracing) — reads it as a hole.

The repair is exact rather than a tolerance fudge: it only ever inserts a vertex that **already lies** on the edge it splits, so no position moves and no volume changes; only which triangles agree along that edge does. Triangles that gain edge points are re-emitted as a centroid fan — a fan from an existing corner emits exactly-degenerate triangles whose zero normals surface downstream as `DIRECTION((NaN,NaN,NaN))` in the STEP writer. Normals and face-kind tags are carried through, and closed meshes take an early out.

Healing at tessellation time is the point: it closes cracks while the solid keeps its analytic surfaces. #789's only tool for this was swapping the solid for a re-meshed triangle soup, which closes the same cracks but discards the cylinders and spheres downstream code depends on — and two existing tests (`b1_result_cylinder_faces_are_bands_or_slivers`, the interdigitated-comb fast path) exist precisely to stop that.

## Honest scope: this does **not** close the gap it was aimed at

I opened this expecting to recover the ~34 torture cases that are cracked on *analytic* arrangements (657 → ~691 pass), where #789 deliberately declines to swap in the mesh fallback. **It recovers one** (`rand-155`). The hypothesis that those cases are T-junction cracks is wrong, and the measurement says so clearly:

| case | open edges | T-junction-like | longest open edge | odd-degree verts | divergence vol | parity-sampled vol | ratio |
|---|---|---|---|---|---|---|---|
| `rand-002` | 155 | 15 | 9.91 mm | 2 | 610.1 | 1043.3 | **0.585** |
| `rand-030` | 136 | 14 | 6.88 mm | 2 | 2227.4 | 3379.1 | **0.659** |

Only ~10% of the open edges have any vertex lying on them, the longest is a full-scale edge rather than a hairline seam, and just two vertices have odd degree — the open edges chain into large closed loops. Decisively, the divergence-theorem volume runs **34–41% below** the parity-sampled volume: those meshes are not merely cracked, **whole surface patches are absent**. No amount of seam stitching can add geometry that was never emitted.

Rendering the failing meshes with their open edges highlighted pinned the real defect: both cases are booleans against a **razor-thin cylinder** (the corpus's `cyl-flat`: r = 50 mm, h = 0.01 mm). The open boundaries chain into the disc's full rim circle plus unsewn partial rectangles on the crossed box faces — the disc's caps survive, but the 0.01 mm-tall **wall band connecting them is never emitted**, and the planar splits around it are left unsewn. The missing volume is the entire lens-shaped interface of a near-degenerate solid, which no seam stitch can restore.

That defect is pre-existing and unrelated to #789 — `rand-002`, `rand-030`, `chain-02`, `rand-086` and `rand-130` are all `bad-geometry` in the pre-PR baseline. It lives in the boolean band/sewing machinery (a curved-face analogue of the existing `split_thin_face_at_curve_vertices` thin-face fallback, which covers ~0.5 mm planar faces — 50× thicker than this), and wants its own change.

## Verification

- Full torture track: **658 pass** (from 657), 1 improvement, **0 regressions**.
- `vcad-kernel-tessellate`, `vcad-kernel-booleans`, `vcad-kernel` suites pass; clippy and fmt clean.
- No measurable cost: the torture run (752 booleans, thousands of tessellations) is unchanged at ~1.5 s, since a closed mesh exits after the edge-pairing pass.

## Reviewer note

The honest question is whether +1 case justifies an extra `O(E)` edge-pairing pass on every `tessellate_brep` call. My read is yes on correctness grounds rather than on the torture number — unpaired edges on an otherwise-sound solid are a real export defect, and this removes a whole class of them at the point where they can still be fixed without giving up analytic geometry. If you disagree, this is a clean single commit to drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
