### PR TITLE
fix(booleans): cone booleans through the apex plane no longer drop the wall band

### DIFF
--- a/changelog/entries/2026-08-11-cone-boolean-rulings.json
+++ b/changelog/entries/2026-08-11-cone-boolean-rulings.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-08-11-cone-boolean-rulings",
+  "version": "0.9.4",
+  "date": "2026-08-11",
+  "category": "fix",
+  "title": "Cone booleans: apex-plane rulings and frozen rims",
+  "summary": "Booleans against cones no longer drop the lateral wall when a face plane passes through the cone axis; cone rims now freeze onto the canonical grid like cylinders.",
+  "features": ["booleans", "kernel"]
+}

--- a/crates/vcad-kernel-booleans/src/freeze.rs
+++ b/crates/vcad-kernel-booleans/src/freeze.rs
@@ -62,25 +62,33 @@ pub(crate) fn freeze_circle_loops(brep: &mut BRepSolid, segments: u32) {
         }
         let twin = he.twin;
 
-        // Find the cylinder that carries this circle (own face or twin's).
-        let cyl_of = |hid: HalfEdgeId| -> Option<CylinderSurface> {
+        // Find the cylinder or cone that carries this circle (own face or
+        // twin's). Both carry rings perpendicular to their axis; all the
+        // machinery below needs is the axis direction and a point on it.
+        let axis_of = |hid: HalfEdgeId| -> Option<(Vec3, vcad_kernel_math::Point3)> {
             let lp = brep.topology.half_edges[hid].loop_id?;
             let face_id = brep.topology.loops[lp].face?;
             let face = &brep.topology.faces[face_id];
-            brep.geometry.surfaces[face.surface_index]
+            let surface = &brep.geometry.surfaces[face.surface_index];
+            if let Some(cyl) = surface.as_any().downcast_ref::<CylinderSurface>() {
+                return Some((*cyl.axis.as_ref(), cyl.center));
+            }
+            if let Some(cone) = surface
                 .as_any()
-                .downcast_ref::<CylinderSurface>()
-                .cloned()
+                .downcast_ref::<vcad_kernel_geom::ConeSurface>()
+            {
+                return Some((*cone.axis.as_ref(), cone.apex));
+            }
+            None
         };
-        let cyl = match cyl_of(he_id).or_else(|| twin.and_then(cyl_of)) {
+        let (axis, axis_pt) = match axis_of(he_id).or_else(|| twin.and_then(axis_of)) {
             Some(c) => c,
-            None => continue, // sphere poles, cone apex rings, etc. — skip
+            None => continue, // sphere poles etc. — skip
         };
 
         let v_pt = brep.topology.vertices[origin].point;
-        let axis = *cyl.axis.as_ref();
-        let d = v_pt - cyl.center;
-        let center = cyl.center + axis * d.dot(axis);
+        let d = v_pt - axis_pt;
+        let center = axis_pt + axis * d.dot(axis);
         let radius = (v_pt - center).norm();
         if radius < 1e-9 {
             continue;
@@ -136,7 +144,7 @@ pub(crate) fn freeze_circle_loops(brep: &mut BRepSolid, segments: u32) {
                     let mut vmin = f64::MAX;
                     for h in brep.topology.loop_half_edges(l) {
                         let p = brep.topology.vertices[brep.topology.half_edges[h].origin].point;
-                        vmin = vmin.min((p - cyl.center).dot(axis));
+                        vmin = vmin.min((p - axis_pt).dot(axis));
                     }
                     (d.dot(axis) - vmin).abs() < 1e-6
                 })

--- a/crates/vcad-kernel-booleans/src/pipeline.rs
+++ b/crates/vcad-kernel-booleans/src/pipeline.rs
@@ -172,7 +172,7 @@ fn apply_splits_to_solid(
     ordered.sort_by_key(|(fid, _)| *fid);
     for (face_id, split_list) in ordered {
         let mut current_faces = vec![face_id];
-        for (curve, _entry, _exit) in split_list {
+        for (curve, entry, exit) in split_list {
             let mut new_faces = Vec::new();
             for &fid in &current_faces {
                 if solid.topology.faces.contains_key(fid) {
@@ -194,7 +194,8 @@ fn apply_splits_to_solid(
                                 _ => format!("{:?}", curve),
                             }
                         );
-                        let result = split::split_conical_face(solid, fid, &curve);
+                        let result =
+                            split::split_conical_face(solid, fid, &curve, &entry, &exit, segments);
                         debug_bool!(
                             "    -> Conical split result: {} sub-faces {:?}",
                             result.sub_faces.len(),
@@ -921,15 +922,53 @@ pub(crate) fn brep_boolean(
             for single_curve in &curves_to_process {
                 // Trim curve to A's face boundary (for non-circle curves)
                 let segs_a = trim::trim_curve_to_face(single_curve, face_a, &a, 64);
+                // Trimmed to B up-front too: a conical face must only be
+                // split where the curve lies on BOTH faces (see below).
+                let segs_b = trim::trim_curve_to_face(single_curve, face_b, &b, 64);
+                // A ruling (Line) on a cone spans the cone's entire lateral
+                // face, but the split it demands only exists where the other
+                // face actually meets the cone. Recording the full-extent
+                // segment splits sub-bands the cut never reaches (e.g. the
+                // part of a tall cone above a short box), whose rim corners
+                // then have no counterpart on the neighboring cap — an open
+                // T-junction. Clip the conical side's interval to the other
+                // side's. Planar faces keep the full chord: a planar split
+                // must reach the face boundary to partition the face.
+                let clip_to = |segs: &[trim::TrimmedSegment],
+                               other: &[trim::TrimmedSegment]|
+                 -> Vec<(f64, f64)> {
+                    let mut out = Vec::new();
+                    for s in segs {
+                        for o in other {
+                            let lo = s.t_start.max(o.t_start);
+                            let hi = s.t_end.min(o.t_end);
+                            if hi > lo {
+                                out.push((lo, hi));
+                            }
+                        }
+                    }
+                    out
+                };
+                let line_curve = matches!(single_curve, ssi::IntersectionCurve::Line(_));
+                let clipped_a: Option<Vec<(f64, f64)>> = (line_curve
+                    && split::is_conical_face(&a, face_a))
+                .then(|| clip_to(&segs_a, &segs_b));
+                let clipped_b: Option<Vec<(f64, f64)>> = (line_curve
+                    && split::is_conical_face(&b, face_b))
+                .then(|| clip_to(&segs_b, &segs_a));
                 debug_bool!(
                     "    Trim to face A ({:?}): {} segments",
                     face_a,
                     segs_a.len()
                 );
                 let mut recorded_a = false;
-                for seg in &segs_a {
-                    let entry = evaluate_curve(single_curve, seg.t_start);
-                    let exit = evaluate_curve(single_curve, seg.t_end);
+                let intervals_a: Vec<(f64, f64)> = match &clipped_a {
+                    Some(c) => c.clone(),
+                    None => segs_a.iter().map(|s| (s.t_start, s.t_end)).collect(),
+                };
+                for &(t_start, t_end) in &intervals_a {
+                    let entry = evaluate_curve(single_curve, t_start);
+                    let exit = evaluate_curve(single_curve, t_end);
                     let len = (exit - entry).norm();
                     debug_bool!(
                     "      Segment: entry=({:.2},{:.2},{:.2}) exit=({:.2},{:.2},{:.2}) len={:.4}",
@@ -979,17 +1018,19 @@ pub(crate) fn brep_boolean(
                     }
                 }
 
-                // Trim curve to B's face boundary (for non-circle curves)
-                let segs_b = trim::trim_curve_to_face(single_curve, face_b, &b, 64);
                 debug_bool!(
                     "    Trim to face B ({:?}): {} segments",
                     face_b,
                     segs_b.len()
                 );
                 let mut recorded_b = false;
-                for seg in &segs_b {
-                    let entry = evaluate_curve(single_curve, seg.t_start);
-                    let exit = evaluate_curve(single_curve, seg.t_end);
+                let intervals_b: Vec<(f64, f64)> = match &clipped_b {
+                    Some(c) => c.clone(),
+                    None => segs_b.iter().map(|s| (s.t_start, s.t_end)).collect(),
+                };
+                for &(t_start, t_end) in &intervals_b {
+                    let entry = evaluate_curve(single_curve, t_start);
+                    let exit = evaluate_curve(single_curve, t_end);
                     let len = (exit - entry).norm();
                     debug_bool!(
                     "      Segment: entry=({:.2},{:.2},{:.2}) exit=({:.2},{:.2},{:.2}) len={:.4}",

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -799,19 +799,32 @@ pub fn circle_on_cylinder_wall(other: &BRepSolid, circle: &vcad_kernel_geom::Cir
         .cross(circle.y_dir.into_inner())
         .normalize();
     other.geometry.surfaces.iter().any(|s| {
-        let Some(cyl) = s
+        if let Some(cyl) = s
             .as_any()
             .downcast_ref::<vcad_kernel_geom::CylinderSurface>()
-        else {
-            return false;
-        };
-        let axis = cyl.axis.into_inner();
-        if axis.cross(n).norm() > 1e-6 {
-            return false;
+        {
+            let axis = cyl.axis.into_inner();
+            if axis.cross(n).norm() > 1e-6 {
+                return false;
+            }
+            let d = circle.center - cyl.center;
+            let radial = d - axis * d.dot(axis);
+            return radial.norm() < 1e-6 && (cyl.radius - circle.radius).abs() < 1e-6;
         }
-        let d = circle.center - cyl.center;
-        let radial = d - axis * d.dot(axis);
-        radial.norm() < 1e-6 && (cyl.radius - circle.radius).abs() < 1e-6
+        // Cone walls carry canonical (frozen) rims too: a constant-v circle
+        // on a cone must ride the same canonical grid the frozen band and
+        // its splits use, or the planar hole ring can never conform.
+        if let Some(cone) = s.as_any().downcast_ref::<vcad_kernel_geom::ConeSurface>() {
+            let axis = cone.axis.into_inner();
+            if axis.cross(n).norm() > 1e-6 {
+                return false;
+            }
+            let d = circle.center - cone.apex;
+            let radial = d - axis * d.dot(axis);
+            let r_at = d.dot(axis) * cone.half_angle.tan();
+            return radial.norm() < 1e-6 && (r_at - circle.radius).abs() < 1e-6 && r_at > 1e-9;
+        }
+        false
     })
 }
 
@@ -3484,21 +3497,641 @@ pub fn split_conical_face(
     brep: &mut BRepSolid,
     face_id: FaceId,
     curve: &IntersectionCurve,
+    entry: &Point3,
+    exit: &Point3,
+    segments: u32,
 ) -> SplitResult {
     match curve {
-        IntersectionCurve::Circle(circle) => split_conical_face_by_circle(brep, face_id, circle),
-        IntersectionCurve::Sampled(_) | IntersectionCurve::Line(_) => SplitResult {
+        IntersectionCurve::Circle(circle) => {
+            split_conical_face_by_circle(brep, face_id, circle, segments)
+        }
+        IntersectionCurve::Line(line) => {
+            split_conical_face_by_ruling(brep, face_id, line, entry, exit, segments)
+        }
+        IntersectionCurve::Sampled(_) => SplitResult {
             sub_faces: vec![face_id],
         },
         IntersectionCurve::Empty | IntersectionCurve::Point(_) => SplitResult {
             sub_faces: vec![face_id],
         },
-        IntersectionCurve::TwoLines(line1, _line2) => {
-            split_conical_face(brep, face_id, &IntersectionCurve::Line(line1.clone()))
-        }
+        IntersectionCurve::TwoLines(line1, _line2) => split_conical_face(
+            brep,
+            face_id,
+            &IntersectionCurve::Line(line1.clone()),
+            entry,
+            exit,
+            segments,
+        ),
         IntersectionCurve::TwoSampled(_, _) => SplitResult {
             sub_faces: vec![face_id],
         },
+    }
+}
+
+/// Split a conical face along a ruling (a straight line through the apex,
+/// lying on the cone surface — the intersection of the cone with a plane
+/// through its apex, e.g. a box side plane containing the cone axis).
+///
+/// In the cone's UV space `[0, 2π] × [v_min, v_max]` a ruling is a vertical
+/// line at constant `u = u_split`, exactly like an axis-parallel line on a
+/// cylinder. Mirrors `split_cylindrical_face_by_line`: the rim arcs of the
+/// two sub-faces are emitted as DENSE canonical chains
+/// (`canonical_arc_points` on each rim circle) so they conform vertex-for-
+/// vertex with the neighboring cap faces' arcs.
+///
+/// Handles full lateral frustum faces (degenerate seam loop) and sector
+/// faces from previous ruling splits (dense two-rim loops). Pointed cones
+/// (a rim collapsed to the apex) are declined and returned unsplit.
+fn split_conical_face_by_ruling(
+    brep: &mut BRepSolid,
+    face_id: FaceId,
+    line: &vcad_kernel_geom::Line3d,
+    entry: &Point3,
+    exit: &Point3,
+    segments: u32,
+) -> SplitResult {
+    use std::f64::consts::PI;
+    macro_rules! unsplit {
+        ($fid:expr) => {{
+            split_dbg!("by_ruling declined at split.rs:{}", line!());
+            return SplitResult {
+                sub_faces: vec![$fid],
+            };
+        }};
+    }
+    let face = &brep.topology.faces[face_id];
+    let surface_index = face.surface_index;
+    let orientation = face.orientation;
+    let cone = match brep.geometry.surfaces[surface_index]
+        .as_any()
+        .downcast_ref::<vcad_kernel_geom::ConeSurface>()
+    {
+        Some(c) => c.clone(),
+        None => unsplit!(face_id),
+    };
+
+    let axis = *cone.axis.as_ref();
+    let ref_dir = *cone.ref_dir.as_ref();
+    let y_dir = axis.cross(ref_dir);
+    let ca = cone.half_angle.cos();
+    let sa = cone.half_angle.sin();
+
+    // The line must be a ruling: through the apex, at the cone's half-angle
+    // to the axis (on the positive-v side).
+    let mut dir = line.direction.normalize();
+    if dir.dot(axis) < 0.0 {
+        dir = -dir;
+    }
+    if (dir.dot(axis) - ca).abs() > 1e-6 {
+        unsplit!(face_id);
+    }
+    let apex_off = cone.apex - line.origin;
+    if (apex_off - apex_off.dot(dir) * dir).norm() > 1e-6 {
+        unsplit!(face_id);
+    }
+    let dir_perp = dir - dir.dot(axis) * axis;
+    let u_split = {
+        let u = dir_perp.dot(y_dir).atan2(dir_perp.dot(ref_dir));
+        if u < 0.0 {
+            u + 2.0 * PI
+        } else {
+            u
+        }
+    };
+
+    let cone_u = |p: &Point3| -> Option<f64> {
+        let d = *p - cone.apex;
+        let d_perp = d - d.dot(axis) * axis;
+        if d_perp.norm() < 1e-9 {
+            return None; // apex vertex, u undefined
+        }
+        let u = d_perp.dot(y_dir).atan2(d_perp.dot(ref_dir));
+        Some(if u < 0.0 { u + 2.0 * PI } else { u })
+    };
+    let cone_v = |p: &Point3| -> f64 { (*p - cone.apex).dot(axis) / ca };
+
+    // Collect the loop's unique vertices with (v, u).
+    let loop_hes: Vec<_> = brep.topology.loop_half_edges(face.outer_loop).collect();
+    if loop_hes.is_empty() {
+        unsplit!(face_id);
+    }
+    let mut all_verts: Vec<(vcad_kernel_topo::VertexId, f64, f64)> = Vec::new();
+    let mut v_min = f64::INFINITY;
+    let mut v_max = f64::NEG_INFINITY;
+    for &he_id in &loop_hes {
+        let vid = brep.topology.half_edges[he_id].origin;
+        let point = brep.topology.vertices[vid].point;
+        let v = cone_v(&point);
+        v_min = v_min.min(v);
+        v_max = v_max.max(v);
+        if !all_verts.iter().any(|(id, _, _)| *id == vid) {
+            let Some(u) = cone_u(&point) else {
+                // Pointed cone (rim collapsed to the apex) — decline.
+                unsplit!(face_id);
+            };
+            all_verts.push((vid, v, u));
+        }
+    }
+    if v_max - v_min < 1e-9 || v_min < 1e-9 {
+        unsplit!(face_id);
+    }
+
+    // The recorded segment [entry, exit] is the stretch of the ruling that
+    // lies on BOTH intersecting faces (clipped at record time). A sub-band
+    // the cut never reaches must stay unsplit: splitting it would put rim
+    // corner vertices on its rims that the neighboring cap faces (which the
+    // cut also never reaches) don't carry — an open T-junction.
+    {
+        let v_entry = cone_v(entry);
+        let v_exit = cone_v(exit);
+        let (seg_lo, seg_hi) = (v_entry.min(v_exit), v_entry.max(v_exit));
+        if seg_hi < v_min + 1e-6 || seg_lo > v_max - 1e-6 {
+            unsplit!(face_id);
+        }
+    }
+
+    let bottom_verts: Vec<_> = all_verts
+        .iter()
+        .filter(|(_, v, _)| (*v - v_min).abs() < 1e-6)
+        .cloned()
+        .collect();
+    let top_verts: Vec<_> = all_verts
+        .iter()
+        .filter(|(_, v, _)| (*v - v_max).abs() < 1e-6)
+        .cloned()
+        .collect();
+    // Every loop vertex must sit on one of the two rims (constant-v rims are
+    // the only shape this splitter produces or understands).
+    if bottom_verts.len() + top_verts.len() != all_verts.len() {
+        unsplit!(face_id);
+    }
+
+    // Determine the face's u-extent and its four corner vertices.
+    let (u_start, u_end, v_start_bot, v_end_bot, v_start_top, v_end_top, is_full_face) =
+        if bottom_verts.len() == 1 && top_verts.len() == 1 {
+            // Full lateral face: degenerate seam loop, u spans the whole turn.
+            let seam_u = bottom_verts[0].2;
+            (
+                seam_u,
+                seam_u + 2.0 * PI,
+                bottom_verts[0].0,
+                bottom_verts[0].0,
+                top_verts[0].0,
+                top_verts[0].0,
+                true,
+            )
+        } else if bottom_verts.len() >= 2 && top_verts.len() >= 2 {
+            // Sector face (possibly with dense rim chains): walk the loop to
+            // find its corners — a corner is a rim vertex adjacent (in loop
+            // order) to the other rim's chain, i.e. the rim chain's first
+            // and last vertices.
+            let on_bottom = |vid| bottom_verts.iter().any(|(id, _, _)| *id == vid);
+            let n = loop_hes.len();
+            let vid_at = |i: usize| brep.topology.half_edges[loop_hes[i % n]].origin;
+            // Find a loop position where the walk transitions top→bottom;
+            // that position starts the bottom chain.
+            let mut start = None;
+            for i in 0..n {
+                if !on_bottom(vid_at(i)) && on_bottom(vid_at(i + 1)) {
+                    start = Some((i + 1) % n);
+                    break;
+                }
+            }
+            let Some(start) = start else {
+                unsplit!(face_id);
+            };
+            let mut bot_chain: Vec<vcad_kernel_topo::VertexId> = Vec::new();
+            let mut top_chain: Vec<vcad_kernel_topo::VertexId> = Vec::new();
+            let mut i = start;
+            while on_bottom(vid_at(i)) {
+                bot_chain.push(vid_at(i));
+                i += 1;
+                if bot_chain.len() > n {
+                    unsplit!(face_id);
+                }
+            }
+            while !on_bottom(vid_at(i)) {
+                top_chain.push(vid_at(i));
+                i += 1;
+                if top_chain.len() > n {
+                    unsplit!(face_id);
+                }
+            }
+            if bot_chain.len() + top_chain.len() != n {
+                // More than two rim runs — not a plain sector.
+                unsplit!(face_id);
+            }
+            // Loop order: bottom chain ascending u, then top chain
+            // descending u (the convention both make_cone and this splitter
+            // emit). Corners: bottom first/last, top last/first.
+            let u_of = |vid| {
+                all_verts
+                    .iter()
+                    .find(|(id, _, _)| *id == vid)
+                    .map(|(_, _, u)| *u)
+                    .unwrap_or(0.0)
+            };
+            let sb = *bot_chain.first().unwrap();
+            let eb = *bot_chain.last().unwrap();
+            let st = *top_chain.last().unwrap();
+            let et = *top_chain.first().unwrap();
+            let u0 = u_of(sb);
+            let u1 = u_of(eb);
+            // A dense FROZEN full band (freeze_circle_loops rewrote its two
+            // analytic rim circles into canonical polylines) walks the full
+            // turn: its rim chain has no gap wider than a couple of grid
+            // steps. Treat it like the degenerate full face, with the seam
+            // at the chain's start/end vertex.
+            let is_frozen_full = {
+                let mut us: Vec<f64> = bot_chain.iter().map(|&v| u_of(v)).collect();
+                us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                let mut max_gap = 2.0 * PI - (us[us.len() - 1] - us[0]);
+                for w in us.windows(2) {
+                    max_gap = max_gap.max(w[1] - w[0]);
+                }
+                max_gap < 0.5
+            };
+            if is_frozen_full {
+                if angle_dist(u0, u1) > 1e-6 || angle_dist(u_of(st), u_of(et)) > 1e-6 {
+                    unsplit!(face_id);
+                }
+                (u0, u0 + 2.0 * PI, sb, eb, et, st, true)
+            } else {
+                // Corner u values must agree between rims (rulings are
+                // vertical).
+                if angle_dist(u1, u_of(et)) > 1e-6 || angle_dist(u0, u_of(st)) > 1e-6 {
+                    unsplit!(face_id);
+                }
+                let wraps_around = u1 < u0 - 0.01;
+                let end_u = if wraps_around { u1 + 2.0 * PI } else { u1 };
+                (u0, end_u, sb, eb, st, et, false)
+            }
+        } else {
+            unsplit!(face_id);
+        };
+
+    // Is the split ruling within the face's u-range?
+    let in_range = if is_full_face {
+        let seam_u = u_start;
+        angle_dist(u_split, seam_u) > 0.01
+    } else {
+        angle_in_range(u_split, u_start, u_end)
+    };
+    if !in_range {
+        unsplit!(face_id);
+    }
+
+    // 3D points at the split ruling's two rim crossings.
+    let (sin_u, cos_u) = u_split.sin_cos();
+    let ruling_dir = ca * axis + sa * (cos_u * ref_dir + sin_u * y_dir);
+    let point_bottom = cone.apex + v_min * ruling_dir;
+    let point_top = cone.apex + v_max * ruling_dir;
+
+    let tolerance = 1e-6;
+    let v_split_bottom = find_or_create_vertex(brep, &point_bottom, tolerance);
+    let v_split_top = find_or_create_vertex(brep, &point_top, tolerance);
+
+    // Rim circle data: center on the axis, radius v·sin(α).
+    let r_bot = v_min * sa;
+    let r_top = v_max * sa;
+    let bot_center = cone.apex + v_min * ca * axis;
+    let top_center = cone.apex + v_max * ca * axis;
+
+    let chain_vids =
+        |brep: &mut BRepSolid, center: Point3, radius: f64, from: Point3, to: Point3| {
+            // Increasing u = CCW about the cone axis.
+            canonical_arc_points(center, radius, axis, from, to, segments)
+                .into_iter()
+                .map(|p| find_or_create_vertex(brep, &p, tolerance))
+                .collect::<Vec<_>>()
+        };
+    let build_face = |brep: &mut BRepSolid,
+                      v_bot_a: vcad_kernel_topo::VertexId,
+                      v_bot_b: vcad_kernel_topo::VertexId,
+                      v_top_a: vcad_kernel_topo::VertexId,
+                      v_top_b: vcad_kernel_topo::VertexId|
+     -> (FaceId, HalfEdgeId, HalfEdgeId) {
+        let p_bot_a = brep.topology.vertices[v_bot_a].point;
+        let p_bot_b = brep.topology.vertices[v_bot_b].point;
+        let p_top_a = brep.topology.vertices[v_top_a].point;
+        let p_top_b = brep.topology.vertices[v_top_b].point;
+        // Bottom chain ascending u (a→b), up ruling, top chain descending u
+        // (b→a), down ruling — same loop shape as make_cone's lateral face.
+        let mut bot = chain_vids(brep, bot_center, r_bot, p_bot_a, p_bot_b);
+        let mut top = chain_vids(brep, top_center, r_top, p_top_a, p_top_b);
+        *bot.first_mut().unwrap() = v_bot_a;
+        *bot.last_mut().unwrap() = v_bot_b;
+        *top.first_mut().unwrap() = v_top_a;
+        *top.last_mut().unwrap() = v_top_b;
+        top.reverse(); // descending u: b → a
+
+        let mut origins: Vec<vcad_kernel_topo::VertexId> = Vec::new();
+        origins.extend(&bot[..bot.len() - 1]);
+        origins.extend(&top[..top.len() - 1]);
+        origins.insert(bot.len() - 1, bot[bot.len() - 1]);
+        origins.push(top[top.len() - 1]);
+
+        let hes: Vec<_> = origins
+            .iter()
+            .map(|&v| brep.topology.add_half_edge(v))
+            .collect();
+        let lp = brep.topology.add_loop(&hes);
+        let face = brep.topology.add_face(lp, surface_index, orientation);
+        let up_he = hes[bot.len() - 1];
+        let down_he = hes[hes.len() - 1];
+        (face, up_he, down_he)
+    };
+
+    let (face1, he1_up, _he1_down) =
+        build_face(brep, v_start_bot, v_split_bottom, v_start_top, v_split_top);
+    let (face2, _he2_up, he2_down) =
+        build_face(brep, v_split_bottom, v_end_bot, v_split_top, v_end_top);
+
+    // Twin the shared split ruling: face1 goes up at u_split, face2 comes
+    // back down at u_split.
+    brep.topology.add_edge(he1_up, he2_down);
+    if is_full_face {
+        brep.topology.add_edge(_he1_down, _he2_up);
+    }
+
+    if let Some(shell_id) = brep.topology.faces[face_id].shell {
+        brep.topology.shells[shell_id].faces.push(face1);
+        brep.topology.shells[shell_id].faces.push(face2);
+        brep.topology.faces[face1].shell = Some(shell_id);
+        brep.topology.faces[face2].shell = Some(shell_id);
+        brep.topology.shells[shell_id]
+            .faces
+            .retain(|&f| f != face_id);
+    }
+
+    brep.topology.faces.remove(face_id);
+    brep.geometry.add_curve_3d(Box::new(line.clone()));
+
+    SplitResult {
+        sub_faces: vec![face1, face2],
+    }
+}
+
+/// Minimal cyclic distance between two angles in radians.
+fn angle_dist(a: f64, b: f64) -> f64 {
+    use std::f64::consts::PI;
+    let d = (a - b).rem_euclid(2.0 * PI);
+    d.min(2.0 * PI - d)
+}
+
+/// Split a dense (frozen-polyline) full conical band at a constant-v
+/// circle, producing two dense bands.
+///
+/// `freeze_circle_loops` rewrites primitive frusta rims into canonical
+/// polylines before the pipeline runs, so a cone lateral face arrives here
+/// as a dense two-ring loop (bottom ring +u, seam up, top ring −u, seam
+/// down — make_cone's shape, densified). The legacy splitter's degenerate
+/// seam-loop reconstruction would thaw those rims back into analytic
+/// circles that can never conform; instead, keep both existing rings
+/// verbatim and realize the new mid ring on the same canonical grid.
+fn split_dense_conical_band_by_circle(
+    brep: &mut BRepSolid,
+    face_id: FaceId,
+    cone: &vcad_kernel_geom::ConeSurface,
+    circle: &vcad_kernel_geom::Circle3d,
+    segments: u32,
+) -> SplitResult {
+    use std::f64::consts::PI;
+    let unsplit = |face_id| SplitResult {
+        sub_faces: vec![face_id],
+    };
+    let face = &brep.topology.faces[face_id];
+    let surface_index = face.surface_index;
+    let orientation = face.orientation;
+    let shell = face.shell;
+
+    let axis = *cone.axis.as_ref();
+    let ref_dir = *cone.ref_dir.as_ref();
+    let y_dir = axis.cross(ref_dir);
+    let ca = cone.half_angle.cos();
+    let sa = cone.half_angle.sin();
+    let cone_v = |p: &Point3| -> f64 { (*p - cone.apex).dot(axis) / ca };
+    let cone_u = |p: &Point3| -> Option<f64> {
+        let d = *p - cone.apex;
+        let d_perp = d - d.dot(axis) * axis;
+        if d_perp.norm() < 1e-9 {
+            return None;
+        }
+        let u = d_perp.dot(y_dir).atan2(d_perp.dot(ref_dir));
+        Some(if u < 0.0 { u + 2.0 * PI } else { u })
+    };
+
+    // Loop origins in order, with rim classification.
+    let loop_vids: Vec<vcad_kernel_topo::VertexId> = brep
+        .topology
+        .loop_half_edges(face.outer_loop)
+        .map(|he| brep.topology.half_edges[he].origin)
+        .collect();
+    let vs: Vec<f64> = loop_vids
+        .iter()
+        .map(|&v| cone_v(&brep.topology.vertices[v].point))
+        .collect();
+    let (v_min, v_max) = vs
+        .iter()
+        .fold((f64::INFINITY, f64::NEG_INFINITY), |(a, b), &v| {
+            (a.min(v), b.max(v))
+        });
+    if v_max - v_min < 1e-9 {
+        return unsplit(face_id);
+    }
+    const V_TOL: f64 = 1e-6;
+    if vs
+        .iter()
+        .any(|&v| (v - v_min).abs() >= V_TOL && (v - v_max).abs() >= V_TOL)
+    {
+        return unsplit(face_id); // wavy boundary — not a plain band
+    }
+    let on_bottom: Vec<bool> = vs.iter().map(|&v| (v - v_min).abs() < V_TOL).collect();
+    let n = loop_vids.len();
+    let transitions = (0..n)
+        .filter(|&i| on_bottom[i] != on_bottom[(i + 1) % n])
+        .count();
+    if transitions != 2 {
+        return unsplit(face_id);
+    }
+    let start = match (0..n).find(|&i| on_bottom[i] && !on_bottom[(i + n - 1) % n]) {
+        Some(s) => s,
+        None => return unsplit(face_id),
+    };
+    let idx = |k: usize| (start + k) % n;
+    let n_bot = (0..n).take_while(|&k| on_bottom[idx(k)]).count();
+    let bot_run: Vec<_> = (0..n_bot).map(|k| loop_vids[idx(k)]).collect();
+    let top_run: Vec<_> = (n_bot..n).map(|k| loop_vids[idx(k)]).collect();
+    if bot_run.len() < 3 || top_run.len() < 3 {
+        return unsplit(face_id);
+    }
+
+    // Both rims must be full rings (frozen band); a sector's rim would
+    // leave a wide angular gap.
+    let full_ring = |run: &[vcad_kernel_topo::VertexId]| -> bool {
+        let mut us: Vec<f64> = run
+            .iter()
+            .filter_map(|&v| cone_u(&brep.topology.vertices[v].point))
+            .collect();
+        if us.len() < 3 {
+            return false;
+        }
+        us.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let mut max_gap = 2.0 * PI - (us[us.len() - 1] - us[0]);
+        for w in us.windows(2) {
+            max_gap = max_gap.max(w[1] - w[0]);
+        }
+        max_gap < 0.5
+    };
+    if !full_ring(&bot_run) || !full_ring(&top_run) {
+        return unsplit(face_id);
+    }
+    // The runs carry the seam vertex at both ends (ring closing edge +
+    // seam edge origin); drop the duplicate.
+    let dedup_run = |run: &[vcad_kernel_topo::VertexId]| -> Vec<vcad_kernel_topo::VertexId> {
+        let mut r = run.to_vec();
+        if r.len() >= 2 && r[0] == r[r.len() - 1] {
+            r.pop();
+        }
+        r
+    };
+    let bot_ring = dedup_run(&bot_run);
+    let top_ring = dedup_run(&top_run);
+
+    // The split circle's v must be strictly inside the band.
+    let v_split = (circle.center - cone.apex).dot(axis) / ca;
+    if v_split <= v_min + 1e-9 || v_split >= v_max - 1e-9 {
+        return unsplit(face_id);
+    }
+
+    // Travel directions: the mid ring must travel like the run it
+    // replaces. canonical_arc_points travels +u (CCW about the axis); the
+    // bottom run travels whichever way the original loop wound. (Computed
+    // before any topology mutation — cone_u borrows the topology.)
+    let run_ascending = |ring: &[vcad_kernel_topo::VertexId]| -> bool {
+        for w in ring.windows(2) {
+            let (Some(a), Some(b)) = (
+                cone_u(&brep.topology.vertices[w[0]].point),
+                cone_u(&brep.topology.vertices[w[1]].point),
+            ) else {
+                continue;
+            };
+            let mut du = (b - a).rem_euclid(2.0 * PI);
+            if du > PI {
+                du -= 2.0 * PI;
+            }
+            if du.abs() > 1e-9 {
+                return du > 0.0;
+            }
+        }
+        true
+    };
+    let bot_asc = run_ascending(&bot_ring);
+
+    // Realize the mid ring on the canonical grid, seamed at the same u as
+    // the band's own seam.
+    let seam_u = match cone_u(&brep.topology.vertices[bot_ring[0]].point) {
+        Some(u) => u,
+        None => return unsplit(face_id),
+    };
+    let (sin_s, cos_s) = seam_u.sin_cos();
+    let ruling_dir = ca * axis + sa * (cos_s * ref_dir + sin_s * y_dir);
+    let mid_seam_pt = cone.apex + v_split * ruling_dir;
+    let mid_center = cone.apex + v_split * ca * axis;
+    let mid_radius = v_split * sa;
+    let tolerance = 1e-6;
+    let mut mid_ring_pts = canonical_arc_points(
+        mid_center,
+        mid_radius,
+        axis,
+        mid_seam_pt,
+        mid_seam_pt,
+        segments,
+    );
+    mid_ring_pts.pop(); // duplicate seam endpoint
+    let mid_ring_asc: Vec<vcad_kernel_topo::VertexId> = mid_ring_pts
+        .iter()
+        .map(|p| find_or_create_vertex(brep, p, tolerance))
+        .collect();
+
+    let mid_like_bot: Vec<vcad_kernel_topo::VertexId> = if bot_asc {
+        mid_ring_asc.clone()
+    } else {
+        let mut r = mid_ring_asc.clone();
+        r[1..].reverse();
+        r
+    };
+    let mid_like_top: Vec<vcad_kernel_topo::VertexId> = {
+        // Opposite travel to the bottom-style ring, same seam start.
+        let mut r = mid_like_bot.clone();
+        r[1..].reverse();
+        r
+    };
+
+    // Assemble a band face from two rings (each in its travel order,
+    // starting at its seam vertex): ring1 edges (closing back to seam),
+    // seam-up, ring2 edges, seam-down.
+    let mut build_band = |ring_lo: &[vcad_kernel_topo::VertexId],
+                          ring_hi: &[vcad_kernel_topo::VertexId]|
+     -> (
+        FaceId,
+        Vec<HalfEdgeId>,
+        HalfEdgeId,
+        Vec<HalfEdgeId>,
+        HalfEdgeId,
+    ) {
+        let mut origins: Vec<vcad_kernel_topo::VertexId> = Vec::new();
+        origins.extend(ring_lo);
+        origins.push(ring_lo[0]); // seam-up
+        origins.extend(ring_hi);
+        origins.push(ring_hi[0]); // seam-down
+        let hes: Vec<HalfEdgeId> = origins
+            .iter()
+            .map(|&v| brep.topology.add_half_edge(v))
+            .collect();
+        let lp = brep.topology.add_loop(&hes);
+        let f = brep.topology.add_face(lp, surface_index, orientation);
+        let k = ring_lo.len();
+        let m = ring_hi.len();
+        (
+            f,
+            hes[..k].to_vec(),
+            hes[k],
+            hes[k + 1..k + 1 + m].to_vec(),
+            hes[k + 1 + m],
+        )
+    };
+
+    let (lower_face, _lo_bot, lo_up, lo_top, lo_down) = build_band(&bot_ring, &mid_like_top);
+    let (upper_face, up_bot, up_up, _up_top, up_down) = build_band(&mid_like_bot, &top_ring);
+
+    // Seam edges twin within each band (make_cone's convention).
+    brep.topology.add_edge(lo_up, lo_down);
+    brep.topology.add_edge(up_up, up_down);
+    // Mid-ring edges pair between the bands: lo_top[i] runs
+    // mid_like_top[i] → mid_like_top[i+1]; the upper band traverses the
+    // same ring in the opposite direction. Edge k of one direction pairs
+    // with edge (m-1-k) of the other.
+    let m = lo_top.len();
+    debug_assert_eq!(m, up_bot.len());
+    for i in 0..m {
+        brep.topology.add_edge(lo_top[i], up_bot[m - 1 - i]);
+    }
+
+    if let Some(shell_id) = shell {
+        brep.topology.shells[shell_id].faces.push(lower_face);
+        brep.topology.shells[shell_id].faces.push(upper_face);
+        brep.topology.faces[lower_face].shell = Some(shell_id);
+        brep.topology.faces[upper_face].shell = Some(shell_id);
+        brep.topology.shells[shell_id]
+            .faces
+            .retain(|&f| f != face_id);
+    }
+    brep.topology.faces.remove(face_id);
+    brep.geometry.add_curve_3d(Box::new(circle.clone()));
+
+    SplitResult {
+        sub_faces: vec![lower_face, upper_face],
     }
 }
 
@@ -3507,6 +4140,7 @@ fn split_conical_face_by_circle(
     brep: &mut BRepSolid,
     face_id: FaceId,
     circle: &vcad_kernel_geom::Circle3d,
+    segments: u32,
 ) -> SplitResult {
     let face = &brep.topology.faces[face_id];
     let surface_index = face.surface_index;
@@ -3529,10 +4163,18 @@ fn split_conical_face_by_circle(
     let apex_to_circle = (circle.center - cone.apex).dot(cone.axis.as_ref());
 
     let loop_hes: Vec<_> = brep.topology.loop_half_edges(face.outer_loop).collect();
+    // This splitter reconstructs its sub-faces as degenerate seam loops
+    // spanning the FULL circumference — only correct when the input face is
+    // itself a full lateral band with analytic rims (primitive frusta and
+    // their circle-split sub-bands, ≤ 6 half-edges). Dense loops (frozen
+    // bands and ruling-split sectors) go through the dense v-split path.
     if loop_hes.is_empty() {
         return SplitResult {
             sub_faces: vec![face_id],
         };
+    }
+    if loop_hes.len() > 6 {
+        return split_dense_conical_band_by_circle(brep, face_id, &cone, circle, segments);
     }
 
     let mut v_min = f64::INFINITY;

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -3514,14 +3514,23 @@ pub fn split_conical_face(
         IntersectionCurve::Empty | IntersectionCurve::Point(_) => SplitResult {
             sub_faces: vec![face_id],
         },
-        IntersectionCurve::TwoLines(line1, _line2) => split_conical_face(
-            brep,
-            face_id,
-            &IntersectionCurve::Line(line1.clone()),
-            entry,
-            exit,
-            segments,
-        ),
+        IntersectionCurve::TwoLines(line1, line2) => {
+            // The pipeline expands TwoLines into individual Line splits, so
+            // this arm is normally not reached — but a direct caller gets
+            // both rulings applied: split by the first, then run the second
+            // over every resulting sub-face.
+            let first = split_conical_face_by_ruling(brep, face_id, line1, entry, exit, segments);
+            let mut out = Vec::new();
+            for fid in first.sub_faces {
+                if brep.topology.faces.contains_key(fid) {
+                    out.extend(
+                        split_conical_face_by_ruling(brep, fid, line2, entry, exit, segments)
+                            .sub_faces,
+                    );
+                }
+            }
+            SplitResult { sub_faces: out }
+        }
         IntersectionCurve::TwoSampled(_, _) => SplitResult {
             sub_faces: vec![face_id],
         },

--- a/crates/vcad-kernel-booleans/src/ssi.rs
+++ b/crates/vcad-kernel-booleans/src/ssi.rs
@@ -509,8 +509,17 @@ fn plane_cone(plane: &Plane, cone: &ConeSurface) -> IntersectionCurve {
     // 0, 1, or 2 straight rulings through the apex (e.g. a box side plane
     // containing the cone axis). The marching fallback yields v=0 for every
     // sample here (numer=0) and returns Empty, silently dropping the cut.
+    // Relative tolerance: at large coordinates the dot product's rounding
+    // error scales with the operand magnitudes, so an absolute 1e-9 would
+    // miss a genuinely apex-containing plane far from the origin.
+    let apex_scale = cone
+        .apex
+        .to_vec()
+        .norm()
+        .max(plane.origin.to_vec().norm())
+        .max(1.0);
     let apex_dist = (plane.origin - cone.apex).dot(n.as_ref());
-    if apex_dist.abs() < 1e-9 {
+    if apex_dist.abs() < 1e-9 * apex_scale {
         return plane_through_apex_cone(plane, cone);
     }
 

--- a/crates/vcad-kernel-booleans/src/ssi.rs
+++ b/crates/vcad-kernel-booleans/src/ssi.rs
@@ -505,6 +505,15 @@ fn plane_cone(plane: &Plane, cone: &ConeSurface) -> IntersectionCurve {
 
     let cos_angle = n.as_ref().dot(axis.as_ref()).abs();
 
+    // Plane passing through the apex: the intersection is not a conic but
+    // 0, 1, or 2 straight rulings through the apex (e.g. a box side plane
+    // containing the cone axis). The marching fallback yields v=0 for every
+    // sample here (numer=0) and returns Empty, silently dropping the cut.
+    let apex_dist = (plane.origin - cone.apex).dot(n.as_ref());
+    if apex_dist.abs() < 1e-9 {
+        return plane_through_apex_cone(plane, cone);
+    }
+
     if (cos_angle - 1.0).abs() < 1e-12 {
         // Plane is perpendicular to cone axis → Circle
         // Distance along axis from apex to plane
@@ -543,6 +552,69 @@ fn plane_cone(plane: &Plane, cone: &ConeSurface) -> IntersectionCurve {
         // General case → conic section (ellipse, parabola, or hyperbola)
         // Use sampling with higher density for accuracy
         marching_ssi_cone_plane(plane, cone, 64)
+    }
+}
+
+/// Intersection of a cone with a plane that passes through its apex.
+///
+/// Writing the ruling direction as
+/// `dir(u) = cos(α)·axis + sin(α)·(cos(u)·ref + sin(u)·y)`, a ruling lies in
+/// the plane iff `n·dir(u) = 0`, i.e. `A·cos(u) + B·sin(u) = -C` with
+/// `A = sin(α)·(n·ref)`, `B = sin(α)·(n·y)`, `C = cos(α)·(n·axis)`.
+/// With `R = √(A²+B²)`: no solution (`R < |C|`) → the plane meets the cone
+/// only at the apex; one solution → a single tangent ruling; two solutions
+/// → two rulings through the apex.
+fn plane_through_apex_cone(plane: &Plane, cone: &ConeSurface) -> IntersectionCurve {
+    let n = plane.normal_dir;
+    let ca = cone.half_angle.cos();
+    let sa = cone.half_angle.sin();
+    let y_dir = cone.y_dir();
+
+    let a = sa * n.as_ref().dot(cone.ref_dir.as_ref());
+    let b = sa * n.as_ref().dot(y_dir);
+    let c = ca * n.as_ref().dot(cone.axis.as_ref());
+    let r = (a * a + b * b).sqrt();
+
+    if r < c.abs() - 1e-12 {
+        return IntersectionCurve::Point(cone.apex);
+    }
+
+    let ruling = |u: f64| -> Line3d {
+        let (sin_u, cos_u) = u.sin_cos();
+        let dir =
+            ca * cone.axis.into_inner() + sa * (cos_u * cone.ref_dir.into_inner() + sin_u * y_dir);
+        Line3d {
+            origin: cone.apex,
+            direction: dir,
+        }
+    };
+
+    let phi = b.atan2(a);
+    if r < c.abs() + 1e-12 {
+        // Tangent: exactly one ruling, at cos(u - phi) = ±1.
+        let u = if c <= 0.0 {
+            phi
+        } else {
+            phi + std::f64::consts::PI
+        };
+        return IntersectionCurve::Line(ruling(u));
+    }
+
+    let delta = (-c / r).clamp(-1.0, 1.0).acos();
+    let l1 = ruling(phi + delta);
+    let l2 = ruling(phi - delta);
+
+    // Deterministic ordering (mirrors plane_cylinder's TwoLines sort).
+    let (d1, d2) = (l1.direction, l2.direction);
+    let cmp =
+        d1.x.partial_cmp(&d2.x)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(d1.y.partial_cmp(&d2.y).unwrap_or(std::cmp::Ordering::Equal))
+            .then(d1.z.partial_cmp(&d2.z).unwrap_or(std::cmp::Ordering::Equal));
+    if cmp == std::cmp::Ordering::Greater {
+        IntersectionCurve::TwoLines(l2, l1)
+    } else {
+        IntersectionCurve::TwoLines(l1, l2)
     }
 }
 

--- a/crates/vcad-kernel-booleans/src/trim.rs
+++ b/crates/vcad-kernel-booleans/src/trim.rs
@@ -462,8 +462,62 @@ fn point_in_face_inner(brep: &BRepSolid, face_id: FaceId, point_3d: &Point3) -> 
             }
         }
 
-        // Full cone lateral face with ≤2 unique vertices: check V range only
-        if unique_verts.len() <= 2 {
+        // A frozen full band (dense canonical rims from freeze_circle_loops)
+        // spans the whole turn just like the analytic ≤2-vertex seam loop:
+        // every vertex sits on one of two rims and the u coverage has no
+        // wide gap. Mirrors the cylinder branch's detection above.
+        let frozen_full_band = unique_verts.len() > 2
+            && surface
+                .as_any()
+                .downcast_ref::<vcad_kernel_geom::ConeSurface>()
+                .map(|cone| {
+                    let ca = cone.half_angle.cos();
+                    let axis = *cone.axis.as_ref();
+                    let vs: Vec<f64> = unique_verts
+                        .iter()
+                        .map(|p| (*p - cone.apex).dot(axis) / ca)
+                        .collect();
+                    let v_min = vs.iter().cloned().fold(f64::INFINITY, f64::min);
+                    let v_max = vs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                    if v_max - v_min < 1e-9
+                        || !vs
+                            .iter()
+                            .all(|v| (v - v_min).abs() < 1e-6 || (v - v_max).abs() < 1e-6)
+                    {
+                        return false;
+                    }
+                    let ref_dir = cone.ref_dir.as_ref();
+                    let y_dir = axis.cross(ref_dir);
+                    let mut us: Vec<f64> = unique_verts
+                        .iter()
+                        .filter_map(|p| {
+                            let d = *p - cone.apex;
+                            let d_perp = d - d.dot(axis) * axis;
+                            if d_perp.norm() < 1e-9 {
+                                return None;
+                            }
+                            let u = d_perp.dot(y_dir).atan2(d_perp.dot(ref_dir));
+                            Some(if u < 0.0 {
+                                u + 2.0 * std::f64::consts::PI
+                            } else {
+                                u
+                            })
+                        })
+                        .collect();
+                    if us.len() < 3 {
+                        return false;
+                    }
+                    us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+                    let mut max_gap = us[0] + 2.0 * std::f64::consts::PI - us[us.len() - 1];
+                    for w in us.windows(2) {
+                        max_gap = max_gap.max(w[1] - w[0]);
+                    }
+                    max_gap < std::f64::consts::FRAC_PI_2
+                })
+                .unwrap_or(false);
+
+        // Full cone lateral face: check V range only
+        if unique_verts.len() <= 2 || frozen_full_band {
             if let Some(cone) = surface
                 .as_any()
                 .downcast_ref::<vcad_kernel_geom::ConeSurface>()

--- a/crates/vcad-kernel-booleans/tests/cone_axis_on_box_edge.rs
+++ b/crates/vcad-kernel-booleans/tests/cone_axis_on_box_edge.rs
@@ -1,0 +1,132 @@
+//! Regression: a cone whose axis lies exactly on a box corner edge — the
+//! box planes x=0 and y=0 both pass through the cone axis, so plane∩cone
+//! degenerates to two straight rulings instead of a conic. The lateral wall
+//! band used to be dropped entirely (torture cases rand-002/030/086/130:
+//! open rim circles + 34-41% volume deficit).
+//!
+//! Assertions are on volume against the analytic value, not just
+//! watertightness — see curved_face_classification.rs for why.
+
+use std::f64::consts::PI;
+use vcad_kernel_booleans::{boolean_op, BooleanOp};
+use vcad_kernel_primitives::{make_cone, make_cube};
+
+const SEGMENTS: u32 = 32;
+
+fn frustum_volume(rb: f64, rt: f64, h: f64) -> f64 {
+    PI * h / 3.0 * (rb * rb + rb * rt + rt * rt)
+}
+
+/// Volume of the frustum's +x,+y quarter clipped to z <= zmax (the box is
+/// wide enough in x/y to contain the quarter for every case below).
+fn quarter_frustum_below(rb: f64, rt: f64, h: f64, zmax: f64) -> f64 {
+    if zmax >= h {
+        return frustum_volume(rb, rt, h) / 4.0;
+    }
+    let rm = rb + (rt - rb) * (zmax / h);
+    frustum_volume(rb, rm, zmax) / 4.0
+}
+
+fn mesh_volume(mesh: &vcad_kernel_tessellate::TriangleMesh) -> f64 {
+    let verts = &mesh.vertices;
+    let mut vol = 0.0_f64;
+    for tri in mesh.indices.chunks(3) {
+        let i0 = tri[0] as usize * 3;
+        let i1 = tri[1] as usize * 3;
+        let i2 = tri[2] as usize * 3;
+        let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
+        let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
+        let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
+        vol += v0[0] * (v1[1] * v2[2] - v2[1] * v1[2]) - v1[0] * (v0[1] * v2[2] - v2[1] * v0[2])
+            + v2[0] * (v0[1] * v1[2] - v1[1] * v0[2]);
+    }
+    vol / 6.0
+}
+
+fn check(case: &str, sx: f64, sy: f64, sz: f64, rb: f64, rt: f64, h: f64, union_op: bool) {
+    let cube = make_cube(sx, sy, sz);
+    let cone = make_cone(rb, rt, h, SEGMENTS);
+    let v_cube = sx * sy * sz;
+    let v_overlap = quarter_frustum_below(rb, rt, h, sz.min(h));
+    let (op, expected) = if union_op {
+        (
+            BooleanOp::Union,
+            v_cube + frustum_volume(rb, rt, h) - v_overlap,
+        )
+    } else {
+        (BooleanOp::Difference, v_cube - v_overlap)
+    };
+    let result = boolean_op(&cube, &cone, op, SEGMENTS).expect("boolean should succeed");
+    let mesh = result.to_mesh(SEGMENTS);
+    let open = mesh.boundary_edges().len();
+    assert_eq!(open, 0, "{case}: {open} open boundary edges");
+    let v = mesh_volume(&mesh);
+    let rel = (v - expected).abs() / expected;
+    assert!(
+        rel < 0.02,
+        "{case}: volume {v:.4} vs analytic {expected:.4} (rel err {:.2}%)",
+        rel * 100.0
+    );
+}
+
+#[test]
+fn rand_002_cube_minus_cone_axis_on_corner() {
+    check(
+        "rand-002",
+        10.90671106413945,
+        17.75451124540674,
+        4.615343499803716,
+        9.910569812730584,
+        1.1726645375261058,
+        2.4735394613289343,
+        false,
+    );
+}
+
+#[test]
+fn rand_030_cube_minus_cone_axis_on_corner() {
+    check(
+        "rand-030",
+        19.359394782885566,
+        9.650830329754319,
+        16.076476317416457,
+        6.875037331366226,
+        0.45694795134827615,
+        14.784346481906827,
+        false,
+    );
+}
+
+#[test]
+fn rand_086_cube_union_cone_axis_on_corner() {
+    check(
+        "rand-086",
+        10.1041605926844,
+        13.684462663150608,
+        17.498866474834283,
+        6.475596216765858,
+        2.9404818972270004,
+        6.444204498945038,
+        true,
+    );
+}
+
+#[test]
+fn rand_130_cube_union_cone_axis_on_corner() {
+    check(
+        "rand-130",
+        13.049185556942604,
+        14.95758620279308,
+        4.791990137455045,
+        8.62772952972415,
+        3.802442143234791,
+        13.515303284875346,
+        true,
+    );
+}
+
+/// Clean round numbers, same degeneracy.
+#[test]
+fn simple_cube_minus_cone_axis_on_corner() {
+    check("simple", 10.0, 10.0, 5.0, 8.0, 2.0, 4.0, false);
+}

--- a/crates/vcad-kernel-booleans/tests/cone_axis_on_box_edge.rs
+++ b/crates/vcad-kernel-booleans/tests/cone_axis_on_box_edge.rs
@@ -130,3 +130,45 @@ fn rand_130_cube_union_cone_axis_on_corner() {
 fn simple_cube_minus_cone_axis_on_corner() {
     check("simple", 10.0, 10.0, 5.0, 8.0, 2.0, 4.0, false);
 }
+
+/// A direct `TwoLines` split must apply BOTH rulings: on a full lateral
+/// band (seam at u=0) rulings at u=90° and u=270° yield three sectors, not
+/// two. Guards the defensive `TwoLines` arm of `split_conical_face` (the
+/// pipeline itself expands `TwoLines` into individual `Line` splits).
+#[test]
+fn two_lines_applies_both_rulings() {
+    use vcad_kernel_booleans::split::{is_conical_face, split_conical_face};
+    use vcad_kernel_geom::Line3d;
+    use vcad_kernel_math::Point3;
+
+    let mut cone = make_cone(8.0, 2.0, 4.0, SEGMENTS);
+    let lateral = cone
+        .topology
+        .faces
+        .keys()
+        .find(|&f| is_conical_face(&cone, f))
+        .expect("lateral face");
+
+    // Apex of the frustum sits at z = h·rb/(rb−rt) = 16/3 above the base;
+    // rulings run from the apex through the rims at u = ±90°.
+    let apex = Point3::new(0.0, 0.0, 16.0 / 3.0);
+    let ruling = |sy: f64| Line3d {
+        origin: apex,
+        direction: Point3::new(0.0, sy * 8.0, 0.0) - apex,
+    };
+    let curve = vcad_kernel_booleans::ssi::IntersectionCurve::TwoLines(ruling(1.0), ruling(-1.0));
+    // Entry/exit span the full band in v (base rim to top rim).
+    let result = split_conical_face(
+        &mut cone,
+        lateral,
+        &curve,
+        &Point3::new(0.0, 8.0, 0.0),
+        &Point3::new(0.0, 2.0, 4.0),
+        SEGMENTS,
+    );
+    assert_eq!(
+        result.sub_faces.len(),
+        3,
+        "both rulings of a TwoLines split must be applied (seam + 2 cuts → 3 sectors)"
+    );
+}

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -4328,6 +4328,19 @@ fn tessellate_conical_face(
         return tessellate_cone_direct(&verts, z_min, z_max, r_min, n_circ, n_height, reversed);
     };
 
+    // Sector faces (from boolean ruling splits) carry dense two-rim loops
+    // spanning less than a full turn; render them verbatim from the loop so
+    // the rim vertices conform with the neighboring caps. Full lateral faces
+    // and v-sub-bands (degenerate seam loops) fall through to the grid path.
+    if let Some(cone) = surface
+        .as_any()
+        .downcast_ref::<vcad_kernel_geom::ConeSurface>()
+    {
+        if let Some(mesh) = tessellate_cone_sector_two_chain(cone, &verts, reversed) {
+            return mesh;
+        }
+    }
+
     // Project vertices onto axis to get v parameter range (distance from apex)
     let mut v_min = f64::MAX;
     let mut v_max = f64::MIN;
@@ -4453,6 +4466,184 @@ fn tessellate_conical_face(
     }
 
     mesh
+}
+
+/// Tessellate a conical sector face bounded by two constant-v rim chains
+/// and two rulings — the shape produced by the boolean ruling splitter.
+///
+/// Renders the loop's own vertices verbatim (zipper triangulation between
+/// the two rims) so both rims conform vertex-for-vertex with the
+/// neighboring cap faces. Returns `None` for any loop that is not a plain
+/// two-rim sector (full seam loops, wavy boundaries, apex fans), which
+/// then falls through to the full-circumference grid path.
+fn tessellate_cone_sector_two_chain(
+    cone: &vcad_kernel_geom::ConeSurface,
+    verts: &[Point3],
+    reversed: bool,
+) -> Option<TriangleMesh> {
+    let l = verts.len();
+    if l < 4 {
+        return None;
+    }
+
+    let axis = *cone.axis.as_ref();
+    let ref_dir = *cone.ref_dir.as_ref();
+    let y_dir = axis.cross(ref_dir);
+    let ca = cone.half_angle.cos();
+    let sa = cone.half_angle.sin();
+
+    let uv_of = |p: &Point3| -> Option<(f64, f64)> {
+        let d = *p - cone.apex;
+        let v = d.dot(axis) / ca;
+        let d_perp = d - d.dot(axis) * axis;
+        if d_perp.norm() < 1e-9 {
+            return None; // apex — not a sector loop
+        }
+        let u = d_perp.dot(y_dir).atan2(d_perp.dot(ref_dir));
+        Some((u, v))
+    };
+    let uvs: Vec<(f64, f64)> = verts.iter().map(uv_of).collect::<Option<Vec<_>>>()?;
+
+    let v_min = uvs.iter().map(|p| p.1).fold(f64::MAX, f64::min);
+    let v_max = uvs.iter().map(|p| p.1).fold(f64::MIN, f64::max);
+    if v_max - v_min < 1e-9 {
+        return None;
+    }
+    const V_TOL: f64 = 1e-6;
+    // Every vertex must sit on one of the two rims.
+    if uvs
+        .iter()
+        .any(|p| (p.1 - v_min).abs() >= V_TOL && (p.1 - v_max).abs() >= V_TOL)
+    {
+        return None;
+    }
+    let on_bottom: Vec<bool> = uvs.iter().map(|p| (p.1 - v_min).abs() < V_TOL).collect();
+
+    // Exactly one contiguous bottom run and one top run in the cyclic loop.
+    let transitions = (0..l)
+        .filter(|&i| on_bottom[i] != on_bottom[(i + 1) % l])
+        .count();
+    if transitions != 2 {
+        return None;
+    }
+    // Rotate so the loop starts at the bottom run's first vertex.
+    let start = (0..l)
+        .find(|&i| on_bottom[i] && !on_bottom[(i + l - 1) % l])
+        .unwrap_or(0);
+    let idx = |k: usize| (start + k) % l;
+    let n_bot = (0..l).take_while(|&k| on_bottom[idx(k)]).count();
+    let bot_idx: Vec<usize> = (0..n_bot).map(idx).collect();
+    let top_idx: Vec<usize> = (n_bot..l).map(idx).collect();
+    if bot_idx.len() < 2 || top_idx.len() < 2 {
+        return None;
+    }
+
+    // Unwrap u along each chain by continuity.
+    let unwrap_chain = |ids: &[usize]| -> Vec<f64> {
+        let mut out = Vec::with_capacity(ids.len());
+        out.push(uvs[ids[0]].0);
+        for &i in &ids[1..] {
+            let prev: f64 = *out.last().unwrap();
+            let mut du = (uvs[i].0 - prev).rem_euclid(2.0 * PI);
+            if du > PI {
+                du -= 2.0 * PI;
+            }
+            out.push(prev + du);
+        }
+        out
+    };
+    let mut bot_u = unwrap_chain(&bot_idx);
+    let mut top_u = unwrap_chain(&top_idx);
+    let mut bot_ids = bot_idx.clone();
+    let mut top_ids = top_idx.clone();
+    // Normalize both chains to ascending u (loop order has the top chain
+    // descending).
+    if bot_u.first() > bot_u.last() {
+        bot_u.reverse();
+        bot_ids.reverse();
+    }
+    if top_u.first() > top_u.last() {
+        top_u.reverse();
+        top_ids.reverse();
+    }
+    // Align top chain's unwrapped frame onto the bottom's.
+    let shift = ((bot_u[0] - top_u[0]) / (2.0 * PI)).round() * 2.0 * PI;
+    for u in &mut top_u {
+        *u += shift;
+    }
+    // Corner columns must agree (rulings are vertical in uv).
+    // Full frozen bands walk the whole turn (span == 2π, with the seam
+    // vertex duplicated at both chain ends); anything beyond that is not a
+    // band loop.
+    let span = (bot_u[bot_u.len() - 1] - bot_u[0]).max(top_u[top_u.len() - 1] - top_u[0]);
+    if !(1e-9..=2.0 * PI + 1e-3).contains(&span) {
+        return None;
+    }
+    let tol = 1e-6_f64.max(span * 1e-9);
+    if (bot_u[0] - top_u[0]).abs() > tol
+        || (bot_u[bot_u.len() - 1] - top_u[top_u.len() - 1]).abs() > tol
+    {
+        return None;
+    }
+
+    // Emit vertices (each rail verbatim) with cone normals.
+    let mut mesh = TriangleMesh::new();
+    let mut push_vert = |p: &Point3, u: f64| -> u32 {
+        let i = (mesh.vertices.len() / 3) as u32;
+        mesh.vertices
+            .extend_from_slice(&[p.x as f32, p.y as f32, p.z as f32]);
+        let radial = u.cos() * ref_dir + u.sin() * y_dir;
+        let n = ca * radial - sa * axis;
+        let (nx, ny, nz) = if reversed {
+            (-n.x as f32, -n.y as f32, -n.z as f32)
+        } else {
+            (n.x as f32, n.y as f32, n.z as f32)
+        };
+        mesh.normals.extend_from_slice(&[nx, ny, nz]);
+        i
+    };
+    let bot_m: Vec<u32> = bot_ids
+        .iter()
+        .zip(&bot_u)
+        .map(|(&i, &u)| push_vert(&verts[i], u))
+        .collect();
+    let top_m: Vec<u32> = top_ids
+        .iter()
+        .zip(&top_u)
+        .map(|(&i, &u)| push_vert(&verts[i], u))
+        .collect();
+
+    // Zipper triangulation marching by ascending u, using only the loop's
+    // own vertices (no interpolation → no T-junctions against neighbors).
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < bot_m.len() - 1 || j < top_m.len() - 1 {
+        let advance_bottom = if j == top_m.len() - 1 {
+            true
+        } else if i == bot_m.len() - 1 {
+            false
+        } else {
+            bot_u[i + 1] <= top_u[j + 1]
+        };
+        // Quad convention (bl, br, tl, tr) → (bl, br, tl), (br, tr, tl);
+        // zipper equivalents keep the same orientation.
+        let tri = if advance_bottom {
+            [bot_m[i], bot_m[i + 1], top_m[j]]
+        } else {
+            [bot_m[i], top_m[j + 1], top_m[j]]
+        };
+        if reversed {
+            mesh.indices.extend_from_slice(&[tri[0], tri[2], tri[1]]);
+        } else {
+            mesh.indices.extend_from_slice(&tri);
+        }
+        if advance_bottom {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+
+    Some(mesh)
 }
 
 /// Fallback cone tessellation using direct z-axis coordinates.

--- a/crates/vcad-torture/examples/dump_case.rs
+++ b/crates/vcad-torture/examples/dump_case.rs
@@ -1,0 +1,7 @@
+//! Print a corpus case's spec as JSON (debug aid).
+fn main() {
+    let id = std::env::args().nth(1).expect("case id");
+    let corpus = vcad_torture::build_corpus();
+    let c = corpus.iter().find(|c| c.id == id).expect("unknown id");
+    println!("{}", serde_json::to_string_pretty(c).unwrap());
+}


### PR DESCRIPTION
## What

Fixes the boolean family where a planar face's plane passes through a cone's apex — e.g. a box whose corner-at-origin edge lies exactly on the cone axis (torture rand-002/030/086/130 at identity pose). The result used to lose the entire conical wall band and leave the planar splits unsewn: open rim circles, 34–41% volume deficit.

**Torture: 13 bad-geometry cases now pass** (rand-002/030/051/069/086/130/186/187/206/207/314/349, chain-10), **0 regressions** on the full 752-case corpus.

Note: the original handoff described this as a razor-thin-cylinder (cyl-flat) failure; dumping the actual case specs (new `vcad-torture` `dump_case` example) showed all affected cases are cone-vs-cube with the cone axis on the box corner edge.

## Why it broke (4 root causes, all needed)

1. **SSI**: `plane_cone` returned `Empty` when the plane contains the apex — every marching sample lands at v=0 and is rejected. The true intersection is 0/1/2 straight rulings; now solved analytically (`A·cos u + B·sin u = −C`) → `Point` / `Line` / `TwoLines`.
2. **No conical ruling splitter**: cone faces silently ignored `Line` curves. Added `split_conical_face_by_ruling`, mirroring the legacy cylinder line splitter (dense canonical rim chains via `canonical_arc_points`; handles full bands, sectors, and frozen dense loops). Ruling splits are clipped at record time to the t-interval where the curve lies on **both** faces, so sub-bands the cut never reaches keep conforming rims (planar faces keep the full chord — a planar split must reach the face boundary).
3. **Freeze skipped cones**: `freeze_circle_loops` only froze cylinder-carried circles, so cone rims stayed analytic and conformed only by resolution coincidence — the same gap #758 closed for cylinders. Cone rims now freeze onto the canonical grid; trim recognizes frozen full cone bands (v-range test), the cone circle splitter gained a dense-band v-split path, and `tessellate_conical_face` renders sectors/frozen bands verbatim via a two-chain zipper.
4. **Grid routing**: `circle_on_cylinder_wall` (canonical-vs-raw ring router for planar hole rings) didn't recognize cone rims — caught as a rand-318 regression during development and fixed by extending it to cones.

## Reviewer notes

- Based on `claude/vcad-difference-boolean-bug-0b6b4e` (PR #789), so this PR targets that branch; retarget to `main` after #789 merges.
- New regression test `crates/vcad-kernel-booleans/tests/cone_axis_on_box_edge.rs` asserts **volume against analytic values** (2%), not just watertightness, per the curved-face-classification precedent.
- `cargo test --workspace`, `cargo clippy --workspace --exclude vcad-desktop -- -D warnings`, and `cargo fmt --all --check` are clean.
- Changelog entry included (`fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)