### PR TITLE
feat(dfm): floating_floor check at STL export + cuff E.2.2

### DIFF
--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -708,6 +708,7 @@ fn export_file(input: &PathBuf, output: &PathBuf) -> Result<()> {
                     combined_idxs.push(idx + base_idx);
                 }
             }
+            warn_floating_floors(&combined_verts, &combined_idxs);
             let stl_bytes = export_stl_bytes(&combined_verts, &combined_idxs)?;
             fs::write(output, stl_bytes)?;
             println!("Exported STL to {}", output.display());
@@ -759,6 +760,156 @@ fn export_loon(doc: &vcad_ir::Document, output: &PathBuf) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// The `floating_floor` DFM check (vcad.dfm/1, FDM pack): a flat
+/// downward-facing triangle above first-layer height with NO geometry
+/// below its footprint starts printing in mid-air — the slicer's
+/// "floating cantilever", caught at export instead of in someone else's
+/// tool.
+///
+/// Print orientation is the user's choice, not the model frame's, so the
+/// check runs in all six axis-down candidates and reports which ones are
+/// support-free. It only warns; supports are sometimes the plan.
+fn warn_floating_floors(vertices: &[f32], indices: &[u32]) {
+    // (label, index of the "up" coordinate, sign) — "down" = -sign axis.
+    const ORIENTS: [(&str, usize, f64); 6] = [
+        ("+Z up", 2, 1.0),
+        ("-Z up", 2, -1.0),
+        ("+Y up", 1, 1.0),
+        ("-Y up", 1, -1.0),
+        ("+X up", 0, 1.0),
+        ("-X up", 0, -1.0),
+    ];
+    // Below this, hanging floors are bridge-scale slivers, not shelves.
+    const MIN_AREA_MM2: f64 = 3.0;
+    let mut clean: Vec<&str> = Vec::new();
+    let mut counts: Vec<(&str, f64)> = Vec::new();
+    for (label, up, sign) in ORIENTS {
+        let a = floating_floor_area(vertices, indices, up, sign);
+        if a < MIN_AREA_MM2 {
+            clean.push(label);
+        }
+        counts.push((label, a));
+    }
+    if clean.len() == ORIENTS.len() {
+        return; // clean every way up: nothing to say
+    }
+    if clean.is_empty() {
+        eprintln!(
+            "warning[floating_floor]: no support-free print orientation — \
+             every axis-down choice leaves downward faces starting in \
+             mid-air ({}). Re-orient a feature to a face, or plan supports.",
+            counts
+                .iter()
+                .map(|(l, a)| format!("{l}: {a:.0} mm2"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    } else {
+        eprintln!(
+            "note[floating_floor]: support-free print orientation(s): {}. \
+             Other orientations have floating floors ({}).",
+            clean.join(", "),
+            counts
+                .iter()
+                .filter(|(_, a)| *a >= MIN_AREA_MM2)
+                .map(|(l, a)| format!("{l}: {a:.0} mm2"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+}
+
+/// Total mid-air floor AREA (mm²) with `axes[up]`·`sign` as world up.
+///
+/// Area, not count: seam tessellation leaves sub-nozzle sliver ledges
+/// (measured: a 0.18 mm annulus where a sphere hands off to a bore — 21
+/// facets, bridges trivially). A latch shelf that actually fails is
+/// hundreds of mm². The rule's threshold separates them.
+fn floating_floor_area(vertices: &[f32], indices: &[u32], up: usize, sign: f64) -> f64 {
+    let v = |k: u32| {
+        let i = (k as usize) * 3;
+        let p = [
+            vertices[i] as f64,
+            vertices[i + 1] as f64,
+            vertices[i + 2] as f64,
+        ];
+        // Rotate the chosen axis into +Z: z' = sign * p[up], and keep the
+        // other two as the build-plane coordinates.
+        let (a, b) = match up {
+            0 => (p[1], p[2]),
+            1 => (p[0], p[2]),
+            _ => (p[0], p[1]),
+        };
+        [a, b, sign * p[up]]
+    };
+    let mut zmin = f64::INFINITY;
+    let mut tris: Vec<([f64; 3], [f64; 3], [f64; 3])> = Vec::new();
+    let mut floors: Vec<([f64; 3], f64)> = Vec::new();
+    for t in indices.chunks_exact(3) {
+        let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
+        for p in [&a, &b, &c] {
+            zmin = zmin.min(p[2]);
+        }
+        tris.push((a, b, c));
+    }
+    for (a, b, c) in &tris {
+        let u = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+        let w = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+        let n = [
+            u[1] * w[2] - u[2] * w[1],
+            u[2] * w[0] - u[0] * w[2],
+            u[0] * w[1] - u[1] * w[0],
+        ];
+        let l = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        if l < 1e-12 {
+            continue;
+        }
+        // Winding orientation is not trusted here (export accepts meshes
+        // from several producers): treat near-horizontal faces as floors
+        // by |nz|, then let the support scan below decide.
+        if (n[2] / l).abs() < 0.985 {
+            continue;
+        }
+        let mid = [
+            (a[0] + b[0] + c[0]) / 3.0,
+            (a[1] + b[1] + c[1]) / 3.0,
+            (a[2] + b[2] + c[2]) / 3.0,
+        ];
+        if mid[2] > zmin + 0.5 {
+            floors.push((mid, l * 0.5));
+        }
+    }
+    let mut hanging = 0.0f64;
+    for (mid, area) in &floors {
+        let mut support_below = false;
+        let mut solid_below = false;
+        for (a, b, c) in &tris {
+            let xmin = a[0].min(b[0]).min(c[0]) - 1e-6;
+            let xmax = a[0].max(b[0]).max(c[0]) + 1e-6;
+            let ymin = a[1].min(b[1]).min(c[1]) - 1e-6;
+            let ymax = a[1].max(b[1]).max(c[1]) + 1e-6;
+            if mid[0] < xmin || mid[0] > xmax || mid[1] < ymin || mid[1] > ymax {
+                continue;
+            }
+            let ztop = a[2].max(b[2]).max(c[2]);
+            if ztop < mid[2] - 1e-4 {
+                support_below = true;
+                break;
+            }
+            let zbot = a[2].min(b[2]).min(c[2]);
+            if zbot < mid[2] - 1e-4 {
+                solid_below = true;
+            }
+        }
+        // A "floor" with same-solid geometry continuing beneath it is a
+        // ceiling seen from inside a cavity — not a floor at all.
+        if !support_below && !solid_below {
+            hanging += area;
+        }
+    }
+    hanging
 }
 
 fn export_stl_bytes(vertices: &[f32], indices: &[u32]) -> Result<Vec<u8>> {

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -847,7 +847,7 @@ fn floating_floor_area(vertices: &[f32], indices: &[u32], up: usize, sign: f64) 
     let mut zmin = f64::INFINITY;
     let mut tris: Vec<([f64; 3], [f64; 3], [f64; 3])> = Vec::new();
     let mut floors: Vec<([f64; 3], f64)> = Vec::new();
-    for t in indices.chunks_exact(3) {
+    for t in indices.as_chunks::<3>().0 {
         let (a, b, c) = (v(t[0]), v(t[1]), v(t[2]));
         for p in [&a, &b, &c] {
             zmin = zmin.min(p[2]);

--- a/hardware/k1-ball-cuff/k1-ball-cuff-mono.loon
+++ b/hardware/k1-ball-cuff/k1-ball-cuff-mono.loon
@@ -1,4 +1,21 @@
-; K1 Ball Cuff, rev E.1 "mono" — print-in-place clamshell with integral flexure
+; K1 Ball Cuff, rev E.2 "mono" — print-in-place clamshell, flexure + ratchet latch
+;
+; E.2 DELETES THE BOLTS. Each bolt station becomes a printed cable-tie
+; ratchet: a hook arm rooted on the UPPER cheek wraps around the rib and
+; clicks down a rack of teeth on the LOWER cheek. Squeeze the jaws to
+; latch (1 mm tooth pitch at the rib = ~0.5 mm per click at the seat);
+; press the release tab to let the jaws spring open. Both are ~20 N
+; pushes — robot- or dock-operable, no fasteners, no assembly.
+;
+; WHY IT PRINTS IN PLACE: every latch feature is a CONSTANT CROSS-SECTION
+; ALONG Y — a prism. In the mouth-down orientation Y is vertical, so the
+; hook, teeth, and tab all print as clean stacked slices with no supports,
+; and the 0.5 mm as-printed clearance between hook tip and first tooth is
+; a vertical gap between vertical walls, which FDM renders exactly.
+; The hook's vertical blade is the release flexure, sized for PLA:
+; 1.6 mm thick x 17.5 mm long, 1.0 mm engagement -> 0.9 percent strain at
+; full release (PLA elastic limit ~1.5-2). Click force ~9 N per latch at
+; PLA's modulus. PETG prints of the same geometry are simply softer.
 ;
 ; Rev E.0 was a seatpost-style pinch collar: one axial slit, closed by
 ; ovalizing the whole ring. That works, but the ring is stiff (high bolt
@@ -71,10 +88,11 @@
 ; 25.8 square tube tunnel — E.0's pocket was accidentally an open channel.
 [let boss [bx 52.0 46.0 34.0 -26.0 -16.0 28.0]]
 
-; Bolt rib at -X, also flush to the mouth face and full length: the two
-; jaw cheeks the M4s pull together. Spans z -8..8 so the bolts get ~7 mm
-; of material each side of the gap.
-[let rib [bx 12.0 70.0 16.0 -38.0 -40.0 -8.0]]
+; Latch rib at -X, flush to the mouth face and full length: the two jaw
+; cheeks the ratchets pull together. Upper face z 8; lower reaches z -12
+; so the whole rack (deepest tooth to -9.9) lands on cheek material —
+; at z -8 the third tooth was a floating chip the volume check caught.
+[let rib [bx 12.0 70.0 20.0 -38.0 -40.0 -12.0]]
 
 ; ORDER IS LOAD-BEARING: boxes union first, the cylinder joins LAST.
 ; The other association — a box union'd onto the already-derived
@@ -103,21 +121,60 @@
 ; solid roof over the seat crown at 25.05), ceiling z = 57.8, boss top 62.
 [let tunnel [bx 60.0 25.8 25.8 -30.0 -12.9 32.0]]
 
-; M4 clearance holes through the rib along Z, crossing the gap:
-;   bolt 1 at y = +8  — closes the jaws over the ball equator
-;   bolt 2 at y = -30 — closes the journal half-shells on the rod
-[let pinch-hole [fn [py]
-  [translate -32.0 py -9.0
-    [cylinder 2.2 18.0]]]]
+; --- the ratchet latch: one prism per station, extruded 10 mm in Y -------
+; Frame per station (XZ profile): rib outer face at x = -38. The hook arm
+; roots on the upper cheek (z 4.5..7), runs out to x = -45, drops as a
+; 2.0 mm blade to z = -6.5, and carries an inward tooth at the tip. The
+; lower cheek carries a 3-tooth rack on its outer face. As-printed, the
+; hook tooth hovers 0.5 mm above the first rack tooth.
+[let latch-arm [fn [py]
+  [union
+    ; root + horizontal run (attaches to upper cheek at x = -38 face)
+    [bx 7.5 18.0 2.5 -45.1 py 4.5]
+    [union
+      ; vertical release blade: 1.6 thick, root z 7 down to -10.5 (~17.5
+      ; flexing length) — the PLA-safe spring
+      [bx 1.6 18.0 17.5 -45.1 py -10.5]
+      [union
+        ; hook tooth pointing +X at the tip
+        [bx 2.5 18.0 1.6 -43.5 py -9.0]
+        ; release tab: press +X to flex the blade and free the hook
+        [bx 2.5 18.0 2.0 -47.6 py -10.5]]]]]]
 
+; Rack: three teeth on the lower cheek outer face, 1.5 mm pitch in z,
+; moved down to meet the longer blade. Tips reach x = -42.0: the hook
+; tooth (spanning -43.5..-41.0) engages 1.0 mm in X on square hold faces.
+; As printed the hook tooth sits 0.5 mm ABOVE the first tooth — vertical
+; clearance, nothing fuses. Approach faces get a 45-degree lead so
+; closing clicks over.
+[let rack [fn [py]
+  [pipe
+    [union
+      [bx 4.0 18.0 1.0 -42.0 py -6.9]
+      [union
+        [bx 4.0 18.0 1.0 -42.0 py -8.4]
+        [bx 4.0 18.0 1.0 -42.0 py -9.9]]]
+    ; one 45-degree cut shaves all three approach faces at once
+    [difference
+      [translate -44.0 py -11.4
+        [rotate 0.0 -45.0 0.0
+          [bx 4.0 18.0 8.0 0.0 0.0 0.0]]]]]]]
+
+; ONE latch station, 18 mm wide, FLUSH TO THE MOUTH FACE — so the whole
+; mechanism prints from the plate. Two mid-height stations looked right
+; per-layer but their plate-facing ends were floating shelves 17 mm up
+; (the slicer's "floating cantilever" — and vcad's own steep_overhang DFM
+; rule would flag the same 180-degree floor; it just isn't run at export
+; yet). The rod-end station is deleted, not moved: the 7 mm cheek carries
+; clamp to the journal over 40 mm at prototype loads.
 [let mono
   [pipe body
+    [union [latch-arm 12.0]]
+    [union [rack 12.0]]
     [difference tunnel]
     [difference seat]
     [difference lead-in]
     [difference rod-pass]
-    [difference hinge-gap]
-    [difference [pinch-hole 8.0]]
-    [difference [pinch-hole -30.0]]]]
+    [difference hinge-gap]]]
 
 [root mono "petg"]

--- a/hardware/k1-ball-cuff/k1-cuff-functional-sim.md
+++ b/hardware/k1-ball-cuff/k1-cuff-functional-sim.md
@@ -1,8 +1,11 @@
 # K1 ball cuff — functional verification (quasi-static, mesh-grounded)
 
 Method: the printable STLs (exported by vcad from k1-ball-cuff.loon), trimesh
-signed-distance settle sweeps, and direct force balance. Scripts: settle_mesh.py /
-loads.py alongside; rerunnable against any revision.
+signed-distance settle sweeps, and direct force balance. The sweep drops a
+R25 sphere onto the lower half's signed-distance field and descends
+quasi-statically; the load figures are closed-form from bolt preload. Both
+are a few dozen lines against the exported STL — reproduce from the numbers
+in this doc rather than from a script pinned to one machine's paths.
 
 Note: vcad's STL export still emits some T-junction edges (61 upper / 16 lower,
 tracked as defect C in vcad-boolean-bug-handoff.md). Volumes are verified correct

--- a/lib/dfm/fdm.toml
+++ b/lib/dfm/fdm.toml
@@ -18,3 +18,14 @@ fix = "manual"
 severity = "warning"
 min_diameter_mm = 0.8
 fix = "manual"
+
+[rules.floating_floor]
+severity = "warning"
+# A flat downward face above first-layer height with no geometry below
+# its footprint starts printing in mid-air (the slicer's "floating
+# cantilever"). Distinct from steep_overhang: 45-degree walls
+# self-support; flat shelves cannot. Checked at STL export (Z-up
+# assumed as print direction).
+min_clearance_mm = 0.5
+min_area_mm2 = 3.0
+fix = "reorient_or_support"


### PR DESCRIPTION
Post-#801 work, re-cut onto a clean branch off main. Two pieces:

## DFM: `floating_floor` runs at STL export
`steep_overhang` existed in the FDM pack but nothing ran DFM at export; a latch feature starting 17 mm up shipped to the slicer as a "floating cantilever". `vcad export *.stl` now:
- sweeps **all six axis-down orientations** (print direction is the user's choice, not the model frame's) and reports which are support-free — e.g. `note: support-free print orientation(s): -Y up`
- **area-thresholds at 3 mm²**: seam tessellation leaves sub-nozzle sliver ledges (measured: a 0.18 mm annulus at a sphere/bore handoff — bridges trivially) that a count-based check false-flags, while a real 62 mm² floating shelf warns loudly
- warns, never fails: supports are sometimes the plan

Validated on the part that motivated it: the bad revision warns in every orientation; the fixed one reports its correct print orientation. `fdm.toml` gains the matching `floating_floor` rule entry.

## Hardware: K1 cuff → E.2.2
Print-in-place ratchet latch replaces all fasteners; flexure sized for PLA (1.6 × 17.5 mm blade, 0.9% release strain); rib deepened after a volume check caught a floating tooth-chip; single 18 mm latch station flush to the mouth face — the floating-cantilever fix the DFM check now enforces. Printed clean on a P1S in PLA.

*(Earlier revision of this PR carried two analysis scripts with hardcoded local paths — dropped; the functional-sim doc now describes the methods instead of pinning them to one machine.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)