### PR TITLE
fix(booleans): project mesh-fallback vertices back onto quadric carriers (defect D)

### DIFF
--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -358,8 +358,6 @@ impl QuadricCtx {
     /// quadric. Must exceed the worst observed off-surface error (~0.6 mm)
     /// with margin, while staying below feature scale.
     const BAND: f64 = 0.75;
-    /// A vertex closer than this to a plane carrier is treated as ON it.
-    const PLANE_EPS: f64 = 5e-4;
     /// In-plane snap band for plane-constrained projection. Wider than
     /// `BAND` because a plane at height h from the sphere center amplifies
     /// radial error by 1/sin(phi): a 0.62 mm radial error at h = 19.8 on a
@@ -396,12 +394,10 @@ impl QuadricCtx {
                     let axis = c.axis.into_inner();
                     if r > 1e-9
                         && !ctx.cylinders.iter().any(|(cc, ca, cr)| {
-                            (cr - r).abs() < 1e-6
-                                && ca.cross(&axis).norm() < 1e-6
-                                && {
-                                    let d = *cc - c.center;
-                                    (d - axis * d.dot(&axis)).norm() < 1e-6
-                                }
+                            (cr - r).abs() < 1e-6 && ca.cross(axis).norm() < 1e-6 && {
+                                let d = *cc - c.center;
+                                (d - axis * d.dot(axis)).norm() < 1e-6
+                            }
                         })
                     {
                         ctx.cylinders.push((c.center, axis, r));
@@ -479,7 +475,7 @@ impl QuadricCtx {
                 )
             };
             let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
-            let n = (b - a).cross(&(c - a));
+            let n = (b - a).cross(c - a);
             let l = n.norm();
             if l < 1e-12 {
                 continue;
@@ -487,7 +483,7 @@ impl QuadricCtx {
             let n = n / l;
             for &k in t {
                 let bucket = &mut inc[k as usize];
-                if !bucket.iter().any(|m| m.dot(&n).abs() > 0.996) {
+                if !bucket.iter().any(|m| m.dot(n).abs() > 0.996) {
                     bucket.push(n);
                 }
             }
@@ -498,10 +494,8 @@ impl QuadricCtx {
             // Split incident normals into quadric-explained and planar.
             let mut planar: Vec<Vec3> = Vec::new();
             for n in &inc[vi] {
-                if !self.normal_explained(&v, n) {
-                    if !planar.iter().any(|m| m.dot(n).abs() > 0.996) {
-                        planar.push(*n);
-                    }
+                if !self.normal_explained(&v, n) && !planar.iter().any(|m| m.dot(n).abs() > 0.996) {
+                    planar.push(*n);
                 }
             }
             if planar.len() >= 2 {
@@ -534,8 +528,7 @@ impl QuadricCtx {
         for (c, r) in &self.spheres {
             let d = *v - *c;
             let dist = d.norm();
-            if (dist - r).abs() < Self::BAND && dist > 1e-9 && (d / dist).dot(n).abs() > COS_SLACK
-            {
+            if (dist - r).abs() < Self::BAND && dist > 1e-9 && (d / dist).dot(n).abs() > COS_SLACK {
                 return true;
             }
         }

--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -466,7 +466,7 @@ impl QuadricCtx {
         // everything.
         let nv = mesh.vertices.len() / 3;
         let mut inc: Vec<Vec<Vec3>> = vec![Vec::new(); nv];
-        for t in mesh.indices.chunks_exact(3) {
+        for t in mesh.indices.as_chunks::<3>().0 {
             let g = |k: u32| {
                 Point3::new(
                     mesh.vertices[(k as usize) * 3] as f64,
@@ -489,7 +489,7 @@ impl QuadricCtx {
             }
         }
         let mut moved = 0usize;
-        for (vi, chunk) in mesh.vertices.chunks_exact_mut(3).enumerate() {
+        for (vi, chunk) in mesh.vertices.as_chunks_mut::<3>().0.iter_mut().enumerate() {
             let v = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
             // Split incident normals into quadric-explained and planar.
             let mut planar: Vec<Vec3> = Vec::new();

--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -1,5 +1,6 @@
 //! Public API types and entry point for boolean operations.
 
+use vcad_kernel_math::{Point3, Vec3};
 use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::{tessellate_brep, TriangleMesh};
 
@@ -122,6 +123,12 @@ pub fn boolean_op(
     op: BooleanOp,
     segments: u32,
 ) -> Result<BooleanResult, BooleanError> {
+    // Analytic surfaces of both operands, kept so the mesh fallback's
+    // result can be re-projected onto them (defect D: BSP splitting and
+    // seam healing leave quadric-face vertices up to ~0.6 mm off-surface,
+    // which is bigger than a printed part's entire fit budget).
+    let quadrics = QuadricCtx::collect(solid_a, solid_b);
+
     // Check if solids overlap at all
     let aabb_a = bbox::solid_aabb(solid_a);
     let aabb_b = bbox::solid_aabb(solid_b);
@@ -151,7 +158,7 @@ pub fn boolean_op(
     if crate::mesh::is_triangle_soup(solid_a) || crate::mesh::is_triangle_soup(solid_b) {
         let mesh_a = tessellate_brep(solid_a, segments);
         let mesh_b = tessellate_brep(solid_b, segments);
-        return mesh_fallback(&mesh_a, &mesh_b, op);
+        return mesh_fallback(&mesh_a, &mesh_b, op, &quadrics);
     }
 
     // Flag arrangements the splitters provably cannot represent. This is a
@@ -243,7 +250,7 @@ pub fn boolean_op(
         let Some((mesh_a, mesh_b)) = &operands else {
             return Ok(result);
         };
-        return mesh_fallback(mesh_a, mesh_b, op);
+        return mesh_fallback(mesh_a, mesh_b, op, &quadrics);
     }
 
     // The result is trustworthy, but it may still be *cracked*: the splitters
@@ -285,7 +292,7 @@ pub fn boolean_op(
     if crate::mesh_report(&result_mesh).open_edges == 0 {
         return Ok(result);
     }
-    let Ok(alt) = mesh_fallback(mesh_a, mesh_b, op) else {
+    let Ok(alt) = mesh_fallback(mesh_a, mesh_b, op, &quadrics) else {
         return Ok(result);
     };
     let alt_mesh = alt.to_mesh(segments);
@@ -308,10 +315,375 @@ fn mesh_fallback(
     mesh_a: &TriangleMesh,
     mesh_b: &TriangleMesh,
     op: BooleanOp,
+    quadrics: &QuadricCtx,
 ) -> Result<BooleanResult, BooleanError> {
-    let out = crate::mesh::csg::mesh_csg(mesh_a, mesh_b, op);
+    let mut out = crate::mesh::csg::mesh_csg(mesh_a, mesh_b, op);
+    quadrics.project_mesh(&mut out);
     validate_boolean_result(&out).map_err(BooleanError::InvalidResult)?;
-    Ok(BooleanResult::BRep(Box::new(crate::mesh::mesh_to_brep(
-        &out,
-    ))))
+    let mut brep = crate::mesh::mesh_to_brep(&out);
+    // Carry the operands' quadric carriers forward in the result's geometry
+    // store (no face references them; they are dormant). A later boolean
+    // whose operand is this triangle soup can then still recognize sphere
+    // and cylinder vertices and re-project them — without this, the first
+    // fallback in a chain is the LAST time the surfaces are known, and
+    // every subsequent cut re-shatters the quadric regions unrepaired.
+    quadrics.stash_into(&mut brep.geometry);
+    Ok(BooleanResult::BRep(Box::new(brep)))
+}
+
+/// Analytic quadric carriers of the two operands, used to push the mesh
+/// fallback's vertices back onto the surfaces they came from.
+///
+/// The mesh boolean works on tessellations: operand triangles get split by
+/// the other operand's carrier planes and the seams re-welded, so vertices
+/// that belong to a sphere end up on chords, midpoints, and snapped seam
+/// positions — measured up to ~0.6 mm off a R25 sphere, versus a 0.03 mm
+/// chord sag. Planes and cylinders come through exact; spheres do not.
+///
+/// The repair is conservative by construction:
+///  - a vertex is only moved if some quadric is within `BAND` of it, the
+///    move is small, and exactly ONE quadric claims it (seam vertices
+///    between two quadrics are left alone);
+///  - a vertex lying on one operand plane is projected ALONG that plane
+///    (onto the plane∩sphere circle), so planar faces stay planar;
+///  - a vertex on two or more planes (a box edge) is never moved.
+struct QuadricCtx {
+    spheres: Vec<(Point3, f64)>,
+    cylinders: Vec<(Point3, Vec3, f64)>,
+    planes: Vec<(Point3, Vec3)>,
+}
+
+impl QuadricCtx {
+    /// Distance band within which a vertex is considered to belong to a
+    /// quadric. Must exceed the worst observed off-surface error (~0.6 mm)
+    /// with margin, while staying below feature scale.
+    const BAND: f64 = 0.75;
+    /// A vertex closer than this to a plane carrier is treated as ON it.
+    const PLANE_EPS: f64 = 5e-4;
+    /// In-plane snap band for plane-constrained projection. Wider than
+    /// `BAND` because a plane at height h from the sphere center amplifies
+    /// radial error by 1/sin(phi): a 0.62 mm radial error at h = 19.8 on a
+    /// R25 sphere shows up as 0.93 mm in the plane.
+    const INPLANE_BAND: f64 = 1.3;
+    /// Vertices within this of the surface are already correct — leave
+    /// them; only genuinely displaced vertices are snapped. This is what
+    /// keeps legitimate geometry that merely passes near a quadric safe.
+    const GOOD_EPS: f64 = 0.02;
+
+    fn collect(a: &BRepSolid, b: &BRepSolid) -> Self {
+        let mut ctx = QuadricCtx {
+            spheres: Vec::new(),
+            cylinders: Vec::new(),
+            planes: Vec::new(),
+        };
+        let mut plane_keys: std::collections::HashSet<(i64, i64, i64, i64)> =
+            std::collections::HashSet::new();
+        for solid in [a, b] {
+            for surface in &solid.geometry.surfaces {
+                let any = surface.as_any();
+                if let Some(s) = any.downcast_ref::<vcad_kernel_geom::SphereSurface>() {
+                    let r = s.radius.abs();
+                    if r > 1e-9
+                        && !ctx
+                            .spheres
+                            .iter()
+                            .any(|(c, cr)| (*c - s.center).norm() < 1e-6 && (cr - r).abs() < 1e-6)
+                    {
+                        ctx.spheres.push((s.center, r));
+                    }
+                } else if let Some(c) = any.downcast_ref::<vcad_kernel_geom::CylinderSurface>() {
+                    let r = c.radius.abs();
+                    let axis = c.axis.into_inner();
+                    if r > 1e-9
+                        && !ctx.cylinders.iter().any(|(cc, ca, cr)| {
+                            (cr - r).abs() < 1e-6
+                                && ca.cross(&axis).norm() < 1e-6
+                                && {
+                                    let d = *cc - c.center;
+                                    (d - axis * d.dot(&axis)).norm() < 1e-6
+                                }
+                        })
+                    {
+                        ctx.cylinders.push((c.center, axis, r));
+                    }
+                } else if let Some(p) = any.downcast_ref::<vcad_kernel_geom::Plane>() {
+                    // Dedupe coincident carriers: a triangle-soup operand
+                    // contributes one Plane per triangle, and thousands of
+                    // copies of the same carrier would pin every vertex as
+                    // "on two planes". Canonical key: normal with its
+                    // largest component made positive, plus signed offset.
+                    let mut n = p.normal_dir.into_inner();
+                    let amax = n.x.abs().max(n.y.abs()).max(n.z.abs());
+                    let flip = if n.x.abs() == amax {
+                        n.x < 0.0
+                    } else if n.y.abs() == amax {
+                        n.y < 0.0
+                    } else {
+                        n.z < 0.0
+                    };
+                    if flip {
+                        n = -n;
+                    }
+                    let o = p.origin;
+                    let d = (o - Point3::origin()).dot(n);
+                    let key = (
+                        (n.x * 1e6).round() as i64,
+                        (n.y * 1e6).round() as i64,
+                        (n.z * 1e6).round() as i64,
+                        (d * 1e4).round() as i64,
+                    );
+                    if plane_keys.insert(key) {
+                        ctx.planes.push((o, n));
+                    }
+                }
+            }
+        }
+        ctx
+    }
+
+    /// Append this context's quadrics as dormant surfaces on a geometry
+    /// store, so `collect` on a chained boolean rediscovers them.
+    fn stash_into(&self, geom: &mut vcad_kernel_geom::GeometryStore) {
+        for (c, r) in &self.spheres {
+            let mut s = vcad_kernel_geom::SphereSurface::new(*r);
+            s.center = *c;
+            geom.add_surface(Box::new(s));
+        }
+        for (c, axis, r) in &self.cylinders {
+            let mut cy = vcad_kernel_geom::CylinderSurface::new(*r);
+            cy.center = *c;
+            cy.axis = vcad_kernel_math::Dir3::new_normalize(*axis);
+            geom.add_surface(Box::new(cy));
+        }
+    }
+
+    fn project_mesh(&self, mesh: &mut TriangleMesh) {
+        let dbg = std::env::var_os("VCAD_PROJ_DEBUG").is_some();
+        if self.spheres.is_empty() && self.cylinders.is_empty() {
+            return;
+        }
+        // Per-vertex incident triangle normals. The constraint a vertex
+        // lives under is decided LOCALLY: an incident face whose normal a
+        // nearby quadric cannot explain is a planar feature the vertex
+        // must stay on. Global plane lists cannot do this — a tessellated
+        // sphere contributes one facet carrier per triangle and pins
+        // everything.
+        let nv = mesh.vertices.len() / 3;
+        let mut inc: Vec<Vec<Vec3>> = vec![Vec::new(); nv];
+        for t in mesh.indices.chunks_exact(3) {
+            let g = |k: u32| {
+                Point3::new(
+                    mesh.vertices[(k as usize) * 3] as f64,
+                    mesh.vertices[(k as usize) * 3 + 1] as f64,
+                    mesh.vertices[(k as usize) * 3 + 2] as f64,
+                )
+            };
+            let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+            let n = (b - a).cross(&(c - a));
+            let l = n.norm();
+            if l < 1e-12 {
+                continue;
+            }
+            let n = n / l;
+            for &k in t {
+                let bucket = &mut inc[k as usize];
+                if !bucket.iter().any(|m| m.dot(&n).abs() > 0.996) {
+                    bucket.push(n);
+                }
+            }
+        }
+        let mut moved = 0usize;
+        for (vi, chunk) in mesh.vertices.chunks_exact_mut(3).enumerate() {
+            let v = Point3::new(chunk[0] as f64, chunk[1] as f64, chunk[2] as f64);
+            // Split incident normals into quadric-explained and planar.
+            let mut planar: Vec<Vec3> = Vec::new();
+            for n in &inc[vi] {
+                if !self.normal_explained(&v, n) {
+                    if !planar.iter().any(|m| m.dot(n).abs() > 0.996) {
+                        planar.push(*n);
+                    }
+                }
+            }
+            if planar.len() >= 2 {
+                continue; // feature edge or corner: pinned
+            }
+            if let Some(p) = self.project_point(&v, planar.first()) {
+                moved += 1;
+                chunk[0] = p.x as f32;
+                chunk[1] = p.y as f32;
+                chunk[2] = p.z as f32;
+            }
+        }
+        if dbg {
+            eprintln!(
+                "[proj] spheres={} cyls={} moved={} of {}",
+                self.spheres.len(),
+                self.cylinders.len(),
+                moved,
+                nv
+            );
+        }
+    }
+
+    /// Can any nearby quadric's surface normal at `v` explain the incident
+    /// facet normal `n`? Facet normals of a tessellated quadric lag the true
+    /// normal by up to the facet's angular pitch; 25 degrees of slack covers
+    /// coarse tessellations without absorbing genuinely planar features.
+    fn normal_explained(&self, v: &Point3, n: &Vec3) -> bool {
+        const COS_SLACK: f64 = 0.90; // ~25 degrees
+        for (c, r) in &self.spheres {
+            let d = *v - *c;
+            let dist = d.norm();
+            if (dist - r).abs() < Self::BAND && dist > 1e-9 && (d / dist).dot(n).abs() > COS_SLACK
+            {
+                return true;
+            }
+        }
+        for (c, axis, r) in &self.cylinders {
+            let d = *v - *c;
+            let radial = d - *axis * d.dot(*axis);
+            let dist = radial.norm();
+            if (dist - r).abs() < Self::BAND
+                && dist > 1e-9
+                && (radial / dist).dot(n).abs() > COS_SLACK
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn project_point(&self, v: &Point3, plane_n: Option<&Vec3>) -> Option<Point3> {
+        // A single planar constraint from the caller: the vertex lies on a
+        // planar feature through v with this normal, and must stay in it.
+        let on_planes: Vec<(Point3, Vec3)> = plane_n.map(|n| (*v, *n)).into_iter().collect();
+
+        // Classify against every quadric: `good` = already on it,
+        // `bad` = near it but displaced.
+        let mut sph_good: Vec<usize> = Vec::new();
+        let mut sph_bad: Vec<usize> = Vec::new();
+        for (i, (c, r)) in self.spheres.iter().enumerate() {
+            let e = ((*v - *c).norm() - r).abs();
+            if e <= Self::GOOD_EPS {
+                sph_good.push(i);
+            } else if e < Self::BAND {
+                sph_bad.push(i);
+            }
+        }
+        let mut cyl_good: Vec<usize> = Vec::new();
+        let mut cyl_bad: Vec<usize> = Vec::new();
+        for (i, (c, axis, r)) in self.cylinders.iter().enumerate() {
+            let d = *v - *c;
+            let radial = d - *axis * d.dot(*axis);
+            let e = (radial.norm() - r).abs();
+            if e <= Self::GOOD_EPS {
+                cyl_good.push(i);
+            } else if e < Self::BAND {
+                cyl_bad.push(i);
+            }
+        }
+
+        let bads = sph_bad.len() + cyl_bad.len();
+        if bads == 0 {
+            return None; // on-surface or far from everything
+        }
+
+        // Seam cases: displaced from a sphere while on (or also displaced
+        // from) a cylinder whose axis passes through the sphere center —
+        // the intersection is an exact circle; snap onto it. This keeps
+        // the vertex on the cylinder too.
+        if on_planes.is_empty() && sph_bad.len() == 1 && (cyl_good.len() + cyl_bad.len()) == 1 {
+            let ci = *cyl_good.first().or(cyl_bad.first()).unwrap();
+            let (sc, sr) = self.spheres[sph_bad[0]];
+            let (cc, axis, cr) = self.cylinders[ci];
+            if let Some(p) = Self::seam_circle(v, &sc, sr, &cc, &axis, cr) {
+                return Some(p).filter(|p| (*p - *v).norm() < Self::INPLANE_BAND);
+            }
+            return None;
+        }
+        if on_planes.is_empty() && cyl_bad.len() == 1 && sph_good.len() == 1 && sph_bad.is_empty() {
+            let (sc, sr) = self.spheres[sph_good[0]];
+            let (cc, axis, cr) = self.cylinders[cyl_bad[0]];
+            if let Some(p) = Self::seam_circle(v, &sc, sr, &cc, &axis, cr) {
+                return Some(p).filter(|p| (*p - *v).norm() < Self::INPLANE_BAND);
+            }
+            return None;
+        }
+        if !sph_good.is_empty() || !cyl_good.is_empty() {
+            return None; // already on some quadric; no clean target
+        }
+        if bads >= 2 {
+            return None; // multi-quadric displacement with no analytic seam
+        }
+
+        // Single displaced quadric.
+        if let Some(&i) = sph_bad.first() {
+            let (c, r) = self.spheres[i];
+            let d = *v - c;
+            let dist = d.norm();
+            if dist < 1e-9 {
+                return None;
+            }
+            let p = if let Some((o, n)) = on_planes.first() {
+                // Stay in the plane: project onto the plane∩sphere circle.
+                let h = (c - *o).dot(*n);
+                let rc2 = r * r - h * h;
+                if rc2 <= 1e-12 {
+                    return None;
+                }
+                let rc = rc2.sqrt();
+                let cc = c - *n * h;
+                let mut u = *v - cc;
+                u -= *n * u.dot(*n);
+                let ul = u.norm();
+                if ul < 1e-9 || (ul - rc).abs() >= Self::INPLANE_BAND {
+                    return None;
+                }
+                cc + u * (rc / ul)
+            } else {
+                c + d * (r / dist)
+            };
+            return Some(p).filter(|p| (*p - *v).norm() < Self::INPLANE_BAND);
+        }
+        if let Some(&i) = cyl_bad.first() {
+            let (c, axis, r) = self.cylinders[i];
+            let d = *v - c;
+            let radial = d - axis * d.dot(axis);
+            let dist = radial.norm();
+            if dist < 1e-9 || !on_planes.is_empty() {
+                return None; // plane-constrained cylinder: skip
+            }
+            let p = *v - radial + radial * (r / dist);
+            return Some(p).filter(|p| (*p - *v).norm() < Self::INPLANE_BAND);
+        }
+        None
+    }
+
+    /// Intersection circle of a sphere and a cylinder whose axis passes
+    /// through the sphere center; projection of `v` onto it, or None when
+    /// the configuration is not that special case.
+    fn seam_circle(
+        v: &Point3,
+        sc: &Point3,
+        sr: f64,
+        cc: &Point3,
+        axis: &Vec3,
+        cr: f64,
+    ) -> Option<Point3> {
+        let co = *sc - *cc;
+        let off = co - *axis * co.dot(*axis);
+        if off.norm() > 1e-6 || sr * sr <= cr * cr {
+            return None;
+        }
+        let h = (sr * sr - cr * cr).sqrt();
+        let d = *v - *sc;
+        let t = d.dot(*axis);
+        let radial = d - *axis * t;
+        let rl = radial.norm();
+        if rl < 1e-9 {
+            return None;
+        }
+        let t_seam = if t >= 0.0 { h } else { -h };
+        Some(*sc + *axis * t_seam + radial * (cr / rl))
+    }
 }

--- a/crates/vcad-kernel-booleans/tests/quadric_surface_fidelity.rs
+++ b/crates/vcad-kernel-booleans/tests/quadric_surface_fidelity.rs
@@ -1,0 +1,186 @@
+//! Regression tests for defect D (printed-part handoff, 2026-08-12):
+//! tessellated boolean results must keep quadric-face vertices ON the
+//! analytic surface.
+//!
+//! The mesh-CSG fallback splits operand triangles and heals seams at the
+//! mesh level, which used to leave sphere vertices up to ~0.6 mm off a
+//! R25 sphere — 20x the legitimate chord sag, and larger than a printed
+//! part's entire fit budget (a Ø50 conforming socket runs 0.05–0.4 mm
+//! fits). Volume assertions cannot catch this: the displacements average
+//! out, so every volume check passed while the surface was lumpy.
+//!
+//! Hence these assert SURFACE FIDELITY: max |dist(v, center) − R| over
+//! the mesh vertices lying in a band around each quadric.
+
+use vcad_kernel_booleans::{boolean_op, BooleanOp, BooleanResult};
+use vcad_kernel_math::{Point3, Transform};
+use vcad_kernel_primitives::{make_cube, make_cylinder, make_sphere, BRepSolid};
+use vcad_kernel_tessellate::{tessellate_brep, TriangleMesh};
+
+const SEGMENTS: u32 = 32;
+
+fn apply_transform(brep: &mut BRepSolid, t: &Transform) {
+    for (_, v) in &mut brep.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    brep.geometry.surfaces = brep
+        .geometry
+        .surfaces
+        .drain(..)
+        .map(|s| s.transform(t))
+        .collect();
+}
+
+fn translate(brep: &mut BRepSolid, dx: f64, dy: f64, dz: f64) {
+    apply_transform(brep, &Transform::translation(dx, dy, dz));
+}
+
+fn result_mesh(r: BooleanResult) -> TriangleMesh {
+    let BooleanResult::BRep(brep) = r;
+    tessellate_brep(&brep, SEGMENTS)
+}
+
+/// Max |dist(v, c) − r| over vertices within `band` of the sphere surface,
+/// optionally restricted by a vertex filter (used to exclude designed
+/// feature edges where a vertex legitimately belongs to two surfaces).
+fn sphere_fidelity(
+    mesh: &TriangleMesh,
+    c: Point3,
+    r: f64,
+    band: f64,
+    keep: impl Fn(&Point3) -> bool,
+) -> (usize, f64) {
+    let mut n = 0usize;
+    let mut worst = 0.0f64;
+    for v in mesh.vertices.chunks_exact(3) {
+        let p = Point3::new(v[0] as f64, v[1] as f64, v[2] as f64);
+        let e = ((p - c).norm() - r).abs();
+        if e < band && keep(&p) {
+            n += 1;
+            worst = worst.max(e);
+        }
+    }
+    (n, worst)
+}
+
+fn mesh_volume(mesh: &TriangleMesh) -> f64 {
+    let mut vol = 0.0f64;
+    for t in mesh.indices.chunks_exact(3) {
+        let g = |k: u32| {
+            let i = (k as usize) * 3;
+            [
+                mesh.vertices[i] as f64,
+                mesh.vertices[i + 1] as f64,
+                mesh.vertices[i + 2] as f64,
+            ]
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        vol += (a[0] * (b[1] * c[2] - b[2] * c[1]) - a[1] * (b[0] * c[2] - b[2] * c[0])
+            + a[2] * (b[0] * c[1] - b[1] * c[0]))
+            / 6.0;
+    }
+    vol.abs()
+}
+
+/// The printed-part control: a sphere pocket breaking through several faces
+/// of a block (forces the mesh fallback). Every socket vertex must sit on
+/// the R25 sphere to well under a printed fit budget.
+#[test]
+fn sphere_pocket_through_faces_stays_on_surface() {
+    // Ball center at origin; block corner at (-38, -40, 0.2), i.e. the
+    // rev D upper cuff blank: sphere breaks the z, one y, and no x faces.
+    let mut cube = make_cube(76.0, 62.0, 19.8);
+    translate(&mut cube, -38.0, -40.0, 0.2);
+    let sphere = make_sphere(25.0, SEGMENTS);
+
+    let mesh = result_mesh(
+        boolean_op(&cube, &sphere, BooleanOp::Difference, SEGMENTS).expect("boolean"),
+    );
+
+    let vol = mesh_volume(&mesh);
+    // MC ground truth for this arrangement: 63,228 ± 60.
+    assert!(
+        (vol - 63_228.0).abs() < 0.01 * 63_228.0,
+        "volume {vol:.0} departs from ground truth 63,228"
+    );
+
+    // Functional seat surface: away from the block rims (y = 22) and the
+    // relief plane (z = 0.2), where designed feature corners legitimately
+    // pin vertices between two planes.
+    let (n, worst) = sphere_fidelity(&mesh, Point3::origin(), 25.0, 0.4, |p| {
+        p.z > 0.5 && p.y < 20.0
+    });
+    assert!(n > 100, "expected a populated socket band, got {n} verts");
+    // At this test's 32-segment tessellation the projection floor is
+    // ~0.09 mm (a handful of seam vertices constrained by damaged facet
+    // normals); export-resolution meshes measure <= 0.02. The threshold
+    // is set to catch the failure class (0.64 pre-fix), not the floor.
+    assert!(
+        worst < 0.15,
+        "seat vertices up to {worst:.3} mm off the R25 sphere (was 0.64 before the fix)"
+    );
+}
+
+/// Chained cuts must not re-shatter the sphere region: the quadric
+/// carriers are stashed on the fallback result so later booleans keep
+/// projecting. Two box cuts after the pocket, then check fidelity.
+#[test]
+fn chained_cuts_keep_sphere_fidelity() {
+    let mut cube = make_cube(76.0, 62.0, 19.8);
+    translate(&mut cube, -38.0, -40.0, 0.2);
+    let sphere = make_sphere(25.0, SEGMENTS);
+    let r1 = boolean_op(&cube, &sphere, BooleanOp::Difference, SEGMENTS).expect("cut 1");
+    let BooleanResult::BRep(s1) = r1;
+
+    let mut slot = make_cube(5.0, 5.0, 40.0);
+    translate(&mut slot, -34.5, 12.0, -5.0);
+    let r2 = boolean_op(&s1, &slot, BooleanOp::Difference, SEGMENTS).expect("cut 2");
+    let BooleanResult::BRep(s2) = r2;
+
+    let mut slot2 = make_cube(5.0, 5.0, 40.0);
+    translate(&mut slot2, 29.5, 12.0, -5.0);
+    let r3 = boolean_op(&s2, &slot2, BooleanOp::Difference, SEGMENTS).expect("cut 3");
+
+    let mesh = result_mesh(r3);
+    let (n, worst) = sphere_fidelity(&mesh, Point3::origin(), 25.0, 0.4, |p| {
+        p.z > 0.5 && p.y < 20.0
+    });
+    assert!(n > 100, "expected a populated socket band, got {n} verts");
+    assert!(
+        worst < 0.15,
+        "after chained cuts, seat vertices up to {worst:.3} mm off the sphere (0.39 pre-fix)"
+    );
+}
+
+/// Sphere ∩ cylinder with the cylinder axis through the sphere center (the
+/// cuff's socket/journal handoff): seam vertices must land on the exact
+/// intersection circle, and both surfaces must stay true away from designed
+/// feature corners.
+#[test]
+fn sphere_cylinder_seam_lands_on_intersection_circle() {
+    let mut cube = make_cube(76.0, 62.0, 19.8);
+    translate(&mut cube, -38.0, -40.0, 0.2);
+    let sphere = make_sphere(25.0, SEGMENTS);
+    let r1 = boolean_op(&cube, &sphere, BooleanOp::Difference, SEGMENTS).expect("cut 1");
+    let BooleanResult::BRep(s1) = r1;
+
+    // Bore along -Y, axis through the ball center, breaking out the y face.
+    let mut bore = make_cylinder(17.5, 28.0, SEGMENTS);
+    apply_transform(
+        &mut bore,
+        &Transform::rotation_x(-std::f64::consts::FRAC_PI_2),
+    );
+    translate(&mut bore, 0.0, -16.0, 0.0);
+    let r2 = boolean_op(&s1, &bore, BooleanOp::Difference, SEGMENTS).expect("cut 2");
+
+    let mesh = result_mesh(r2);
+    // Exclude the bore rim's plane crossings; judge the open sphere band.
+    let (n, worst) = sphere_fidelity(&mesh, Point3::origin(), 25.0, 0.4, |p| {
+        p.z > 0.5 && p.y < 20.0 && (p.x.hypot(p.z) - 17.5).abs() > 1.0
+    });
+    assert!(n > 50, "expected a populated socket band, got {n} verts");
+    assert!(
+        worst < 0.15,
+        "seat vertices up to {worst:.3} mm off the sphere near the bore (0.39 pre-fix)"
+    );
+}

--- a/crates/vcad-kernel-booleans/tests/quadric_surface_fidelity.rs
+++ b/crates/vcad-kernel-booleans/tests/quadric_surface_fidelity.rs
@@ -93,9 +93,8 @@ fn sphere_pocket_through_faces_stays_on_surface() {
     translate(&mut cube, -38.0, -40.0, 0.2);
     let sphere = make_sphere(25.0, SEGMENTS);
 
-    let mesh = result_mesh(
-        boolean_op(&cube, &sphere, BooleanOp::Difference, SEGMENTS).expect("boolean"),
-    );
+    let mesh =
+        result_mesh(boolean_op(&cube, &sphere, BooleanOp::Difference, SEGMENTS).expect("boolean"));
 
     let vol = mesh_volume(&mesh);
     // MC ground truth for this arrangement: 63,228 ± 60.

--- a/hardware/k1-ball-cuff/README.md
+++ b/hardware/k1-ball-cuff/README.md
@@ -1,0 +1,20 @@
+# K1 ball cuff — tool coupling for the Booster K1 humanoid
+
+Real hardware designed in vcad/loon: a tool-side coupling that grips the K1's
+Ø50.000 terminal hand ball so the robot can hold a shovel (or any handled tool).
+
+| file | what |
+|---|---|
+| `k1-ball-cuff.loon` | rev D — two-piece clamshell, exact spherical socket, pillow-block face relief, bump-stop journal |
+| `k1-ball-cuff-mono.loon` | rev E — single-piece slide-on pinch collar (the ball is the terminal link, so the cuff enters axially and one M4 across a slit captures it) |
+| `tool-coupling-first-principles.md` | why the design looks like this: the 14 N·m arm budget, the over-constraint story, the forearm-axis torque problem |
+| `k1-cuff-functional-sim.md` | seating-funnel and load-capacity verification methodology |
+| `vcad-boolean-bug-handoff.md` | the kernel bugs this part flushed out, with repros and post-fix evaluations (defects A–C fixed; **defect D — sphere tessellation vertices ±0.6 mm off-surface — still open and blocks printing these**) |
+
+This part is a natural kernel torture test: sphere∕cylinder∕box booleans in
+every combination, thin slits through curved bodies, and printed-fit tolerances
+(0.05–0.4 mm) that fail loudly when tessellation fidelity slips. Every claim in
+the handoff doc is volume-verified against an independent Monte-Carlo model —
+never render-verified.
+
+Export: `vcad export k1-ball-cuff-mono.loon mono.stl`

--- a/hardware/k1-ball-cuff/k1-ball-cuff-mono.loon
+++ b/hardware/k1-ball-cuff/k1-ball-cuff-mono.loon
@@ -1,0 +1,90 @@
+; K1 Ball Cuff, rev E "mono" — single-piece slide-on pinch collar
+;
+; THE OBSERVATION THAT MAKES ONE PIECE POSSIBLE
+; The ball is the TERMINAL link of the arm — nothing exists distal of it. So the
+; cuff does not need to open at all: it slides on axially from the fingertip
+; direction over a Ø50.1 bore, the ball seats in an exact spherical zone, and a
+; single M4 pinch bolt across an axial slit ovalizes the mouth ~1 mm. The ball
+; is then captive behind its own equator. One print, one bolt, no hinge, no
+; clamshell, no alignment features — the slit collar IS the preload mechanism,
+; same as a bicycle seatpost clamp.
+;
+; Versus a print-in-place hinge: a hinge still needs a closure bolt row on the
+; far side, its pin becomes a wear part, and PLA living hinges are brittle.
+; The slit deletes all of that.
+;
+; PRINT ORIENTATION — mouth down (collar axis vertical, rod hole at top).
+; The spherical ceiling narrows from the equator to the Ø35 rod hole; at that
+; hole the surface sits at 45.6 degrees from horizontal, i.e. the rod hole
+; truncates the sphere almost exactly at the self-supporting limit. The whole
+; cavity prints clean with no supports; only the handle boss (sideways in this
+; orientation) needs them, and those touch outside surfaces only.
+;
+; Frame: ball center at origin. Collar axis = Y (the forearm axis).
+;   -Y proximal (rod side), +Y distal (open mouth), +Z handle boss.
+;
+; Surfaces are exact per the rev D rule:
+;   ball seat   sphere R 25.05  (0.05 clearance; pinch closes it)
+;   lead-in     cylinder R 25.05, equator to the distal face
+;   rod pass    cylinder R 17.5 (Ø35 bump stop, 1.0 mm clearance)
+;   outer body  cylinder R 31 — round, because it can be now
+;
+; Sized to the robot: arm joints all stop at 14 Nm and the arm pulls 38 N max.
+; One M4 at 0.15 Nm closing the slit gives hundreds of newtons of conforming
+; grip on the equator band — geometric retention axially, friction about the
+; forearm axis with the bump stop as backstop. A second bolt row is provided at
+; the rod end to close the journal onto the rod; leave it loose if the tool
+; should swivel there.
+;
+; NOTE - BLOCKED ON PRINT with rev D by vcad defect D (sphere tessellation puts
+; vertices +/-0.6 mm off-surface). Same acceptance: re-export after the fix.
+
+[let petg [material "petg" 0.15 0.55 0.75 0.0 0.45]]
+[let bx [fn [sx sy sz px py pz] [translate px py pz [cube sx sy sz]]]]
+
+; --- body: round collar + handle boss --------------------------------------
+; Collar: R 31 about Y, y -40 .. +30 (10 mm of wall beyond the ball equator
+; before the mouth; the rod end carries the bump-stop journal).
+[let collar
+  [translate 0.0 -40.0 0.0
+    [rotate -90.0 0.0 0.0
+      [cylinder 31.0 70.0]]]]
+
+; Handle boss embedded into the collar top, 25.8 square pocket for 1 in tube.
+; Pocket floor z = 40 leaves ~15 mm of solid between tube and cavity crown.
+[let body
+  [union [bx 52.0 34.0 26.0 -26.0 -16.0 28.0] collar]]
+
+; --- the one-piece magic: cavity, slit, bolts -------------------------------
+[let seat [sphere 25.05]]
+[let lead-in
+  [rotate -90.0 0.0 0.0
+    [cylinder 25.05 32.0]]]
+[let rod-pass
+  [translate 0.0 -41.0 0.0
+    [rotate -90.0 0.0 0.0
+      [cylinder 17.5 26.0]]]]
+
+; Axial slit, 2.5 mm, from the cavity straight down through the bottom of the
+; collar, full length. This is the compliance that lets one bolt do everything.
+[let slit [bx 2.5 70.0 34.0 -1.25 -40.0 -34.0]]
+
+; Pinch bolts: M4 clearance holes along X through both slit cheeks.
+;   bolt 1 at y = +8  — closes the mouth over the ball equator (the keeper)
+;   bolt 2 at y = -30 — closes the journal on the rod (optional / swivel)
+[let pinch-hole [fn [py]
+  [translate -32.0 py -26.0
+    [rotate 0.0 90.0 0.0
+      [cylinder 2.2 64.0]]]]]
+
+[let mono
+  [pipe body
+    [difference [bx 60.0 25.8 25.8 -30.0 -12.9 40.0]]
+    [difference seat]
+    [difference lead-in]
+    [difference rod-pass]
+    [difference slit]
+    [difference [pinch-hole 8.0]]
+    [difference [pinch-hole -30.0]]]]
+
+[root mono "petg"]

--- a/hardware/k1-ball-cuff/k1-ball-cuff.loon
+++ b/hardware/k1-ball-cuff/k1-ball-cuff.loon
@@ -1,0 +1,102 @@
+; K1 Ball Capture Cuff, rev D — exact-surface clamshell for the Booster K1 hand ball
+;
+; MEASURED (Left_Arm_4.STL): ball a true sphere, D 50.000 (sphericity 0.002 mm),
+; center 203.0 mm from the Elbow_Yaw origin; forearm rod D 34.00 concentric to
+; 0.06 mm; arm is 4-DOF, no wrist; every arm joint limited to 14 Nm.
+;
+; Frame: ball center at origin, split plane z = 0.
+;   +X = tool handle axis    -Y = proximal, toward the elbow    +Z = up
+;
+; ---------------------------------------------------------------------------
+; WHAT CHANGED FROM REV C AND WHY
+;
+; Rev C approximated the ball with crossed 45-degree V-troughs cut from rotated
+; boxes, because the kernel of the day could not cut a sphere and then keep
+; working on the part. Those kernel bugs are fixed (#789/#792/#793), and the
+; printed rev C did not seat cleanly. Rev D models the mating surfaces as what
+; they are:
+;
+;   ball  -> spherical socket, R 25.00 exact, conforming
+;   rod   -> cylindrical bore, R 17.50 (1.0 mm diametral clearance)
+;
+; Preload is the pillow-block scheme: the sockets are cut at EXACTLY the ball
+; radius, both centered on the true ball center, and the mating FACES are
+; relieved 0.2 mm per side instead. Bolting closes the 0.4 mm face gap and the
+; halves conform elastically onto the ball — zero designed interference, full
+; surface contact, and FDM's natural hole-undersize only adds grip.
+;
+; (Rev D.0 tried displacing each socket center 0.2 mm into the split gap for a
+; "polar pinch". Checked analytically, that undersizes the whole cap above
+; z ~ 6 mm — 204 mm3 of tapering crush, the same small-everywhere-conforming-
+; socket failure this header already warned against. Offset centers are the
+; wrong preload mechanism for conforming sockets; face relief is the right one.)
+;
+; The journal is a BUMP STOP, not a bearing. Rev C's 0.2 mm journal clearance
+; made the cuff kinematically over-constrained (8 constraints on 5 DOF) and was
+; below what FDM holds — the most likely cause of the bad seat. At 1.0 mm
+; clearance the bore carries nothing until ~1.5 degrees of prying rotation,
+; then takes the moment on the 30 mm seat-to-journal arm. Blade slop of 1.5
+; degrees is irrelevant for digging; a clean seat is not.
+;
+; Sized to the robot, not to the material: every arm joint stops at 14 Nm and
+; the arm can pull 38 N, so bolts at 0.15 Nm (four of them, not six) give
+; ~1.1 kN of clamp — friction capacity about the forearm axis then matches the
+; actuator, and everything else is geometric. Rev C's 6 kN / six-bolt spec was
+; strength the robot cannot use, paid for in grams at 369 mm of reach.
+; ---------------------------------------------------------------------------
+
+[let petg [material "petg" 0.15 0.55 0.75 0.0 0.45]]
+
+; corner-positioned box helper, so every dimension reads as a real extent
+[let bx [fn [sx sy sz px py pz] [translate px py pz [cube sx sy sz]]]]
+
+; 5 mm square slot for an M4 carriage bolt, through Z. Square stays: it is the
+; right shape for a carriage-bolt neck, nothing to do with old kernel limits.
+[let bolt-slot [fn [px py pz] [bx 5.0 5.0 40.0 px py pz]]]
+
+; --- exact tools ------------------------------------------------------------
+; Socket: R 25.00 exact, centered on the true ball center for BOTH halves.
+[let socket [sphere 25.0]]
+
+; Neck bore: R 17.5 on the R 17.0 rod, axis -Y, spanning y -44..-16.
+; It may overlap the socket freely — both are exact cuts now, and their union
+; is simply "the robot, offset". No hand-off plane to manage.
+[let neck-bore
+  [translate 0.0 -44.0 0.0
+    [rotate -90.0 0.0 0.0
+      [cylinder 17.5 28.0]]]]
+
+; --- upper half -------------------------------------------------------------
+; Block x +/-38, y -40..22, z 0..20: 4 bolts instead of 6, ~20% less material
+; than rev C. Handle boss on top with the 25.8 square pocket for 1 in square
+; aluminium tube (floor at z = 30 clears the socket crown at 25.0 by 5 mm of
+; solid roof — the load path from handle to clamp).
+; Block face sits at z = +0.2 (the 0.2 mm relief); boss on top as before.
+[let upper-blank
+  [union [bx 52.0 34.0 22.0 -26.0 -16.0 20.0]
+         [bx 76.0 62.0 19.8 -38.0 -40.0 0.2]]]
+
+[let upper
+  [pipe upper-blank
+    [difference socket]
+    [difference neck-bore]
+    [difference [bx 60.0 25.8 25.8 -30.0 -12.9 30.0]]
+    [difference [bolt-slot -34.5 12.0 -5.0]]
+    [difference [bolt-slot 29.5 12.0 -5.0]]
+    [difference [bolt-slot -34.5 -33.0 -5.0]]
+    [difference [bolt-slot 29.5 -33.0 -5.0]]]]
+
+; --- lower half: plain cap, same footprint, same bolt pattern ---------------
+[let lower-blank [bx 76.0 62.0 19.8 -38.0 -40.0 -20.0]]
+
+[let lower
+  [pipe lower-blank
+    [difference socket]
+    [difference neck-bore]
+    [difference [bolt-slot -34.5 12.0 -35.0]]
+    [difference [bolt-slot 29.5 12.0 -35.0]]
+    [difference [bolt-slot -34.5 -33.0 -35.0]]
+    [difference [bolt-slot 29.5 -33.0 -35.0]]]]
+
+[root upper "petg"]
+[root lower "petg"]

--- a/hardware/k1-ball-cuff/k1-cuff-functional-sim.md
+++ b/hardware/k1-ball-cuff/k1-cuff-functional-sim.md
@@ -1,0 +1,84 @@
+# K1 ball cuff — functional verification (quasi-static, mesh-grounded)
+
+Method: the printable STLs (exported by vcad from k1-ball-cuff.loon), trimesh
+signed-distance settle sweeps, and direct force balance. Scripts: settle_mesh.py /
+loads.py alongside; rerunnable against any revision.
+
+Note: vcad's STL export still emits some T-junction edges (61 upper / 16 lower,
+tracked as defect C in vcad-boolean-bug-handoff.md). Volumes are verified correct
+(+0.5%/+0.6% vs Monte-Carlo, pure tessellation). Slicers handle T-junctions;
+some renderers show them as spurious backfaces. Re-export once defect C lands.
+
+## Seating (the robot-facing half of "attach")
+
+Sphere-drop settle against the actual lower-half mesh: every start inside the
+V mouth — ±34 mm across the groove — converges to the exact seat (x=0,
+z=+0.42 mm) with zero snags from bolt slots or the neck relief. Along the
+groove the cradle is deliberately prismatic; Y is set by pressing the rod
+against the journal end, then the upper half's crossed groove locks it.
+Yaw tolerance before the rod fouls the block edge: ~41°.
+
+±34 mm / ±41° is an enormous funnel by robot standards — the arm can be
+centimeters off and gravity finishes the job.
+
+## Attach/detach as designed — honest status
+
+Rev C is a bolted clamshell: DETACH IS A HUMAN WITH A DRIVER, not a robot
+action. The robot's part is only: lay the ball into the open cradle (verified
+above), hold still while a human closes six M4s, and later pull straight out
+once opened. Robot-self-service don/doff needs the over-center latch variant
+in place of the bolt rows — same socket geometry, latch replaces fasteners.
+
+## Load capacity (does it shovel?)
+
+Preload path: 6× M4 at 0.8 N·m → ~6 kN clamp, all of it through the ball
+(the 0.42 mm designed gap guarantees this) → ~4.2 kN per V contact, which
+flattens to a ~7 mm-radius patch at PETG's long-term 30 MPa. Fine.
+
+- **Caged directions** (all translations, both bending moments): geometric.
+  Prying at 27.5 N·m (4 kg on a 0.7 m arm) puts 0.86 MPa on the journal —
+  30x margin. A 200 N yank adds 33 N per bolt against ~4 kN proof. Not the
+  limit in any realistic dig.
+- **Rod-axis torque is friction-only** — sphere and cylinder are both
+  surfaces of revolution about the forearm axis, so nothing geometric resists
+  rotation about it. Capacity ~75 N·m at μ=0.25 with fresh preload. That is
+  11x the elbow-yaw actuator's ~7 N·m, so the actuator stalls before the cuff
+  slips — and a slip under rock-strike overload acts as a mechanical fuse.
+  The real risk is PETG creep quietly eating the preload: retorque after the
+  first day, and treat audible slip as the retorque alarm. If it ever needs
+  to be geometric, that's a keyway rev — but there is no flat on the forearm
+  to key against, so it would mean bonding a collar to the rod.
+
+## What quasi-statics cannot answer
+
+Impact/vibration (blade striking rock), preload decay rate, and the actual
+digging cycle under the balance policy. Next step there: convex-decompose the
+halves (coacd), weld into K1_22dof.xml as a MuJoCo body or into phyz via the
+URDF, and replay a dig trajectory. The mass properties to use: assembled cuff
+137 g, COM (0, −10.4, +7.5) mm from ball center (at 4-wall/40%-infill effective density).
+
+
+## Correction, 2026-08-12 — the lower journal did not exist
+
+Found while bisecting a T-junction count: the rev-C lower V-groove ran the full
+block length in Y, and at x = 0 that trough is void past the block's bottom
+face — so it deleted every scrap of material under the forearm rod. Probing at
+the journal station y = -33 found air below, beside and above the rod in the
+lower half. The journal was upper-shell-only: the ball-seat/journal couple
+carried moment in one direction and nothing in the other, which is most of the
+reason the cuff exists.
+
+Fixed by stopping the lower trough at y = -19 — exactly where the robot stops
+being a ball and starts being a rod (ball radius there is 16.25 mm, already
+inside the 17.2 mm bore, so the bore takes over clearance duty). Groove and
+bore now hand off at the same plane. Re-probed: lower half SOLID below and
+beside the rod, upper half SOLID above it — a full journal. Interference back
+to 26.8 mm³, i.e. the four designed preload lenses and nothing else.
+
+Why the earlier verification missed it: the Monte-Carlo model was written from
+the same CSG as the loon source, so it proved the mesh matched the code — never
+that the code expressed the design. Geometric-intent probes (is there material
+where the journal is supposed to be?) are a different check from volume
+agreement, and only the probe could have caught this.
+
+Mass rose 127 g -> 137 g; COM (0, -10.4, +7.5) mm from the ball center.

--- a/hardware/k1-ball-cuff/tool-coupling-first-principles.md
+++ b/hardware/k1-ball-cuff/tool-coupling-first-principles.md
@@ -1,0 +1,128 @@
+# K1 tool coupling — first-principles reconsideration
+
+Written after rev C printed and didn't seat cleanly. This revisits the premises
+rather than the dimensions, because the dimensions turn out to be right.
+
+## What is not wrong
+
+The CAD geometry is exact, so nothing here is a measurement error:
+
+- hand ball: best-fit centre y = 203.000 mm, R = 25.000, **sphericity spread
+  0.002 mm** over 1621 vertices. A true Ø50.000 sphere.
+- forearm rod: Ø34.00, concentric with the ball axis to 0.06 mm.
+
+Both halves also verified against an independent volume model (+0.5%/+0.6%) and
+the seating funnel is ±34 mm. The part that got printed is the part that was
+designed. So the problem is in the design premises.
+
+## The premise that was wrong
+
+**I optimised for strength. Strength was never the binding constraint.**
+
+Every arm joint on the K1 is limited to **14 N·m** (URDF `effort`, all four:
+shoulder pitch, shoulder roll, elbow pitch, elbow yaw). With the ball 369 mm
+from shoulder roll, that is:
+
+| quantity | value |
+|---|---|
+| static payload at the hand | **3.9 kg** |
+| straight pull the arm can exert at the hand | **38 N** |
+| largest moment the arm can apply about any axis | **14 N·m** |
+
+Against that, rev C at its *specified* 0.8 N·m bolt torque delivers 6 kN of
+clamp and 75 N·m of rod-axis friction capacity — **5× more than the arm can
+ever demand**, and the caged directions are 30× over. I built a coupling for a
+machine an order of magnitude stronger than the one we own.
+
+Working backwards from 14 N·m instead: friction capacity needs
+`N = M/(4 μ r) = 14/(4·0.25·0.01768)` = 792 N per contact, ≈ 1.1 kN of clamp,
+which is **0.15 N·m per bolt** — a fifth of spec, comfortably inside PLA. And a
+retention feature only has to beat a 38 N pull, so ~100 N of snap holds the tool
+against anything the robot can do to it.
+
+So the real objective function was never strength. It is, in order:
+
+1. **mass at the hand** — 161 g is 4% of a 3.9 kg payload budget, spent at the
+   worst possible moment arm
+2. **tolerance robustness** — it has to seat on a printed part every time
+3. **tool-change** — the original goal was tool-*using* behaviour
+
+Rev C scores badly on all three and superbly on the one that didn't matter.
+
+## The fit failure is over-constraint, and it was predictable
+
+Count constraints on the tool relative to the hand:
+
+- V-seat, 4 point contacts on the sphere → locates 3 translations (1 redundant,
+  benign, standard for a clamped V-block)
+- neck journal, a Ø34.4 bore on a Ø34.0 rod → locates 2 more translations *and*
+  2 rotations
+
+That is **8 constraints for 5 DOF** (the 6th, spin about the rod axis, is
+deliberately free). Three are redundant. With perfect parts they agree; with a
+printed part the V-seat says "ball centre here" and the journal says "rod axis
+there," they disagree by the print error, and the assembly rocks or refuses to
+close. Kinematic design rule I violated: **constrain each DOF exactly once.**
+
+Compounding it, the journal's 0.2 mm diametral clearance is below what FDM
+holds — printed holes typically come out 0.1–0.4 mm *under* nominal from flow
+and elephant's foot. The journal is very likely interfering before the V-seat
+ever touches, which would present exactly as "close, but doesn't sit right."
+
+## The constraint that cannot be designed away
+
+The ball and the rod are both **surfaces of revolution about the forearm axis**.
+No amount of cleverness extracts torque about that axis from them — only
+friction, which needs clamp force, which needs bolts and mass. This is a
+property of the robot, not of the cuff.
+
+Three ways out, and they are genuinely different products:
+
+**A. Pay for friction (rev C's answer, now correctly sized).** 1.1 kN of clamp
+covers the arm's full 14 N·m. Bolted, human-serviced. Right when the tool must
+resist twist about the forearm — a shovel held crosswise.
+
+**B. Move the interface to the forearm.** `Left_Arm_3` is measurably non-round —
+6 to 18 mm of shape off-round across its length. That is a real key: full torque
+transmission with no friction, no preload, no creep. The cost is that
+`Left_Arm_3` sits *before* elbow yaw, so the tool loses the one rotational DOF
+the arm has, and the hand ball becomes a protrusion to design around. Right for
+tools that don't need blade rotation.
+
+**C. Don't need the torque.** Two hands on one bar leaves exactly one free DOF
+(spin about the line joining the two ball centres), killed by a third passive
+bearing point against a forearm or the torso — no clamping anywhere. Also: any
+tool whose load line passes near the forearm axis (a poker, a hook, a coaxial
+gripper) never generates the troublesome moment at all.
+
+## What I would build now
+
+**A light single-locator cuff.** Keep the V-seat as the *only* locator. Open the
+journal to ~1 mm diametral clearance and demote it from bearing to **bump
+stop** — it carries nothing until ~1.5° of rotation, then takes the moment. That
+removes all three redundant constraints and the un-printable fit in one change,
+and 1.5° of blade slop is irrelevant for digging.
+
+Then re-size everything for 0.15 N·m bolts instead of 0.8: fewer bolts, thinner
+sections, and the block can lose most of its 161 g.
+
+Separately, and more interesting for the actual goal: **the docking question is
+the real product.** Because the arm can only pull 38 N, a snap that holds 100 N
+can never be removed by the robot — but *can* be released by pressing the tool
+into a fixed dock, which is a robot-executable motion. That is the difference
+between a prosthetic and a tool-using hand, and it costs nothing in strength
+because there is no strength to spend.
+
+## Measurements needed before cutting metal (or plastic) again
+
+The CAD is exact but the robot may not be:
+
+1. **Caliper the actual ball** in two or three axes. If it is moulded or
+   rubber-skinned it may not be Ø50.000, and a compliant skin changes the seat
+   entirely.
+2. **Caliper the rod** near y = -33 from the ball centre.
+3. **Caliper the printed journal bore** and the V-seat opening on the part in
+   hand — that separates "design over-constraint" from "printer tolerance."
+4. With the lower half alone, check whether the ball rocks in the V before the
+   journal is involved. If it seats cleanly alone and fights once both halves
+   close, over-constraint is confirmed.

--- a/hardware/k1-ball-cuff/vcad-boolean-bug-handoff.md
+++ b/hardware/k1-ball-cuff/vcad-boolean-bug-handoff.md
@@ -1,0 +1,276 @@
+# Handoff: vcad boolean `Difference` mis-classifies faces against curved geometry
+
+## Context
+
+I was modelling a real part in vcad — a two-piece clamp with a hemispherical
+socket (a Ø50 ball capture cuff for a Booster K1 humanoid hand). It is about the
+simplest real mechanical feature there is: a hemispherical pocket in a block,
+then ordinary box cuts around it. It cannot currently be built. Every failure was
+**silent** — `Difference` returned a wrong solid with no error and no warning, so
+each one looked like success until I measured the volume.
+
+Please fix the boolean, and add a validity guard so this class of failure can
+never again be silent.
+
+## Reproducing
+
+Two notes on the harness, because they cost me time:
+
+1. `vcad info` / `vcad export` **cannot read v0.2 VCode `.vcad` files**, even
+   though `vcad-ir` parses them fine. `load_vcad_document` in
+   `crates/vcad-cli/src/main.rs:863` only accepts `FileFormat::V2Crdt` and
+   `FileFormat::V1Json`, and falls through to `unrecognized .vcad file format`.
+   Worth wiring `vcad_ir::vcode::from_vcode` into that match as a separate small
+   fix. I worked around it with a 10-line shim calling `from_vcode` then
+   `Document::to_json`.
+
+2. Verify by **volume**, never by render. Several of these failures look
+   completely plausible in a screenshot.
+
+Each case below is VCode. Analytic expected volumes are given; the tessellated
+sphere reads about 0.5–1.5% off, which is fine and not the issue.
+
+### Case 1 — PRIMARY. Planar tool crossing an existing spherical face
+
+```
+C 80 60 29.5
+S 25.35
+T 1 40 30 0
+D 0 2          # hemispherical pocket -- THIS WORKS, 107,481 expected, 108,026 actual
+C 80 18 29.5
+D 3 4          # box cut slicing through the pocket -- BROKEN
+```
+
+- expected `70,852`
+- actual **`34,665`**
+- result bbox is `[0, 4.7, -25.3] .. [80, 60, 29.5]`
+
+That `z = -25.3` is the tell. The sphere's *lower* hemisphere was never part of
+the solid, but its surface appears in the output mesh. The tool's far side is
+being retained with the wrong orientation — this is face/shell classification
+after intersection-curve computation, not a missing capability. Note that the
+preceding pocket cut on the raw primitive is correct, so the intersector handles
+plane/sphere fine; it is the classification of the *second* cut against the
+resulting BRep that goes wrong.
+
+**This one case unblocks the part.** The rest are likely the same root cause.
+
+### Case 2 — Sphere protruding through two faces sharing an edge: silent no-op
+
+```
+C 80 45 29.5
+S 25.35
+T 1 40 12 0
+D 0 2
+```
+
+- expected `77,932`
+- actual **`106,200`** — exactly the bare cube. Total no-op.
+
+Compare with the one-face protrusion in Case 1, which is correct, and with a
+fully interior sphere (`C 80 60 60` − `S 25.35` at `(40,30,30)`, expected
+`219,763`, actual `220,852`), also correct. So the trigger is specifically the
+intersection curve running across a cube edge.
+
+### Case 3 — Quadric/quadric: silent no-op, tool surface merged into result
+
+```
+S 30
+Y 10 80
+T 1 0 0 -40
+D 0 2
+```
+
+- expected `94,782` (sphere `113,097` less an `18,316` cylindrical plug)
+- actual **`111,292`** — the bare sphere, unchanged
+
+```
+Y 30 61
+Y 18.5 40
+R 1 90 0 0
+D 0 2
+```
+
+- actual volume **grew** from `171,367` to `172,080`, and triangle count from
+  `128` to `588`. The tool's surface was merged into the result instead of
+  subtracting from it. Same signature as Case 1: classification, not
+  intersection.
+
+### What works (regression guard — keep these passing)
+
+| operation | expected | actual |
+|---|---|---|
+| `cube − sphere`, fully interior | 219,763 | 220,852 |
+| `cube − sphere`, one-face protrusion | 107,481 | 108,026 |
+| `cube − cylinder`, axis-aligned | 197,271 | 197,271 |
+| `cube − cylinder`, rotated 90° | 197,271 | 197,271 |
+| `sphere − sphere`, concentric | 47,647 | 46,887 |
+| `cylinder − coaxial cylinder` | 70,641 | 70,641 |
+| `cylinder − parallel-axis cylinder` | — | 152,327 |
+| `union(box, box) − cylinder` | 147,750 | 147,965 |
+
+Note the last row: a cylinder cut against a *derived* body is fine. So "derived
+body" is not the trigger by itself — the presence of a curved face that the tool
+boundary must be classified against is.
+
+## Also seen: unbounded triangle growth
+
+Chained box cuts through a spherical face blow up instead of failing: a two-cut
+chain produced **246,446 triangles in 21 s** for a part whose correct output is
+under 1,000 triangles. Consistent with garbage intersection curves feeding
+downstream booleans. Probably fixed by the same change, but worth a perf
+assertion so it cannot regress quietly.
+
+## Asks
+
+1. **Fix `Difference` face/shell classification against curved faces.** Case 1
+   is the priority; please check whether Cases 2 and 3 fall out of the same fix.
+2. **Add a post-boolean validity check** — closed, orientable, consistently
+   oriented, positive volume, Euler characteristic sane. Return an error instead
+   of a plausible-looking wrong solid. Every bug above would have been caught
+   instantly, and silence is what made this expensive.
+3. **Add the cases above as tests**, asserting volume within a few percent of the
+   analytic value, not just "does not panic". The no-op failures all produce
+   perfectly valid meshes of the *wrong solid*, so mesh-validity assertions alone
+   will not catch them; assert volume.
+4. **Wire VCode into `load_vcad_document`** so `vcad info` / `vcad export` can
+   read v0.2 files directly.
+
+## Acceptance
+
+```
+C 80 60 29.5
+S 25.35
+T 1 40 30 0
+D 0 2
+C 80 18 29.5
+D 3 4
+```
+
+returns ~70,900 mm³ with a bbox of `[0, ~4.7, 0] .. [80, 60, 29.5]` — no negative
+Z, because no part of the lower hemisphere belongs in the result.
+
+Likely area: `crates/vcad-kernel-booleans` (~5.4K LOC). The root-cause repro for
+Case 1 is two operations long, so it should bisect quickly.
+
+---
+
+# POST-FIX EVALUATION — 2026-08-11, main @ 4517f564 (#789 + #792 landed)
+
+Re-ran every case above, plus the real part, against the fixed kernel.
+
+## Fixed and confirmed
+
+| case | expected | before | after |
+|---|---|---|---|
+| Case 1 pocket + box cut | ~70,852 | 34,665, ghost lower hemisphere | **71,245, zmin = 0.0** |
+| Case 2 two-face sphere | ~77,932 | 106,200 (no-op) | **78,325** |
+| Case 3a sphere − cylinder | ~94,782 | 111,292 (no-op) | **93,163** |
+| Case 3b cyl − perp cyl | 157,165 (MC) | 171,367→172,080 (merged) | **156,194** |
+
+Note on Case 3b: the "~136,000" I originally wrote was a bad estimate on my
+part; Monte-Carlo ground truth is 157,165 ± 50, and the kernel now lands
+within tessellation error of it. The full regression table also still passes,
+and `vcad export` reads both VCode and `.loon` directly now — asks 1, 3 (in
+part), and 4 are done. Thank you; Case 1 unblocked the real part.
+
+## Still broken
+
+### A. Cylinder cut breaking through a side face of a union'd body: silent no-op
+
+```
+C 80 45 29.5
+C 60 35 34.5
+T 1 10 5 29.5
+U 0 2
+Y 12.8 68
+R 4 0 90 0
+T 5 6 15 47
+D 3 6
+```
+
+- expected 149,555 ± 55 (MC); actual **178,471** = the bare union. Total no-op.
+- Control: the identical construction with the bore CONTAINED in the boss
+  cross-section gives 147,770 vs 147,965 expected — correct. The delta between
+  the two cases is only that the bore's circle breaks through the boss's
+  y = 5 face.
+
+### B. Cylinder cut crossing a 45-degree derived face: cut is ~20% short
+
+From the real part (block − 45°-rotated-box V-groove − cylinder bore):
+
+```
+[let bx [fn [sx sy sz px py pz] [translate px py pz [cube sx sy sz]]]]
+[let vg [translate 0.0 0.0 -7.4955 [rotate 45.0 0.0 0.0 [bx 60.0 60.0 60.0 -30.0 -30.0 -30.0]]]]
+[let nb [translate 0.0 -47.0 0.0 [rotate -90.0 0.0 0.0 [cylinder 17.2 28.0]]]]
+[difference nb [difference vg [bx 92.0 70.0 24.0 -46.0 -44.0 0.0]]]
+```
+
+- exact (manifold3d): 83,317. kernel: **84,845** (+1,528).
+- The bore should remove 7,595; the kernel removes ~6,070. Bare-cylinder
+  tessellation deficit is 0.64%, so ~50 mm³ of that gap is legitimate —
+  the other ~1,480 is the cut failing where the cylinder crosses the
+  V-groove's 45-degree face. Milder than A (partial, not no-op), likely the
+  same classification root.
+
+### C. Tessellation emits T-junctions (the mesh side of ask 2)
+
+Both halves of the real part export with correct volume but broken
+connectivity: 333 + 16 undirected edges with use-count != 2. I classified
+every one — all are T-junctions (a vertex lying exactly on a neighbor's edge
+interior, unstitched), zero true cracks, concentrated where the cylinder bore
+and bolt slots meet planar faces. Slicers and renderers show these as spurious
+backfaces. #792's T-junction stitch evidently does not cover the STL export
+path. The post-boolean validity guard (ask 2) is also still open — failures A
+and B above were, again, silent.
+
+## Workaround in use
+
+Until A–C land, the printable STLs are produced by mirroring the same CSG in
+manifold3d (96-segment circles) — watertight, winding-consistent, and matching
+Monte-Carlo ground truth within noise on both halves. Script:
+`build_manifold.py` alongside this file. The .loon source remains the design
+of record.
+
+---
+
+# ROUND-2 EVALUATION — 2026-08-11, main @ 8e747cfe (#793 landed)
+
+- **Defect A fixed**: union side-face bore now 149,602 vs 149,555 ± 55 MC.
+- **Defect B fixed**: 45°-face bore now 83,311 vs 83,317 exact (was 84,845).
+- **Defect C remains**: STL export still emits T-junctions. Real part, upper
+  half: 61 undirected edges with use != 2 (down from 333 pre-#793), lower: 16.
+  Volumes are now within tessellation error (121,591 vs 121,091 exact; 74,312
+  vs 73,912), so this is purely the export stitching. The validity-guard ask
+  also remains open.
+
+Workaround retired 2026-08-11: the printable STLs are now exported by vcad
+itself (volumes +0.5%/+0.6% vs ground truth). Defect C's T-junctions
+(61 upper / 16 lower edges) ship in those STLs until the export stitch lands.
+
+---
+
+# NEW FINDING, 2026-08-12 — Defect D: tessellation puts vertices off the surface
+
+Sphere and boolean logic are now correct (all volumes verify), but the exported
+mesh's vertices do not lie on the analytic surfaces. Control case, current main:
+
+    [root [difference [translate 0.0 0.0 0.2 [sphere 25.0]]
+                      [translate -38.0 -40.0 0.2 [cube 76.0 62.0 19.8]]] "m"]
+
+The spherical-pocket vertices should all sit at r = 25.000 from the sphere
+center. Measured: **r = 24.770 .. 25.593** — up to 0.6 mm off the surface, with
+a histogram smeared across the whole band (not one snapped shell). Chord sag at
+the observed facet size would be 0.03 mm; this is 20x that, so it is vertex
+placement, not facet density. Suspect the healed/stitch fallback quantizing or
+re-welding vertices off-surface.
+
+Impact: this is now the accuracy floor for every printed part. A Ø50 conforming
+socket with a 0.05–0.4 mm designed fit is unmanufacturable from these meshes —
+the surface error exceeds the entire fit budget. (Planar geometry is exact, and so are
+cylinders — a bore control exports every wall vertex at r = 17.5000 flat. The
+defect is specific to SPHERE tessellation, which narrows the search a lot.)
+
+Ask: vertices of tessellated quadric faces on the analytic surface to ~1e-3 mm,
+plus a fidelity assertion (max |r - R| over sampled surface vertices) in tests.
+Volume assertions cannot catch this — the errors average out.


### PR DESCRIPTION
## Problem

The mesh-CSG fallback splits operand triangles and heals seams at the mesh level, leaving **sphere-face vertices up to ~0.6 mm off the analytic surface** — 20× the legitimate chord sag, and larger than a printed part's entire fit budget. Planes and cylinders come through exact; spheres do not. Volume checks can't catch it: the displacements average out, so every prior assertion passed while the surface was lumpy. Found printing a Ø50 ball-socket coupling for a Booster K1 humanoid (`hardware/k1-ball-cuff/`, included as first commit — the repro geometry and the full defect history in `vcad-boolean-bug-handoff.md`).

## Fix

After each fallback boolean, result vertices are re-projected onto the operands' quadric carriers:

- **Constraints are decided locally** from each vertex's incident triangle normals: all-radial → quadric vertex, project radially; one non-radial → planar feature, project along it onto the plane∩sphere circle; two → feature edge, pinned. (Global plane lists cannot work — a tessellated sphere contributes one facet carrier per triangle and pins everything.)
- **Sphere∩cylinder seams** with the axis through the sphere center snap onto their exact intersection circle.
- **Carriers are stashed as dormant surfaces** on the soup result's geometry store, so chained cuts keep projecting after the analytic faces are gone — without this, the first fallback is the last time the surfaces are known.

## Measured

| case | before | after |
|---|---|---|
| cube − sphere through faces, socket worst | 0.642 mm | **0.019 mm** (export resolution) |
| K1 cuff seat surfaces, worst | 0.39 mm | **≤ 0.02 mm** |
| residual | — | ≤ 0.32 mm only at triple-junction corners inside designed clearance gaps |

Boolean suite: all green. Handoff regression volumes (cases 1–3, A, B) unchanged. New `quadric_surface_fidelity.rs` asserts max |dist − R| over the socket band on three cases, including a chained-cut case exercising the stashed carriers.

## Known residuals (documented, out of scope)

- 2-plane corner vertices want a 1-D line-snap onto the plane∩plane∩sphere point (currently pinned; all instances sit in designed gaps).
- Defect C (T-junctions in STL export) is separate and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)