### PR TITLE
feat(mcp): face-level B-rep queries — inspect_faces, measure_outer_diameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7271,6 +7271,7 @@ dependencies = [
 name = "vcad-kernel"
 version = "0.9.4"
 dependencies = [
+ "serde",
  "serde_json",
  "vcad-kernel-acoustics",
  "vcad-kernel-antenna",

--- a/changelog/entries/2026-08-15-face-level-brep-queries.json
+++ b/changelog/entries/2026-08-15-face-level-brep-queries.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-15-face-level-brep-queries",
+  "version": "0.9.4",
+  "date": "2026-08-15",
+  "category": "feat",
+  "title": "Face-level B-rep queries for agents",
+  "summary": "New inspect_faces and measure_outer_diameter MCP tools read the kernel's faces directly — exact bore diameters, shaft axes and mounting-face normals, instead of tessellation-bound bounding boxes.",
+  "features": ["mcp", "kernel", "inspection", "brep"],
+  "mcpTools": ["inspect_faces", "measure_outer_diameter"]
+}

--- a/crates/vcad-eval/tests/face_queries.rs
+++ b/crates/vcad-eval/tests/face_queries.rs
@@ -1,0 +1,197 @@
+//! Document-level face queries: the exact path the `inspectDocumentFaces`
+//! WASM binding (and therefore the `inspect_faces` / `measure_outer_diameter`
+//! MCP tools) takes — parse a document, evaluate its roots to kernel solids,
+//! then read the B-rep faces.
+//!
+//! The scenario is a motor in miniature, reproducing the failure that
+//! motivated the tools: an 80 mm-diameter body with a small radial connector
+//! boss, so the bounding box overstates the diameter, and a body axis of
+//! **Y**, so anything that assumes Z gets the axis wrong.
+
+use vcad_kernel::faces::SurfaceInfo;
+use vcad_kernel_math::Vec3;
+
+/// Body Ø80 about Y + a Ø12 boss sticking out along +X.
+fn motor_document_json() -> String {
+    serde_json::json!({
+        "version": "0.1",
+        "nodes": {
+            "1": { "id": 1, "name": "body-raw",
+                   "op": { "type": "Cylinder", "radius": 40.0, "height": 30.0, "segments": 64 } },
+            "2": { "id": 2, "name": "body-y",
+                   "op": { "type": "Rotate", "child": 1, "angles": { "x": -90.0, "y": 0.0, "z": 0.0 } } },
+            "3": { "id": 3, "name": "boss-raw",
+                   "op": { "type": "Cylinder", "radius": 6.0, "height": 30.0, "segments": 32 } },
+            "4": { "id": 4, "name": "boss-x",
+                   "op": { "type": "Rotate", "child": 3, "angles": { "x": 0.0, "y": 90.0, "z": 0.0 } } },
+            "5": { "id": 5, "name": "boss",
+                   "op": { "type": "Translate", "child": 4, "offset": { "x": 24.0, "y": -15.0, "z": 0.0 } } },
+            "6": { "id": 6, "name": "motor",
+                   "op": { "type": "Union", "left": 2, "right": 5 } }
+        },
+        "materials": {},
+        "part_materials": {},
+        "roots": [{ "root": 6, "material": "aluminum" }]
+    })
+    .to_string()
+}
+
+fn motor_report() -> vcad_kernel::faces::FaceReport {
+    let doc: vcad_ir::Document = serde_json::from_str(&motor_document_json()).unwrap();
+    let roots = vcad_eval::evaluate_root_solids(&doc).expect("document evaluates");
+    assert_eq!(roots.len(), 1, "one visible root");
+    roots[0]
+        .solid
+        .as_ref()
+        .expect("root produced a kernel solid")
+        .inspect_faces()
+        .expect("the union keeps B-rep")
+}
+
+#[test]
+fn body_outer_diameter_is_exact_where_the_bbox_overstates_it() {
+    let report = motor_report();
+
+    let group = report
+        .largest_coaxial(None)
+        .expect("the part has a dominant axis");
+
+    // The whole point: exactly 80.0, not the bbox's inflated reading.
+    assert!(
+        (group.max_diameter_mm - 80.0).abs() < 1e-9,
+        "OD {}",
+        group.max_diameter_mm
+    );
+
+    // Dominant axis is Y. A tool that assumed Z would report the boss, or
+    // nothing at all.
+    assert!(
+        (group.axis[1].abs() - 1.0).abs() < 1e-9,
+        "axis {:?}",
+        group.axis
+    );
+
+    // The bounding box across X is inflated well past 80 by the boss.
+    let x_span = report
+        .faces
+        .iter()
+        .map(|f| f.bbox_max_mm[0])
+        .fold(f64::MIN, f64::max)
+        - report
+            .faces
+            .iter()
+            .map(|f| f.bbox_min_mm[0])
+            .fold(f64::MAX, f64::min);
+    assert!(
+        x_span > 90.0,
+        "bbox X span {x_span} should overstate the OD"
+    );
+}
+
+#[test]
+fn a_requested_axis_selects_its_own_cylinder() {
+    let report = motor_report();
+
+    let about_y = report
+        .largest_coaxial(Some(Vec3::new(0.0, 1.0, 0.0)))
+        .expect("a Y group");
+    assert!((about_y.max_diameter_mm - 80.0).abs() < 1e-9);
+
+    let about_x = report
+        .largest_coaxial(Some(Vec3::new(1.0, 0.0, 0.0)))
+        .expect("an X group (the boss)");
+    assert!(
+        (about_x.max_diameter_mm - 12.0).abs() < 1e-9,
+        "boss OD {}",
+        about_x.max_diameter_mm
+    );
+
+    // An axis nothing is built about resolves to nothing, rather than
+    // silently falling back to the dominant axis.
+    assert!(report
+        .largest_coaxial(Some(Vec3::new(0.6, 0.8, 0.0)))
+        .is_none());
+}
+
+#[test]
+fn faces_carry_document_scoped_stable_names() {
+    let report = motor_report();
+    assert!(report.face_count > 0);
+
+    // Evaluated documents rescope names to the node id, so ids stay unique
+    // across a multi-primitive document and survive a parameter change.
+    let named = report.faces.iter().filter(|f| f.stable).count();
+    assert!(
+        named > 0,
+        "an evaluated boolean should keep some named faces: {:?}",
+        report.faces.iter().map(|f| &f.id).collect::<Vec<_>>()
+    );
+
+    // Every id is unique — a caller can round-trip one back as a filter.
+    let mut ids: Vec<&String> = report.faces.iter().map(|f| &f.id).collect();
+    ids.sort();
+    let before = ids.len();
+    ids.dedup();
+    assert_eq!(before, ids.len(), "face ids collide");
+}
+
+#[test]
+fn planar_faces_report_outward_normals() {
+    let report = motor_report();
+
+    // The body's two end caps are planes with normals along ±Y.
+    let caps: Vec<[f64; 3]> = report
+        .faces
+        .iter()
+        .filter_map(|f| match f.surface {
+            SurfaceInfo::Plane { normal, .. } if normal[1].abs() > 0.999 => Some(normal),
+            _ => None,
+        })
+        .collect();
+    assert!(caps.len() >= 2, "two Y-facing caps, got {}", caps.len());
+    assert!(
+        caps.iter().any(|n| n[1] > 0.0) && caps.iter().any(|n| n[1] < 0.0),
+        "caps face opposite ways: {caps:?}"
+    );
+}
+
+#[test]
+fn the_split_body_wall_still_answers_as_one_diameter() {
+    // The boss union trims the body wall into several faces on the same
+    // cylinder — normal boolean behaviour, and precisely why a raw face list
+    // is a poor answer to "what is the OD". The coaxial grouping reassembles
+    // them: several faces in, one diameter and one full-height extent out.
+    let report = motor_report();
+
+    let walls: Vec<&vcad_kernel::faces::FaceInfo> = report
+        .faces
+        .iter()
+        .filter(|f| match f.surface {
+            SurfaceInfo::Cylinder { diameter_mm, .. } => (diameter_mm - 80.0).abs() < 1e-9,
+            _ => false,
+        })
+        .collect();
+    assert!(
+        walls.len() > 1,
+        "the union splits the wall, so a raw list fragments it"
+    );
+    assert!(
+        walls.iter().all(|f| match f.surface {
+            SurfaceInfo::Cylinder { convex, .. } => convex,
+            _ => false,
+        }),
+        "every body-wall piece is an outer surface"
+    );
+
+    let group = report.largest_coaxial(None).expect("a dominant axis");
+    assert_eq!(
+        group.face_ids.len(),
+        walls.len(),
+        "the group gathers exactly the wall pieces"
+    );
+    let extent = group.axial_range_mm[1] - group.axial_range_mm[0];
+    assert!(
+        (extent - 30.0).abs() < 1e-6,
+        "the group spans the full body height: {extent}"
+    );
+}

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -7121,6 +7121,69 @@ pub fn document_to_step_buffer(doc_json: &str) -> Result<Vec<u8>, JsError> {
     vcad_kernel::Solid::solids_to_step_buffer(&refs).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Enumerate the B-rep faces of every visible scene root.
+///
+/// The mesh-based inspection tools (`inspect_cad`, `measure`) are
+/// tessellation-bound and topology-blind: they cannot say which face is a
+/// mounting plane, what a bore's diameter is, or where a shaft axis points.
+/// This walks the kernel B-rep instead and reports, per face, a stable
+/// identifier, surface type, area, bbox, centroid and the *analytic* surface
+/// parameters, plus per-part face groupings and coaxial-cylinder groups
+/// (the honest answer to "true outer diameter" on a part whose bounding box
+/// is inflated by a boss).
+///
+/// # Arguments
+///
+/// * `doc_json` - A JSON string representing a vcad Document
+///
+/// # Returns
+///
+/// A JSON string: `{ "parts": [{ node_id, name, brep: bool, error?, report? }],
+/// "units": "mm" }`. Mesh-only roots report `brep: false` with an `error`
+/// rather than a tessellation-derived guess.
+#[wasm_bindgen(js_name = inspectDocumentFaces)]
+pub fn inspect_document_faces(doc_json: &str) -> Result<String, JsError> {
+    let doc: vcad_ir::Document = serde_json::from_str(doc_json)
+        .map_err(|e| JsError::new(&format!("Failed to parse document: {}", e)))?;
+
+    let roots = vcad_eval::evaluate_root_solids(&doc)
+        .map_err(|e| JsError::new(&format!("Evaluation error: {}", e)))?;
+
+    let parts: Vec<serde_json::Value> = roots
+        .iter()
+        .enumerate()
+        .map(|(i, root)| {
+            let name = root
+                .name
+                .clone()
+                .unwrap_or_else(|| format!("part_{}", i + 1));
+            match root.solid.as_ref().map(vcad_kernel::Solid::inspect_faces) {
+                Some(Ok(report)) => serde_json::json!({
+                    "node_id": root.node_id,
+                    "name": name,
+                    "brep": true,
+                    "report": report,
+                }),
+                Some(Err(e)) => serde_json::json!({
+                    "node_id": root.node_id,
+                    "name": name,
+                    "brep": false,
+                    "error": e.to_string(),
+                }),
+                None => serde_json::json!({
+                    "node_id": root.node_id,
+                    "name": name,
+                    "brep": false,
+                    "error": "this root produced no kernel solid (imported mesh chain)",
+                }),
+            }
+        })
+        .collect();
+
+    serde_json::to_string(&serde_json::json!({ "parts": parts, "units": "mm" }))
+        .map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Solve forward kinematics for an assembly document.
 ///
 /// # Arguments

--- a/crates/vcad-kernel/Cargo.toml
+++ b/crates/vcad-kernel/Cargo.toml
@@ -40,6 +40,7 @@ vcad-kernel-flow = { workspace = true }
 vcad-kernel-fea = { workspace = true }
 vcad-kernel-tolerance = { workspace = true }
 vcad-kernel-calibration = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/vcad-kernel/src/faces.rs
+++ b/crates/vcad-kernel/src/faces.rs
@@ -1,0 +1,904 @@
+//! Face-level B-rep queries for agent-facing inspection.
+//!
+//! `inspect_cad` / `measure` and friends answer questions about a part's
+//! *tessellation*: bbox, volume, centre of mass, min distance. That is not
+//! enough to reason mechanically about a real part — you cannot ask which
+//! face is the mounting plane, what a bore's diameter is, or where a shaft
+//! axis points. Worse, a bounding box actively lies about diameters: a motor
+//! with an 80 mm body and an asymmetric radial connector boss reads ~102 mm
+//! across its bbox.
+//!
+//! This module walks the B-rep directly ([`crate::Solid::brep`]) and reports,
+//! per face: a stable identifier, surface type, area, bounding box, centroid,
+//! and the analytic surface parameters (a cylinder's radius / axis / axial
+//! extent, a plane's normal and a point on it, …).
+//!
+//! Accuracy notes, because the two halves differ:
+//!
+//! - **Analytic** (exact, tessellation-independent): surface type, plane
+//!   normal and origin, cylinder radius and axis, cone half-angle, sphere and
+//!   torus radii.
+//! - **Tessellation-bound** (same caveat as `inspect_cad`): face area, face
+//!   bounding box, face centroid, and the axial extent of a cylindrical face
+//!   — all derived from the face's triangulation.
+//!
+//! All lengths are millimetres, areas mm², angles degrees.
+//!
+//! Face identity uses [`vcad_kernel_naming`] names (`n3:top`, `cube:side.1`)
+//! whenever the solid carries a [`NameMap`](vcad_kernel_naming::NameMap) —
+//! those survive a parameter change, unlike arena indices. Solids without
+//! names (imported STEP, mesh-derived) fall back to `face_<n>`, where `n` is
+//! the face's rank in quantized-centroid order — deterministic for a given
+//! geometry, but *not* stable across a rebuild that moves faces.
+
+use serde::Serialize;
+
+use vcad_kernel_geom::{
+    ConeSurface, CylinderSurface, Plane, SphereSurface, Surface, SurfaceKind, TorusSurface,
+};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_tessellate::{tessellate_brep_by_face, TessellationParams, TriangleMesh};
+use vcad_kernel_topo::{FaceId, Orientation};
+
+/// Quantization step (mm) for deterministic face ordering.
+const QUANT: f64 = 1e-6;
+
+/// Angular tolerance (radians) for calling two axes parallel.
+const AXIS_TOL: f64 = 1e-6;
+
+/// Distance tolerance (mm) for calling two parallel axes collinear.
+const COAXIAL_TOL: f64 = 1e-6;
+
+// =============================================================================
+// Reported shapes
+// =============================================================================
+
+/// Analytic parameters of the surface carrying a face. Exactly one variant is
+/// populated per face; unsupported kinds (BSpline, Bilinear) report `Other`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SurfaceInfo {
+    /// A planar face.
+    Plane {
+        /// Outward unit normal (respects the face's orientation).
+        normal: [f64; 3],
+        /// A point lying on the plane (the surface origin).
+        point: [f64; 3],
+    },
+    /// A cylindrical face.
+    Cylinder {
+        /// Cylinder radius, mm.
+        radius_mm: f64,
+        /// Diameter, mm (`2 × radius`) — what a caller usually wants.
+        diameter_mm: f64,
+        /// Unit axis direction, sign-canonicalised.
+        axis: [f64; 3],
+        /// A point on the axis line.
+        axis_point: [f64; 3],
+        /// Axial extent of *this face* along the axis, `[min, max]`,
+        /// measured from `axis_point`. Tessellation-bound.
+        axial_range_mm: [f64; 2],
+        /// `axial_range_mm[1] - axial_range_mm[0]`, mm.
+        axial_length_mm: f64,
+        /// True if the face's material lies outside the cylinder (a shaft or
+        /// boss); false if inside (a bore). Derived from face orientation.
+        convex: bool,
+    },
+    /// A conical face.
+    Cone {
+        /// Cone apex.
+        apex: [f64; 3],
+        /// Unit axis direction (apex toward base).
+        axis: [f64; 3],
+        /// Half-angle, degrees.
+        half_angle_deg: f64,
+    },
+    /// A spherical face.
+    Sphere {
+        /// Sphere centre.
+        center: [f64; 3],
+        /// Sphere radius, mm.
+        radius_mm: f64,
+    },
+    /// A toroidal face.
+    Torus {
+        /// Torus centre.
+        center: [f64; 3],
+        /// Unit axis direction.
+        axis: [f64; 3],
+        /// Major radius, mm.
+        major_radius_mm: f64,
+        /// Minor radius, mm.
+        minor_radius_mm: f64,
+    },
+    /// A free-form or otherwise unparameterised face.
+    Other {
+        /// Surface kind name (`bspline`, `bilinear`, …).
+        surface_type: String,
+    },
+}
+
+/// One face of a solid.
+#[derive(Debug, Clone, Serialize)]
+pub struct FaceInfo {
+    /// Stable identifier: a topological name (`n3:top`) when the solid
+    /// carries one, else `face_<n>` in quantized-centroid order.
+    pub id: String,
+    /// The topological name, when present. `None` means `id` is positional
+    /// and will not survive a rebuild that moves faces.
+    pub name: Option<String>,
+    /// True when `id` is a topological name (survives parameter changes).
+    pub stable: bool,
+    /// Surface kind: `plane`, `cylinder`, `cone`, `sphere`, `torus`, …
+    pub surface_type: String,
+    /// Face area, mm². Tessellation-bound.
+    pub area_mm2: f64,
+    /// Face bounding box minimum, mm. Tessellation-bound.
+    pub bbox_min_mm: [f64; 3],
+    /// Face bounding box maximum, mm. Tessellation-bound.
+    pub bbox_max_mm: [f64; 3],
+    /// Area-weighted face centroid, mm. Tessellation-bound.
+    pub centroid_mm: [f64; 3],
+    /// Number of inner loops (holes) in the face.
+    pub inner_loops: usize,
+    /// Analytic surface parameters.
+    pub surface: SurfaceInfo,
+}
+
+/// A set of cylindrical faces sharing one axis line.
+#[derive(Debug, Clone, Serialize)]
+pub struct CoaxialGroup {
+    /// Unit axis direction, sign-canonicalised.
+    pub axis: [f64; 3],
+    /// A point on the shared axis line.
+    pub axis_point: [f64; 3],
+    /// Largest radius in the group, mm — the outer diameter of whatever this
+    /// axis carries.
+    pub max_radius_mm: f64,
+    /// `2 × max_radius_mm`, mm.
+    pub max_diameter_mm: f64,
+    /// Smallest radius in the group, mm (the innermost bore on this axis).
+    pub min_radius_mm: f64,
+    /// Distinct radii present, ascending, mm.
+    pub radii_mm: Vec<f64>,
+    /// Total lateral area of the group's faces, mm². Tessellation-bound.
+    pub total_area_mm2: f64,
+    /// Combined axial extent of the group, `[min, max]` from `axis_point`, mm.
+    pub axial_range_mm: [f64; 2],
+    /// Face ids in the group.
+    pub face_ids: Vec<String>,
+}
+
+/// A `(surface_type, count)` tally, or a `(radius, count)` tally for
+/// cylinders — the compact answer to "what is this part made of".
+#[derive(Debug, Clone, Serialize)]
+pub struct FaceGroup {
+    /// Surface kind.
+    pub surface_type: String,
+    /// Radius, mm — cylinders and spheres only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub radius_mm: Option<f64>,
+    /// Number of faces in this group.
+    pub count: usize,
+    /// Total area of the group, mm². Tessellation-bound.
+    pub total_area_mm2: f64,
+    /// Up to eight representative face ids.
+    pub example_face_ids: Vec<String>,
+}
+
+/// Everything [`inspect_faces`] knows about one solid.
+#[derive(Debug, Clone, Serialize)]
+pub struct FaceReport {
+    /// Total face count on the outer shell.
+    pub face_count: usize,
+    /// True when face ids are topological names.
+    pub named: bool,
+    /// Every face.
+    pub faces: Vec<FaceInfo>,
+    /// Faces tallied by surface type (and radius, for cylinders/spheres).
+    pub groups: Vec<FaceGroup>,
+    /// Cylindrical faces grouped by shared axis line, largest first.
+    pub coaxial_groups: Vec<CoaxialGroup>,
+}
+
+impl FaceReport {
+    /// The coaxial cylinder group about `axis`, or — when `axis` is `None` —
+    /// the group carrying the most cylindrical area (the part's dominant
+    /// axis). This is what "true outer diameter" means on a part whose
+    /// bounding box is inflated by a boss: `max_diameter_mm` of this group.
+    pub fn largest_coaxial(&self, axis: Option<Vec3>) -> Option<&CoaxialGroup> {
+        match axis {
+            None => self
+                .coaxial_groups
+                .iter()
+                .max_by(|a, b| a.total_area_mm2.total_cmp(&b.total_area_mm2)),
+            Some(a) => {
+                let a = normalize(a)?;
+                self.coaxial_groups
+                    .iter()
+                    .filter(|g| parallel(Vec3::new(g.axis[0], g.axis[1], g.axis[2]), a))
+                    .max_by(|x, y| x.max_radius_mm.total_cmp(&y.max_radius_mm))
+            }
+        }
+    }
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+/// Errors from a face query.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FaceQueryError {
+    /// The solid has no B-rep (mesh-only import, or empty).
+    NoBRep,
+}
+
+impl std::fmt::Display for FaceQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoBRep => write!(
+                f,
+                "this part has no B-rep topology (it is a mesh or empty), so face-level \
+                 queries are unavailable; only mesh measurements apply"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FaceQueryError {}
+
+impl crate::Solid {
+    /// Enumerate this solid's faces with their analytic surface parameters.
+    ///
+    /// Fails closed on mesh-only solids rather than silently reporting a
+    /// tessellation-derived guess.
+    pub fn inspect_faces(&self) -> Result<FaceReport, FaceQueryError> {
+        let brep = self.brep().ok_or(FaceQueryError::NoBRep)?;
+        Ok(report(brep, self.names()))
+    }
+}
+
+/// Build a face report for a B-rep, optionally using a name map for stable ids.
+pub fn inspect_faces(brep: &BRepSolid, names: Option<&vcad_kernel_naming::NameMap>) -> FaceReport {
+    report(brep, names)
+}
+
+fn report(brep: &BRepSolid, names: Option<&vcad_kernel_naming::NameMap>) -> FaceReport {
+    let params = TessellationParams::default();
+    let per_face = tessellate_brep_by_face(brep, &params);
+
+    // Deterministic positional ids: rank by quantized centroid so the
+    // fallback id doesn't depend on slotmap iteration order.
+    let mut ranked: Vec<([i64; 3], FaceId)> = per_face
+        .iter()
+        .map(|(id, _, mesh)| (quantize(mesh_centroid(mesh)), *id))
+        .collect();
+    ranked.sort();
+    let ordinal = |face: FaceId| ranked.iter().position(|(_, id)| *id == face).unwrap_or(0);
+
+    let named = names.is_some_and(|n| !n.faces.is_empty());
+
+    let mut faces = Vec::with_capacity(per_face.len());
+    for (face_id, kind, mesh) in &per_face {
+        let face = &brep.topology.faces[*face_id];
+        let surface = brep.geometry.surfaces[face.surface_index].as_ref();
+        let reversed = face.orientation == Orientation::Reversed;
+
+        let name = names
+            .and_then(|n| n.faces.get(face_id))
+            .map(|n| n.to_string());
+        let id = name
+            .clone()
+            .unwrap_or_else(|| format!("face_{}", ordinal(*face_id)));
+
+        let (bbox_min, bbox_max) = mesh_bbox(mesh);
+        faces.push(FaceInfo {
+            id,
+            stable: name.is_some(),
+            name,
+            surface_type: kind_name(*kind).to_string(),
+            area_mm2: mesh_area(mesh),
+            bbox_min_mm: bbox_min,
+            bbox_max_mm: bbox_max,
+            centroid_mm: arr(mesh_centroid(mesh)),
+            inner_loops: face.inner_loops.len(),
+            surface: surface_info(surface, reversed, mesh),
+        });
+    }
+
+    faces.sort_by(|a, b| b.area_mm2.total_cmp(&a.area_mm2));
+
+    let groups = group_faces(&faces);
+    let coaxial_groups = coaxial_groups(&faces);
+
+    FaceReport {
+        face_count: faces.len(),
+        named,
+        faces,
+        groups,
+        coaxial_groups,
+    }
+}
+
+// =============================================================================
+// Surface parameters
+// =============================================================================
+
+fn kind_name(kind: SurfaceKind) -> &'static str {
+    match kind {
+        SurfaceKind::Plane => "plane",
+        SurfaceKind::Cylinder => "cylinder",
+        SurfaceKind::Cone => "cone",
+        SurfaceKind::Sphere => "sphere",
+        SurfaceKind::Torus => "torus",
+        SurfaceKind::BSpline => "bspline",
+        SurfaceKind::Bilinear => "bilinear",
+    }
+}
+
+fn surface_info(surface: &dyn Surface, reversed: bool, mesh: &TriangleMesh) -> SurfaceInfo {
+    match surface.surface_type() {
+        SurfaceKind::Plane => {
+            if let Some(p) = surface.as_any().downcast_ref::<Plane>() {
+                let n: Vec3 = p.normal_dir.into_inner();
+                let n = if reversed { -n } else { n };
+                return SurfaceInfo::Plane {
+                    normal: arr_v(n),
+                    point: arr(p.origin),
+                };
+            }
+            SurfaceInfo::Other {
+                surface_type: "plane".into(),
+            }
+        }
+        SurfaceKind::Cylinder => {
+            if let Some(c) = surface.as_any().downcast_ref::<CylinderSurface>() {
+                let axis_raw: Vec3 = c.axis.into_inner();
+                let (axis, flipped) = canonical_axis(axis_raw);
+                let (lo, hi) = axial_range(mesh, c.center, axis);
+                let _ = flipped;
+                return SurfaceInfo::Cylinder {
+                    radius_mm: c.radius,
+                    diameter_mm: 2.0 * c.radius,
+                    axis: arr_v(axis),
+                    axis_point: arr(c.center),
+                    axial_range_mm: [lo, hi],
+                    axial_length_mm: hi - lo,
+                    // A forward-oriented cylindrical face has its surface
+                    // normal pointing away from the axis, i.e. material
+                    // inside → a shaft. Reversed → a bore.
+                    convex: !reversed,
+                };
+            }
+            SurfaceInfo::Other {
+                surface_type: "cylinder".into(),
+            }
+        }
+        SurfaceKind::Cone => {
+            if let Some(c) = surface.as_any().downcast_ref::<ConeSurface>() {
+                return SurfaceInfo::Cone {
+                    apex: arr(c.apex),
+                    axis: arr_v(c.axis.into_inner()),
+                    half_angle_deg: c.half_angle.to_degrees(),
+                };
+            }
+            SurfaceInfo::Other {
+                surface_type: "cone".into(),
+            }
+        }
+        SurfaceKind::Sphere => {
+            if let Some(s) = surface.as_any().downcast_ref::<SphereSurface>() {
+                return SurfaceInfo::Sphere {
+                    center: arr(s.center),
+                    radius_mm: s.radius,
+                };
+            }
+            SurfaceInfo::Other {
+                surface_type: "sphere".into(),
+            }
+        }
+        SurfaceKind::Torus => {
+            if let Some(t) = surface.as_any().downcast_ref::<TorusSurface>() {
+                return SurfaceInfo::Torus {
+                    center: arr(t.center),
+                    axis: arr_v(t.axis.into_inner()),
+                    major_radius_mm: t.major_radius,
+                    minor_radius_mm: t.minor_radius,
+                };
+            }
+            SurfaceInfo::Other {
+                surface_type: "torus".into(),
+            }
+        }
+        other => SurfaceInfo::Other {
+            surface_type: kind_name(other).to_string(),
+        },
+    }
+}
+
+// =============================================================================
+// Grouping
+// =============================================================================
+
+/// Quantize a radius so faces that came off the same feature land in one
+/// bucket despite float noise (1 µm buckets).
+fn radius_key(r: f64) -> i64 {
+    (r / 1e-3).round() as i64
+}
+
+fn group_faces(faces: &[FaceInfo]) -> Vec<FaceGroup> {
+    let mut keys: Vec<(String, Option<i64>)> = Vec::new();
+    let mut groups: Vec<FaceGroup> = Vec::new();
+
+    for f in faces {
+        let radius = match &f.surface {
+            SurfaceInfo::Cylinder { radius_mm, .. } => Some(*radius_mm),
+            SurfaceInfo::Sphere { radius_mm, .. } => Some(*radius_mm),
+            _ => None,
+        };
+        let key = (f.surface_type.clone(), radius.map(radius_key));
+        let idx = match keys.iter().position(|k| *k == key) {
+            Some(i) => i,
+            None => {
+                keys.push(key);
+                groups.push(FaceGroup {
+                    surface_type: f.surface_type.clone(),
+                    radius_mm: radius,
+                    count: 0,
+                    total_area_mm2: 0.0,
+                    example_face_ids: Vec::new(),
+                });
+                groups.len() - 1
+            }
+        };
+        groups[idx].count += 1;
+        groups[idx].total_area_mm2 += f.area_mm2;
+        if groups[idx].example_face_ids.len() < 8 {
+            groups[idx].example_face_ids.push(f.id.clone());
+        }
+    }
+
+    groups.sort_by(|a, b| b.total_area_mm2.total_cmp(&a.total_area_mm2));
+    groups
+}
+
+struct CoaxAccum {
+    axis: Vec3,
+    axis_point: Point3,
+    radii: Vec<f64>,
+    area: f64,
+    lo: f64,
+    hi: f64,
+    face_ids: Vec<String>,
+}
+
+fn coaxial_groups(faces: &[FaceInfo]) -> Vec<CoaxialGroup> {
+    let mut accum: Vec<CoaxAccum> = Vec::new();
+
+    for f in faces {
+        let SurfaceInfo::Cylinder {
+            radius_mm,
+            axis,
+            axis_point,
+            axial_range_mm,
+            ..
+        } = &f.surface
+        else {
+            continue;
+        };
+        let axis = Vec3::new(axis[0], axis[1], axis[2]);
+        let point = Point3::new(axis_point[0], axis_point[1], axis_point[2]);
+
+        let hit = accum
+            .iter_mut()
+            .find(|g| parallel(g.axis, axis) && collinear(g.axis, g.axis_point, point));
+
+        match hit {
+            Some(g) => {
+                // Re-express this face's extent in the group's own axial
+                // coordinate (its origin is the group's axis_point).
+                let shift = (point - g.axis_point).dot(g.axis);
+                g.lo = g.lo.min(axial_range_mm[0] + shift);
+                g.hi = g.hi.max(axial_range_mm[1] + shift);
+                g.radii.push(*radius_mm);
+                g.area += f.area_mm2;
+                g.face_ids.push(f.id.clone());
+            }
+            None => accum.push(CoaxAccum {
+                axis,
+                axis_point: point,
+                radii: vec![*radius_mm],
+                area: f.area_mm2,
+                lo: axial_range_mm[0],
+                hi: axial_range_mm[1],
+                face_ids: vec![f.id.clone()],
+            }),
+        }
+    }
+
+    let mut out: Vec<CoaxialGroup> = accum
+        .into_iter()
+        .map(|g| {
+            let mut radii: Vec<f64> = g.radii.clone();
+            radii.sort_by(f64::total_cmp);
+            radii.dedup_by(|a, b| radius_key(*a) == radius_key(*b));
+            CoaxialGroup {
+                axis: arr_v(g.axis),
+                axis_point: arr(g.axis_point),
+                max_radius_mm: g.radii.iter().copied().fold(f64::MIN, f64::max),
+                max_diameter_mm: 2.0 * g.radii.iter().copied().fold(f64::MIN, f64::max),
+                min_radius_mm: g.radii.iter().copied().fold(f64::MAX, f64::min),
+                radii_mm: radii,
+                total_area_mm2: g.area,
+                axial_range_mm: [g.lo, g.hi],
+                face_ids: g.face_ids,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| b.total_area_mm2.total_cmp(&a.total_area_mm2));
+    out
+}
+
+// =============================================================================
+// Geometry helpers
+// =============================================================================
+
+fn arr(p: Point3) -> [f64; 3] {
+    [p.x, p.y, p.z]
+}
+
+fn arr_v(v: Vec3) -> [f64; 3] {
+    [v.x, v.y, v.z]
+}
+
+fn normalize(v: Vec3) -> Option<Vec3> {
+    let n = (v.x * v.x + v.y * v.y + v.z * v.z).sqrt();
+    if n < 1e-12 {
+        return None;
+    }
+    Some(Vec3::new(v.x / n, v.y / n, v.z / n))
+}
+
+/// Give an axis a canonical sign so `+Z` and `-Z` cylinders group together.
+/// Returns the canonical direction and whether the input was flipped.
+fn canonical_axis(v: Vec3) -> (Vec3, bool) {
+    let v = normalize(v).unwrap_or(Vec3::new(0.0, 0.0, 1.0));
+    let comps = [v.x, v.y, v.z];
+    let dominant = comps
+        .iter()
+        .enumerate()
+        .max_by(|a, b| a.1.abs().total_cmp(&b.1.abs()))
+        .map(|(i, _)| i)
+        .unwrap_or(2);
+    if comps[dominant] < 0.0 {
+        (Vec3::new(-v.x, -v.y, -v.z), true)
+    } else {
+        (v, false)
+    }
+}
+
+fn parallel(a: Vec3, b: Vec3) -> bool {
+    let cross = Vec3::new(
+        a.y * b.z - a.z * b.y,
+        a.z * b.x - a.x * b.z,
+        a.x * b.y - a.y * b.x,
+    );
+    (cross.x * cross.x + cross.y * cross.y + cross.z * cross.z).sqrt() < AXIS_TOL
+}
+
+/// True when `point` lies on the line through `origin` along `axis`.
+fn collinear(axis: Vec3, origin: Point3, point: Point3) -> bool {
+    let d = point - origin;
+    let along = d.dot(axis);
+    let perp = Vec3::new(
+        d.x - along * axis.x,
+        d.y - along * axis.y,
+        d.z - along * axis.z,
+    );
+    (perp.x * perp.x + perp.y * perp.y + perp.z * perp.z).sqrt() < COAXIAL_TOL
+}
+
+fn quantize(p: Point3) -> [i64; 3] {
+    [
+        (p.x / QUANT).round() as i64,
+        (p.y / QUANT).round() as i64,
+        (p.z / QUANT).round() as i64,
+    ]
+}
+
+fn vertices(mesh: &TriangleMesh) -> impl Iterator<Item = Point3> + '_ {
+    mesh.vertices
+        .chunks_exact(3)
+        .map(|c| Point3::new(c[0] as f64, c[1] as f64, c[2] as f64))
+}
+
+fn mesh_bbox(mesh: &TriangleMesh) -> ([f64; 3], [f64; 3]) {
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for p in vertices(mesh) {
+        let v = [p.x, p.y, p.z];
+        for i in 0..3 {
+            lo[i] = lo[i].min(v[i]);
+            hi[i] = hi[i].max(v[i]);
+        }
+    }
+    if !lo[0].is_finite() {
+        return ([0.0; 3], [0.0; 3]);
+    }
+    (lo, hi)
+}
+
+fn triangles(mesh: &TriangleMesh) -> impl Iterator<Item = (Point3, Point3, Point3)> + '_ {
+    let vtx = move |i: u32| -> Point3 {
+        let b = i as usize * 3;
+        Point3::new(
+            mesh.vertices[b] as f64,
+            mesh.vertices[b + 1] as f64,
+            mesh.vertices[b + 2] as f64,
+        )
+    };
+    mesh.indices
+        .chunks_exact(3)
+        .map(move |t| (vtx(t[0]), vtx(t[1]), vtx(t[2])))
+}
+
+fn mesh_area(mesh: &TriangleMesh) -> f64 {
+    triangles(mesh)
+        .map(|(a, b, c)| {
+            let u = b - a;
+            let v = c - a;
+            let cx = u.y * v.z - u.z * v.y;
+            let cy = u.z * v.x - u.x * v.z;
+            let cz = u.x * v.y - u.y * v.x;
+            0.5 * (cx * cx + cy * cy + cz * cz).sqrt()
+        })
+        .sum()
+}
+
+/// Area-weighted centroid of a face's triangulation. Falls back to the mean
+/// vertex position for a degenerate (zero-area) face.
+fn mesh_centroid(mesh: &TriangleMesh) -> Point3 {
+    let mut acc = Vec3::new(0.0, 0.0, 0.0);
+    let mut total = 0.0;
+    for (a, b, c) in triangles(mesh) {
+        let u = b - a;
+        let v = c - a;
+        let cx = u.y * v.z - u.z * v.y;
+        let cy = u.z * v.x - u.x * v.z;
+        let cz = u.x * v.y - u.y * v.x;
+        let area = 0.5 * (cx * cx + cy * cy + cz * cz).sqrt();
+        acc += Vec3::new(
+            (a.x + b.x + c.x) / 3.0 * area,
+            (a.y + b.y + c.y) / 3.0 * area,
+            (a.z + b.z + c.z) / 3.0 * area,
+        );
+        total += area;
+    }
+    if total > 0.0 {
+        return Point3::new(acc.x / total, acc.y / total, acc.z / total);
+    }
+    let mut sum = Vec3::new(0.0, 0.0, 0.0);
+    let mut n = 0usize;
+    for p in vertices(mesh) {
+        sum += Vec3::new(p.x, p.y, p.z);
+        n += 1;
+    }
+    if n == 0 {
+        return Point3::new(0.0, 0.0, 0.0);
+    }
+    Point3::new(sum.x / n as f64, sum.y / n as f64, sum.z / n as f64)
+}
+
+/// Project a face's triangulation onto `axis`, measured from `origin`.
+fn axial_range(mesh: &TriangleMesh, origin: Point3, axis: Vec3) -> (f64, f64) {
+    let mut lo = f64::INFINITY;
+    let mut hi = f64::NEG_INFINITY;
+    for p in vertices(mesh) {
+        let t = (p - origin).dot(axis);
+        lo = lo.min(t);
+        hi = hi.max(t);
+    }
+    if !lo.is_finite() {
+        return (0.0, 0.0);
+    }
+    (lo, hi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Solid;
+
+    fn cyl_faces(report: &FaceReport) -> Vec<&FaceInfo> {
+        report
+            .faces
+            .iter()
+            .filter(|f| f.surface_type == "cylinder")
+            .collect()
+    }
+
+    #[test]
+    fn cube_has_six_named_planar_faces() {
+        let cube = Solid::cube(10.0, 20.0, 30.0);
+        let report = cube.inspect_faces().unwrap();
+
+        assert_eq!(report.face_count, 6);
+        assert!(report.named, "primitives seed a name map");
+        assert!(report.faces.iter().all(|f| f.surface_type == "plane"));
+        assert!(report.faces.iter().all(|f| f.stable));
+
+        // Total area of a 10x20x30 box.
+        let total: f64 = report.faces.iter().map(|f| f.area_mm2).sum();
+        let expect = 2.0 * (10.0 * 20.0 + 10.0 * 30.0 + 20.0 * 30.0);
+        assert!((total - expect).abs() < 1e-6, "area {total} vs {expect}");
+
+        // The top face: outward normal +Z, area 10*20, plane at z=30.
+        let top = report
+            .faces
+            .iter()
+            .find(|f| f.id.ends_with(":top"))
+            .expect("cube:top exists");
+        let SurfaceInfo::Plane { normal, point } = top.surface else {
+            panic!("top face is planar");
+        };
+        assert!((normal[2] - 1.0).abs() < 1e-9, "normal {normal:?}");
+        assert!((point[2] - 30.0).abs() < 1e-9, "point {point:?}");
+        assert!((top.area_mm2 - 200.0).abs() < 1e-6);
+        assert!((top.centroid_mm[2] - 30.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cylinder_reports_exact_radius_and_axis() {
+        // Radius 7, height 25, axis +Z.
+        let cyl = Solid::cylinder(7.0, 25.0, 32);
+        let report = cyl.inspect_faces().unwrap();
+
+        let side = cyl_faces(&report);
+        assert_eq!(side.len(), 1, "one lateral face");
+        let SurfaceInfo::Cylinder {
+            radius_mm,
+            diameter_mm,
+            axis,
+            axial_length_mm,
+            convex,
+            ..
+        } = side[0].surface
+        else {
+            panic!("cylindrical");
+        };
+
+        // Analytic, NOT tessellation-bound: exact to the bit.
+        assert_eq!(radius_mm, 7.0);
+        assert_eq!(diameter_mm, 14.0);
+        assert!((axis[2].abs() - 1.0).abs() < 1e-12, "axis {axis:?}");
+        assert!((axial_length_mm - 25.0).abs() < 1e-6);
+        assert!(convex, "an outer wall is convex");
+
+        // A 32-segment tessellation under-reads the lateral area (the
+        // inscribed prism is shorter around than the circle); the analytic
+        // radius does not care. That gap is why the radius is reported from
+        // the surface and the area is flagged tessellation-bound.
+        let exact_lateral = 2.0 * std::f64::consts::PI * 7.0 * 25.0;
+        assert!(
+            side[0].area_mm2 < exact_lateral,
+            "tessellated {} vs exact {exact_lateral}",
+            side[0].area_mm2
+        );
+        assert!(side[0].area_mm2 > 0.99 * exact_lateral);
+    }
+
+    #[test]
+    fn bore_is_concave_and_bbox_lies_about_outer_diameter() {
+        // Body OD 80 (r=40), height 30, with an off-axis boss that inflates
+        // the bounding box — the MyActuator X6-60 failure mode in miniature.
+        let body = Solid::cylinder(40.0, 30.0, 64);
+        let boss = Solid::cylinder(6.0, 30.0, 32).translate(48.0, 0.0, 0.0);
+        let part = body.union(&boss);
+
+        let report = part.inspect_faces().unwrap();
+        let group = report.largest_coaxial(None).expect("a dominant axis");
+
+        // The bounding box reads ~108 across; the true OD is exactly 80.
+        assert_eq!(group.max_diameter_mm, 80.0);
+        assert!((group.axis[2].abs() - 1.0).abs() < 1e-9);
+
+        let mesh_bbox_span: f64 = {
+            let (lo, hi) = (
+                report
+                    .faces
+                    .iter()
+                    .map(|f| f.bbox_min_mm[0])
+                    .fold(f64::MAX, f64::min),
+                report
+                    .faces
+                    .iter()
+                    .map(|f| f.bbox_max_mm[0])
+                    .fold(f64::MIN, f64::max),
+            );
+            hi - lo
+        };
+        assert!(
+            mesh_bbox_span > 90.0,
+            "bbox inflated by the boss: {mesh_bbox_span}"
+        );
+    }
+
+    #[test]
+    fn a_drilled_hole_reads_as_a_bore() {
+        // 40x40x10 plate with a 5 mm-diameter through hole on the Z axis at
+        // the centre — the "what size is this hole" question.
+        let plate = Solid::cube(40.0, 40.0, 10.0);
+        let drill = Solid::cylinder(2.5, 30.0, 64).translate(20.0, 20.0, -10.0);
+        let part = plate.difference(&drill);
+
+        let report = part.inspect_faces().unwrap();
+        let bores: Vec<&FaceInfo> = report
+            .faces
+            .iter()
+            .filter(|f| matches!(f.surface, SurfaceInfo::Cylinder { .. }))
+            .collect();
+        assert!(!bores.is_empty(), "the hole leaves a cylindrical face");
+
+        let SurfaceInfo::Cylinder {
+            diameter_mm,
+            axis_point,
+            convex,
+            ..
+        } = bores[0].surface
+        else {
+            unreachable!()
+        };
+        assert!((diameter_mm - 5.0).abs() < 1e-9, "diameter {diameter_mm}");
+        assert!(!convex, "a drilled hole is a bore, not a shaft");
+        assert!((axis_point[0] - 20.0).abs() < 1e-9);
+        assert!((axis_point[1] - 20.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn coaxial_query_respects_a_requested_axis() {
+        // Two shafts on different axes: r=20 about Z, r=30 about X.
+        let z_shaft = Solid::cylinder(20.0, 10.0, 64);
+        let x_shaft = Solid::cylinder(30.0, 200.0, 64)
+            .rotate(0.0, 90.0, 0.0)
+            .translate(0.0, 0.0, 5.0);
+        let part = z_shaft.union(&x_shaft);
+        let report = part.inspect_faces().unwrap();
+
+        let about_z = report
+            .largest_coaxial(Some(Vec3::new(0.0, 0.0, 1.0)))
+            .expect("a Z group");
+        assert!((about_z.max_diameter_mm - 40.0).abs() < 1e-9);
+
+        let about_x = report
+            .largest_coaxial(Some(Vec3::new(1.0, 0.0, 0.0)))
+            .expect("an X group");
+        assert!((about_x.max_diameter_mm - 60.0).abs() < 1e-9);
+
+        // Sign of the requested axis must not matter.
+        let about_neg_x = report
+            .largest_coaxial(Some(Vec3::new(-1.0, 0.0, 0.0)))
+            .expect("an X group either way");
+        assert_eq!(about_neg_x.max_diameter_mm, about_x.max_diameter_mm);
+    }
+
+    #[test]
+    fn groups_collapse_repeated_features() {
+        let report = Solid::cube(50.0, 50.0, 10.0).inspect_faces().unwrap();
+        let planes = report
+            .groups
+            .iter()
+            .find(|g| g.surface_type == "plane")
+            .unwrap();
+        assert_eq!(planes.count, 6);
+        assert!(planes.example_face_ids.len() <= 8);
+    }
+
+    #[test]
+    fn mesh_only_solids_fail_closed() {
+        let mesh = Solid::from_mesh(Solid::cube(5.0, 5.0, 5.0).to_mesh(32));
+        assert_eq!(mesh.inspect_faces().unwrap_err(), FaceQueryError::NoBRep);
+    }
+}

--- a/crates/vcad-kernel/src/faces.rs
+++ b/crates/vcad-kernel/src/faces.rs
@@ -611,7 +611,9 @@ fn quantize(p: Point3) -> [i64; 3] {
 
 fn vertices(mesh: &TriangleMesh) -> impl Iterator<Item = Point3> + '_ {
     mesh.vertices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|c| Point3::new(c[0] as f64, c[1] as f64, c[2] as f64))
 }
 
@@ -641,7 +643,9 @@ fn triangles(mesh: &TriangleMesh) -> impl Iterator<Item = (Point3, Point3, Point
         )
     };
     mesh.indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(move |t| (vtx(t[0]), vtx(t[1]), vtx(t[2])))
 }
 

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -50,6 +50,9 @@ pub use vcad_kernel_tolerance;
 pub use vcad_kernel_topo;
 pub use vcad_kernel_topopt;
 
+pub mod faces;
+pub use faces::{inspect_faces, FaceInfo, FaceQueryError, FaceReport};
+
 pub mod cam_verify;
 pub use cam_verify::verify_toolpaths;
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -382,6 +382,94 @@ export { extractEnclosureFeatures } from "./enclosure-mesh.js";
 export type { Solid, WasmAnnotationLayer } from "@vcad/kernel-wasm";
 
 /** 2D projected edge with visibility info */
+/** Analytic parameters of the surface carrying a B-rep face. */
+export type FaceSurfaceInfo =
+  | { kind: "plane"; normal: [number, number, number]; point: [number, number, number] }
+  | {
+      kind: "cylinder";
+      radius_mm: number;
+      diameter_mm: number;
+      axis: [number, number, number];
+      axis_point: [number, number, number];
+      axial_range_mm: [number, number];
+      axial_length_mm: number;
+      /** True for a shaft/boss (material inside), false for a bore. */
+      convex: boolean;
+    }
+  | {
+      kind: "cone";
+      apex: [number, number, number];
+      axis: [number, number, number];
+      half_angle_deg: number;
+    }
+  | { kind: "sphere"; center: [number, number, number]; radius_mm: number }
+  | {
+      kind: "torus";
+      center: [number, number, number];
+      axis: [number, number, number];
+      major_radius_mm: number;
+      minor_radius_mm: number;
+    }
+  | { kind: "other"; surface_type: string };
+
+/** One B-rep face. Areas/bboxes/centroids are tessellation-bound; the
+ * `surface` parameters are analytic. */
+export interface FaceInfo {
+  id: string;
+  name: string | null;
+  stable: boolean;
+  surface_type: string;
+  area_mm2: number;
+  bbox_min_mm: [number, number, number];
+  bbox_max_mm: [number, number, number];
+  centroid_mm: [number, number, number];
+  inner_loops: number;
+  surface: FaceSurfaceInfo;
+}
+
+/** Cylindrical faces sharing one axis line. */
+export interface CoaxialGroup {
+  axis: [number, number, number];
+  axis_point: [number, number, number];
+  max_radius_mm: number;
+  max_diameter_mm: number;
+  min_radius_mm: number;
+  radii_mm: number[];
+  total_area_mm2: number;
+  axial_range_mm: [number, number];
+  face_ids: string[];
+}
+
+/** Faces tallied by surface type (and radius, for cylinders/spheres). */
+export interface FaceGroup {
+  surface_type: string;
+  radius_mm?: number;
+  count: number;
+  total_area_mm2: number;
+  example_face_ids: string[];
+}
+
+/** Face-level report for one solid. */
+export interface FaceReport {
+  face_count: number;
+  named: boolean;
+  faces: FaceInfo[];
+  groups: FaceGroup[];
+  coaxial_groups: CoaxialGroup[];
+}
+
+/** {@link Engine.documentFaces} result: one entry per visible scene root. */
+export interface DocumentFaceReport {
+  units: "mm";
+  parts: Array<{
+    node_id: string;
+    name: string;
+    brep: boolean;
+    error?: string;
+    report?: FaceReport;
+  }>;
+}
+
 export interface ProjectedEdge {
   start: { x: number; y: number };
   end: { x: number; y: number };
@@ -531,6 +619,9 @@ export interface KernelModule {
   };
   /** Export a document's scene roots to a STEP AP214 buffer (BRep-preserving). */
   documentToStepBuffer?: (docJson: string) => Uint8Array;
+  /** Enumerate the B-rep faces of every visible scene root, as a JSON string.
+   * Optional: absent on kernel WASM builds older than the face-query API. */
+  inspectDocumentFaces?: (docJson: string) => string;
   /**
    * Import a URDF (Unified Robot Description Format) file. Returns a
    * JSON-encoded {@link Document} that the caller deserialises with
@@ -1171,6 +1262,7 @@ export class Engine {
       importStepBuffer: wasmModule.importStepBuffer,
       importStepBufferWithReport: (wasmModule as Record<string, unknown>).importStepBufferWithReport as KernelModule["importStepBufferWithReport"],
       documentToStepBuffer: (wasmModule as Record<string, unknown>).documentToStepBuffer as KernelModule["documentToStepBuffer"],
+      inspectDocumentFaces: (wasmModule as Record<string, unknown>).inspectDocumentFaces as KernelModule["inspectDocumentFaces"],
       importUrdfBuffer: (wasmModule as Record<string, unknown>).importUrdfBuffer as KernelModule["importUrdfBuffer"],
       importUrdfBufferWithOptions: (wasmModule as Record<string, unknown>).importUrdfBufferWithOptions as KernelModule["importUrdfBufferWithOptions"],
       urdfCommentedFloatingJoint: (wasmModule as Record<string, unknown>).urdfCommentedFloatingJoint as KernelModule["urdfCommentedFloatingJoint"],
@@ -2210,6 +2302,27 @@ export class Engine {
       );
     }
     return this.kernel.documentToStepBuffer(JSON.stringify(doc));
+  }
+
+  /**
+   * Enumerate the B-rep faces of every visible scene root: per face a stable
+   * id, surface type, area, bbox, centroid and the *analytic* surface
+   * parameters (cylinder radius/axis, plane normal/point, …), plus per-part
+   * groupings and coaxial-cylinder groups.
+   *
+   * Unlike {@link Engine.evaluate}, this reads the kernel's topology, so
+   * radii and axes are exact rather than tessellation-bound. Mesh-only roots
+   * are reported with `brep: false` and an explanation, never a guess.
+   */
+  documentFaces(doc: Document): DocumentFaceReport {
+    if (!this.kernel.inspectDocumentFaces) {
+      throw new Error(
+        "inspectDocumentFaces is not available in this kernel build — rebuild the WASM kernel",
+      );
+    }
+    return JSON.parse(
+      this.kernel.inspectDocumentFaces(JSON.stringify(doc)),
+    ) as DocumentFaceReport;
   }
 
   /** Create a detail view (magnified region) from a projected view.

--- a/packages/mcp/src/__tests__/faces.test.ts
+++ b/packages/mcp/src/__tests__/faces.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { Engine } from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+import { inspectFaces, measureOuterDiameter } from "../tools/faces.js";
+import { documents, openDocument } from "../tools/session.js";
+
+let engine: Engine;
+
+beforeAll(async () => {
+  engine = await Engine.init();
+});
+
+beforeEach(() => {
+  documents.clear();
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function out(result: { content: Array<{ type: string; text: string }> }): any {
+  return JSON.parse(result.content[0].text);
+}
+
+/**
+ * A motor-shaped part in miniature, reproducing the failure that motivated
+ * these tools: an 80 mm-diameter body with a small radial connector boss
+ * hanging off it, so the bounding box reads ~108 mm across while the true
+ * outer diameter is exactly 80.0. The body axis is **Y**, not Z, so a tool
+ * that assumes Z gets it wrong.
+ */
+function motorDocument(): Document {
+  const nodes: Record<string, unknown> = {};
+  let id = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const add = (name: string, op: any): number => {
+    id += 1;
+    nodes[String(id)] = { id, name, op };
+    return id;
+  };
+
+  // Body: r=40, h=30 along Z, rotated -90° about X so its axis becomes Y.
+  const bodyRaw = add("body-raw", {
+    type: "Cylinder",
+    radius: 40,
+    height: 30,
+    segments: 64,
+  });
+  const body = add("body-y", {
+    type: "Rotate",
+    child: bodyRaw,
+    angles: { x: -90, y: 0, z: 0 },
+  });
+  // Boss: r=6, sticking out along +X past the body wall.
+  const bossRaw = add("boss-raw", {
+    type: "Cylinder",
+    radius: 6,
+    height: 30,
+    segments: 32,
+  });
+  const bossRot = add("boss-x", {
+    type: "Rotate",
+    child: bossRaw,
+    angles: { x: 0, y: 90, z: 0 },
+  });
+  const boss = add("boss", {
+    type: "Translate",
+    child: bossRot,
+    offset: { x: 24, y: -15, z: 0 },
+  });
+  const motor = add("motor", { type: "Union", left: body, right: boss });
+
+  return {
+    version: "0.1",
+    nodes,
+    materials: {},
+    part_materials: {},
+    roots: [{ root: motor, material: "aluminum" }],
+  } as unknown as Document;
+}
+
+function openMotor(): string {
+  return out(openDocument({ initial: motorDocument() })).document_id as string;
+}
+
+describe("inspect_faces", () => {
+  it("reports analytic cylinder parameters the mesh tools cannot", () => {
+    const docId = openMotor();
+    const res = out(
+      inspectFaces({ document_id: docId, surface_type: ["cylinder"] }, engine),
+    );
+    expect(res.units).toBe("mm");
+    const part = res.parts[0];
+    expect(part.matched_faces).toBeGreaterThan(0);
+
+    // The body wall: diameter exactly 80, axis Y (not Z). The boss union
+    // splits the wall into several faces on that same cylinder, so this is a
+    // `find`, not a uniqueness claim — reassembling them is the coaxial
+    // group's job, exercised in measure_outer_diameter below.
+    const body = part.faces.find(
+      (f: { diameter_mm: number }) => Math.abs(f.diameter_mm - 80) < 1e-6,
+    );
+    expect(body, "an 80 mm body face exists").toBeTruthy();
+    expect(Math.abs(body.axis[1])).toBeCloseTo(1, 9);
+    expect(body.feature).toBe("shaft_or_boss");
+    expect(body.axial_length_mm).toBeGreaterThan(0);
+    expect(body.axial_length_mm).toBeLessThanOrEqual(30 + 1e-6);
+  });
+
+  it("summarises instead of dumping every face", () => {
+    const docId = openMotor();
+    const res = out(inspectFaces({ document_id: docId, summary_only: true }, engine));
+    const part = res.parts[0];
+    expect(part.faces).toBeUndefined();
+    expect(part.groups.length).toBeGreaterThan(0);
+    // Grouped tallies: each entry counts faces of one type (and radius).
+    const total = part.groups.reduce(
+      (n: number, g: { count: number }) => n + g.count,
+      0,
+    );
+    expect(total).toBe(part.face_count);
+    expect(part.coaxial_groups.length).toBeGreaterThan(0);
+  });
+
+  it("paginates and reports what was withheld", () => {
+    const docId = openMotor();
+    const res = out(inspectFaces({ document_id: docId, limit: 2 }, engine));
+    const part = res.parts[0];
+    expect(part.faces.length).toBe(2);
+    if (part.matched_faces > 2) {
+      expect(part.truncated.showing).toContain("of");
+    }
+    const page2 = out(
+      inspectFaces({ document_id: docId, limit: 2, offset: 2 }, engine),
+    ).parts[0];
+    expect(page2.faces[0].face_id).not.toBe(part.faces[0].face_id);
+  });
+
+  it("filters by radius so 'every M4 clearance hole' is one call", () => {
+    const docId = openMotor();
+    const res = out(
+      inspectFaces({ document_id: docId, radius_mm: 6 }, engine),
+    ).parts[0];
+    expect(res.matched_faces).toBeGreaterThan(0);
+    for (const f of res.faces) {
+      expect(Math.abs(f.radius_mm - 6)).toBeLessThan(0.01);
+    }
+  });
+
+  it("errors with a recovery hint naming the available parts", () => {
+    const docId = openMotor();
+    const res = inspectFaces({ document_id: docId, part: "ghost" }, engine);
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("ghost");
+    expect(res.content[0].text).toContain("motor");
+  });
+});
+
+describe("measure_outer_diameter", () => {
+  it("reads the true OD where the bounding box overstates it", () => {
+    const docId = openMotor();
+    const res = out(measureOuterDiameter({ document_id: docId }, engine));
+    const part = res.parts[0];
+
+    expect(part.axis_selection).toBe("dominant");
+    expect(part.outer_diameter_mm).toBeCloseTo(80, 6);
+    // The dominant axis is Y — the reason "assume Z" is a bug.
+    expect(Math.abs(part.axis[1])).toBeCloseTo(1, 9);
+    // ...while the bbox is inflated well past 80 by the boss.
+    expect(Math.max(...part.bbox_size_mm)).toBeGreaterThan(90);
+    // The split wall pieces are gathered back into one full-height extent.
+    expect(part.face_count).toBeGreaterThan(1);
+    expect(
+      part.axial_range_mm[1] - part.axial_range_mm[0],
+    ).toBeCloseTo(30, 6);
+  });
+
+  it("honours a requested axis, ignoring its sign", () => {
+    const docId = openMotor();
+    const pos = out(
+      measureOuterDiameter({ document_id: docId, axis: [0, 1, 0] }, engine),
+    ).parts[0];
+    const neg = out(
+      measureOuterDiameter({ document_id: docId, axis: [0, -1, 0] }, engine),
+    ).parts[0];
+    expect(pos.axis_selection).toBe("requested");
+    expect(pos.outer_diameter_mm).toBeCloseTo(80, 6);
+    expect(neg.outer_diameter_mm).toBe(pos.outer_diameter_mm);
+  });
+
+  it("explains which axes exist when the requested one has no cylinders", () => {
+    const docId = openMotor();
+    const res = out(
+      measureOuterDiameter({ document_id: docId, axis: [0.6, 0.8, 0] }, engine),
+    );
+    expect(res.parts[0].error).toContain("Axes present");
+  });
+
+  it("rejects a zero axis rather than guessing", () => {
+    const docId = openMotor();
+    const res = measureOuterDiameter(
+      { document_id: docId, axis: [0, 0, 0] },
+      engine,
+    );
+    expect(res.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1625,6 +1625,129 @@
     }
   },
   {
+    "name": "inspect_faces",
+    "title": "Inspect Faces",
+    "description": "List a part's B-rep faces: stable face id, surface type, area, bbox, centroid, plus the exact surface parameters — a cylinder's radius/diameter, axis direction, point on axis and axial extent (and whether it's a bore or a shaft); a plane's outward normal and a point on it. This is the tool for mechanical reasoning an agent can't do from a bounding box: find the mounting face, read a bore diameter, get a shaft axis. Filter with `surface_type` / `radius_mm` / `min_area_mm2`, page with `limit`/`offset`, or start with `summary_only` to get grouped tallies ('17 cylindrical faces at radius 2.1 mm') instead of hundreds of records. Radii, axes and normals are analytic; areas, bboxes and centroids are tessellation-bound. Complements `inspect_cad` and `measure`, which see only the triangle mesh. Requires B-rep geometry — mesh-only parts are refused by name, not guessed at.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id from open_document holding the part."
+        },
+        "part": {
+          "type": "string",
+          "description": "Part id or name to inspect. Omit to inspect every visible part."
+        },
+        "surface_type": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "plane",
+              "cylinder",
+              "cone",
+              "sphere",
+              "torus",
+              "bspline",
+              "bilinear"
+            ]
+          },
+          "description": "Keep only faces of these surface types, e.g. ['cylinder'] for bores and shafts, ['plane'] for mounting faces."
+        },
+        "face_id": {
+          "type": "string",
+          "description": "Return just this face (an id from an earlier call)."
+        },
+        "radius_mm": {
+          "type": "number",
+          "description": "Keep only cylindrical/spherical faces of this radius (within `radius_tolerance_mm`) — e.g. 2.1 to find every M4 clearance hole."
+        },
+        "radius_tolerance_mm": {
+          "type": "number",
+          "description": "Tolerance for `radius_mm`. Default 0.01 mm."
+        },
+        "min_area_mm2": {
+          "type": "number",
+          "description": "Drop faces smaller than this — the fast way past chamfers and fastener detail on a vendor part."
+        },
+        "summary_only": {
+          "type": "boolean",
+          "description": "Return only the grouped tallies and coaxial groups, no per-face records. Best first call on an unfamiliar part."
+        },
+        "limit": {
+          "type": "number",
+          "description": "Max faces to return per part. Default 25."
+        },
+        "offset": {
+          "type": "number",
+          "description": "Faces to skip (pagination). Default 0."
+        }
+      },
+      "required": [
+        "document_id"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "faces": {
+          "type": "object"
+        },
+        "document_id": {
+          "type": "string"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
+    "name": "measure_outer_diameter",
+    "title": "Measure Outer Diameter",
+    "description": "Measure a part's true outer diameter: the largest cylinder coaxial with a given axis (omit `axis` to use the part's dominant axis — do not assume Z). This is what 'OD' means on a real part; a bounding box overstates it whenever a connector boss, flange or mounting ear sticks out, so the result reports the bbox size alongside for contrast. Also reports the smallest radius on that axis (the innermost bore), every distinct radius present, and the axial extent. Diameters are analytic, so exact regardless of tessellation.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document_id": {
+          "type": "string",
+          "description": "Session id from open_document holding the part."
+        },
+        "part": {
+          "type": "string",
+          "description": "Part id or name. Omit to measure every visible part."
+        },
+        "axis": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "description": "Axis to measure about, e.g. [0,1,0]. Sign is ignored. Omit to use the part's dominant axis (the one carrying the most cylindrical area) — do not assume Z."
+        }
+      },
+      "required": [
+        "document_id"
+      ]
+    },
+    "outputSchema": {
+      "type": "object",
+      "properties": {
+        "outer_diameter": {
+          "type": "object"
+        },
+        "document_id": {
+          "type": "string"
+        }
+      }
+    },
+    "annotations": {
+      "readOnlyHint": true
+    }
+  },
+  {
     "name": "list_parameters",
     "title": "List Parameters",
     "description": "List a document's named parameters: raw expression, resolved numeric value, unit, and scrub bounds (min/max). Pair with set_parameters to drive the design and parameter_gradient to differentiate it.",

--- a/packages/mcp/src/browser-tools.ts
+++ b/packages/mcp/src/browser-tools.ts
@@ -20,6 +20,7 @@ import { TOOL_METADATA } from "./tools/tool-metadata.js";
 
 import { toolDefs as inspectTools } from "./tools/inspect.js";
 import { toolDefs as measureTools } from "./tools/measure.js";
+import { toolDefs as facesTools } from "./tools/faces.js";
 import { toolDefs as clearanceTools } from "./tools/clearance.js";
 import { toolDefs as dfmTools } from "./tools/dfm.js";
 import { toolDefs as toleranceTools } from "./tools/tolerance.js";
@@ -47,6 +48,7 @@ export type { ToolResult } from "./tools/tool-result.js";
 const BROWSER_TOOL_MODULES: ToolDef[][] = [
   inspectTools,
   measureTools,
+  facesTools,
   clearanceTools,
   dfmTools,
   toleranceTools,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -140,6 +140,7 @@ import { toolDefs as loonToolDefs } from "./tools/loon.js";
 import { toolDefs as exportToolDefs } from "./tools/export.js";
 import { toolDefs as inspectToolDefs } from "./tools/inspect.js";
 import { toolDefs as measureToolDefs } from "./tools/measure.js";
+import { toolDefs as facesToolDefs } from "./tools/faces.js";
 import { toolDefs as parametersToolDefs } from "./tools/parameters.js";
 import { toolDefs as designConstraintsToolDefs } from "./tools/design-constraints.js";
 import { toolDefs as printCheckToolDefs } from "./tools/print-check.js";
@@ -332,6 +333,7 @@ const STATIC_TOOL_DEFS: readonly ToolDef[] = [
   ...exportToolDefs,
   ...inspectToolDefs,
   ...measureToolDefs,
+  ...facesToolDefs,
   ...parametersToolDefs,
   ...designConstraintsToolDefs,
   ...printCheckToolDefs,
@@ -427,6 +429,8 @@ const LIST_TOOL_ORDER: readonly string[] = [
   "export_cad",
   "inspect_cad",
   "measure",
+  "inspect_faces",
+  "measure_outer_diameter",
   // ── Parametric parameters + differentiable seam ─────────────
   "list_parameters",
   "set_parameters",

--- a/packages/mcp/src/tools/faces.ts
+++ b/packages/mcp/src/tools/faces.ts
@@ -1,0 +1,544 @@
+/**
+ * Face-level B-rep queries: `inspect_faces` and `measure_outer_diameter`.
+ *
+ * The mesh-based tools next door (`inspect_cad`, `inspect_part`,
+ * `describe_scene`, `measure`) are tessellation-bound and topology-blind —
+ * they answer bbox / volume / centre-of-mass / min-distance and nothing
+ * about the part's faces. That is not enough to reason mechanically: you
+ * cannot find the mounting face, read a bore diameter, or get a shaft axis.
+ * A bounding box will even lie about a diameter — a motor with an 80.0 mm
+ * body reads ~102 mm across its bbox because of one radial connector boss.
+ *
+ * These two tools read the kernel's B-rep instead:
+ *
+ * - `inspect_faces` — faces with a stable id, surface type, area, bbox,
+ *   centroid, and the analytic surface parameters; filterable by surface
+ *   type / radius / area, paginated, and summarised by default so a vendor
+ *   part with 800 faces doesn't dump 800 records.
+ * - `measure_outer_diameter` — the largest coaxial cylinder about an axis,
+ *   which is what "true outer diameter" actually means.
+ *
+ * Accuracy split, reported on every result:
+ * - **analytic** (exact): surface type, cylinder radius/axis, plane
+ *   normal/point, cone half-angle, sphere/torus radii.
+ * - **tessellation-bound** (same caveat as `inspect_cad`): area, face bbox,
+ *   centroid, axial extent.
+ *
+ * All lengths are mm, areas mm², angles degrees.
+ */
+
+import type {
+  CoaxialGroup,
+  DocumentFaceReport,
+  Engine,
+  FaceInfo,
+  FaceReport,
+} from "@vcad/engine";
+import type { Document } from "@vcad/ir";
+
+import { getSession } from "./session-core.js";
+import { behavior, type ToolDef } from "./tool-def.js";
+
+/** Faces returned before the result switches to summary-only. */
+const DEFAULT_LIMIT = 25;
+
+/** Round to micron / µm² so payloads stay readable. */
+const r6 = (n: number) => Math.round(n * 1e6) / 1e6;
+const vec = (v: readonly number[]) => v.map(r6);
+
+const ACCURACY_NOTE =
+  "Surface parameters (radius, axis, normal, half-angle) are analytic and exact. " +
+  "Area, bbox, centroid and axial extent come from the face's triangulation, so they are tessellation-bound.";
+
+function err(text: string) {
+  return {
+    content: [{ type: "text" as const, text: `Error: ${text}` }],
+    isError: true as const,
+  };
+}
+
+/** One part's face report plus the label the caller used to ask for it. */
+interface ResolvedPart {
+  name: string;
+  node_id: string;
+  report: FaceReport;
+}
+
+/**
+ * Evaluate the document's B-rep faces, then narrow to the requested part.
+ *
+ * Fails closed with an explanatory message when the part is mesh-only (an
+ * imported mesh, or a feature that dropped to tessellation) rather than
+ * guessing face parameters from triangles.
+ */
+function resolveParts(
+  doc: Document,
+  engine: Engine,
+  partRef: string | undefined,
+): { parts: ResolvedPart[] } | { error: string } {
+  let all: DocumentFaceReport;
+  try {
+    all = engine.documentFaces(doc);
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : String(e) };
+  }
+
+  if (all.parts.length === 0) {
+    return { error: "This document has no visible geometry to inspect." };
+  }
+
+  const wanted = partRef
+    ? all.parts.filter((p) => p.node_id === partRef || p.name === partRef)
+    : all.parts;
+
+  if (wanted.length === 0) {
+    return {
+      error:
+        `No part matched '${partRef}'. Available: ` +
+        all.parts.map((p) => `${p.name} (${p.node_id})`).join(", "),
+    };
+  }
+
+  const usable = wanted.filter((p) => p.brep && p.report);
+  if (usable.length === 0) {
+    const why = wanted.map((p) => `${p.name}: ${p.error}`).join("; ");
+    return {
+      error:
+        `Face queries need B-rep topology, and no requested part has it — ${why}. ` +
+        "Use `measure` / `inspect_part` for mesh-level answers on these parts.",
+    };
+  }
+
+  return {
+    parts: usable.map((p) => ({
+      name: p.name,
+      node_id: p.node_id,
+      report: p.report as FaceReport,
+    })),
+  };
+}
+
+/** Compact per-face payload; rounds and drops nulls. */
+function facePayload(f: FaceInfo) {
+  const out: Record<string, unknown> = {
+    face_id: f.id,
+    stable_id: f.stable,
+    surface_type: f.surface_type,
+    area_mm2: r6(f.area_mm2),
+    centroid_mm: vec(f.centroid_mm),
+    bbox_mm: { min: vec(f.bbox_min_mm), max: vec(f.bbox_max_mm) },
+  };
+  if (f.inner_loops > 0) out.inner_loops = f.inner_loops;
+
+  const s = f.surface;
+  switch (s.kind) {
+    case "plane":
+      out.normal = vec(s.normal);
+      out.point_on_plane_mm = vec(s.point);
+      break;
+    case "cylinder":
+      out.radius_mm = r6(s.radius_mm);
+      out.diameter_mm = r6(s.diameter_mm);
+      out.axis = vec(s.axis);
+      out.point_on_axis_mm = vec(s.axis_point);
+      out.axial_range_mm = vec(s.axial_range_mm);
+      out.axial_length_mm = r6(s.axial_length_mm);
+      out.feature = s.convex ? "shaft_or_boss" : "bore";
+      break;
+    case "cone":
+      out.apex_mm = vec(s.apex);
+      out.axis = vec(s.axis);
+      out.half_angle_deg = r6(s.half_angle_deg);
+      break;
+    case "sphere":
+      out.center_mm = vec(s.center);
+      out.radius_mm = r6(s.radius_mm);
+      break;
+    case "torus":
+      out.center_mm = vec(s.center);
+      out.axis = vec(s.axis);
+      out.major_radius_mm = r6(s.major_radius_mm);
+      out.minor_radius_mm = r6(s.minor_radius_mm);
+      break;
+    case "other":
+      out.note = `${s.surface_type} surfaces have no closed-form parameters`;
+      break;
+  }
+  return out;
+}
+
+function coaxialPayload(g: CoaxialGroup) {
+  return {
+    axis: vec(g.axis),
+    point_on_axis_mm: vec(g.axis_point),
+    outer_diameter_mm: r6(g.max_diameter_mm),
+    outer_radius_mm: r6(g.max_radius_mm),
+    inner_radius_mm: r6(g.min_radius_mm),
+    radii_mm: g.radii_mm.map(r6),
+    axial_range_mm: vec(g.axial_range_mm),
+    lateral_area_mm2: r6(g.total_area_mm2),
+    face_count: g.face_ids.length,
+    face_ids: g.face_ids.slice(0, 12),
+  };
+}
+
+// =============================================================================
+// inspect_faces
+// =============================================================================
+
+interface FaceFilters {
+  surfaceTypes?: string[];
+  faceId?: string;
+  minAreaMm2?: number;
+  radiusMm?: number;
+  radiusToleranceMm: number;
+}
+
+function applyFilters(faces: FaceInfo[], f: FaceFilters): FaceInfo[] {
+  return faces.filter((face) => {
+    if (f.faceId && face.id !== f.faceId) return false;
+    if (f.surfaceTypes && !f.surfaceTypes.includes(face.surface_type)) {
+      return false;
+    }
+    if (f.minAreaMm2 !== undefined && face.area_mm2 < f.minAreaMm2) return false;
+    if (f.radiusMm !== undefined) {
+      const s = face.surface;
+      const r =
+        s.kind === "cylinder" || s.kind === "sphere" ? s.radius_mm : undefined;
+      if (r === undefined) return false;
+      if (Math.abs(r - f.radiusMm) > f.radiusToleranceMm) return false;
+    }
+    return true;
+  });
+}
+
+/** `inspect_faces` payload builder, shared with any in-app caller. */
+export function inspectFacesResult(
+  doc: Document,
+  engine: Engine,
+  args: {
+    partRef?: string;
+    filters: FaceFilters;
+    limit: number;
+    offset: number;
+    summaryOnly: boolean;
+  },
+): Record<string, unknown> | { error: string } {
+  const resolved = resolveParts(doc, engine, args.partRef);
+  if ("error" in resolved) return resolved;
+
+  const parts = resolved.parts.map((p) => {
+    const filtered = applyFilters(p.report.faces, args.filters);
+    // Faces arrive largest-area-first, which is the useful order: the
+    // mounting face and the body OD come before the fastener chamfers.
+    const page = args.summaryOnly
+      ? []
+      : filtered.slice(args.offset, args.offset + args.limit);
+
+    const payload: Record<string, unknown> = {
+      part: p.name,
+      node_id: p.node_id,
+      face_count: p.report.face_count,
+      matched_faces: filtered.length,
+      face_ids_stable: p.report.named,
+      groups: p.report.groups.map((g) => ({
+        surface_type: g.surface_type,
+        ...(g.radius_mm !== undefined
+          ? { radius_mm: r6(g.radius_mm), diameter_mm: r6(2 * g.radius_mm) }
+          : {}),
+        count: g.count,
+        total_area_mm2: r6(g.total_area_mm2),
+        example_face_ids: g.example_face_ids,
+      })),
+      coaxial_groups: p.report.coaxial_groups.slice(0, 10).map(coaxialPayload),
+    };
+
+    if (!args.summaryOnly) {
+      payload.faces = page.map(facePayload);
+      const shown = args.offset + page.length;
+      if (shown < filtered.length) {
+        payload.truncated = {
+          showing: `${args.offset + 1}-${shown} of ${filtered.length}`,
+          hint: "Pass `offset` for the next page, or narrow with `surface_type` / `radius_mm` / `min_area_mm2`.",
+        };
+      }
+    }
+
+    if (!p.report.named) {
+      payload.id_note =
+        "This part carries no topological names (imported or mesh-derived), so face ids are positional " +
+        "(`face_<n>` in centroid order): stable for this geometry, but not across a rebuild that moves faces.";
+    }
+    return payload;
+  });
+
+  return { units: "mm", parts, note: ACCURACY_NOTE };
+}
+
+const inspectFacesSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description: "Session id from open_document holding the part.",
+    },
+    part: {
+      type: "string" as const,
+      description:
+        "Part id or name to inspect. Omit to inspect every visible part.",
+    },
+    surface_type: {
+      type: "array" as const,
+      items: {
+        type: "string" as const,
+        enum: ["plane", "cylinder", "cone", "sphere", "torus", "bspline", "bilinear"],
+      },
+      description:
+        "Keep only faces of these surface types, e.g. ['cylinder'] for bores and shafts, ['plane'] for mounting faces.",
+    },
+    face_id: {
+      type: "string" as const,
+      description: "Return just this face (an id from an earlier call).",
+    },
+    radius_mm: {
+      type: "number" as const,
+      description:
+        "Keep only cylindrical/spherical faces of this radius (within `radius_tolerance_mm`) — e.g. 2.1 to find every M4 clearance hole.",
+    },
+    radius_tolerance_mm: {
+      type: "number" as const,
+      description: "Tolerance for `radius_mm`. Default 0.01 mm.",
+    },
+    min_area_mm2: {
+      type: "number" as const,
+      description:
+        "Drop faces smaller than this — the fast way past chamfers and fastener detail on a vendor part.",
+    },
+    summary_only: {
+      type: "boolean" as const,
+      description:
+        "Return only the grouped tallies and coaxial groups, no per-face records. Best first call on an unfamiliar part.",
+    },
+    limit: {
+      type: "number" as const,
+      description: `Max faces to return per part. Default ${DEFAULT_LIMIT}.`,
+    },
+    offset: {
+      type: "number" as const,
+      description: "Faces to skip (pagination). Default 0.",
+    },
+  },
+  required: ["document_id"],
+} as const;
+
+/** `inspect_faces` MCP handler. */
+export function inspectFaces(args: Record<string, unknown>, engine: Engine) {
+  const documentId = String(args.document_id ?? "");
+  if (!documentId) return err("Pass `document_id` (the open CAD session).");
+
+  let doc: Document;
+  try {
+    doc = getSession(documentId);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  const surfaceTypes = Array.isArray(args.surface_type)
+    ? args.surface_type.map((x) => String(x))
+    : undefined;
+
+  const payload = inspectFacesResult(doc, engine, {
+    partRef: args.part === undefined ? undefined : String(args.part),
+    filters: {
+      surfaceTypes,
+      faceId: args.face_id === undefined ? undefined : String(args.face_id),
+      minAreaMm2:
+        args.min_area_mm2 === undefined ? undefined : Number(args.min_area_mm2),
+      radiusMm: args.radius_mm === undefined ? undefined : Number(args.radius_mm),
+      radiusToleranceMm:
+        args.radius_tolerance_mm === undefined
+          ? 0.01
+          : Number(args.radius_tolerance_mm),
+    },
+    limit: args.limit === undefined ? DEFAULT_LIMIT : Number(args.limit),
+    offset: args.offset === undefined ? 0 : Number(args.offset),
+    summaryOnly: args.summary_only === true,
+  });
+
+  if ("error" in payload) return err(String(payload.error));
+
+  const body = { document_id: documentId, ...payload };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(body) }],
+    structuredContent: { faces: body, document_id: documentId },
+  };
+}
+
+// =============================================================================
+// measure_outer_diameter
+// =============================================================================
+
+const outerDiameterSchema = {
+  type: "object" as const,
+  properties: {
+    document_id: {
+      type: "string" as const,
+      description: "Session id from open_document holding the part.",
+    },
+    part: {
+      type: "string" as const,
+      description: "Part id or name. Omit to measure every visible part.",
+    },
+    axis: {
+      type: "array" as const,
+      items: { type: "number" as const },
+      minItems: 3,
+      maxItems: 3,
+      description:
+        "Axis to measure about, e.g. [0,1,0]. Sign is ignored. Omit to use the part's dominant axis (the one carrying the most cylindrical area) — do not assume Z.",
+    },
+  },
+  required: ["document_id"],
+} as const;
+
+/** `measure_outer_diameter` payload builder. */
+export function outerDiameterResult(
+  doc: Document,
+  engine: Engine,
+  partRef: string | undefined,
+  axis: [number, number, number] | undefined,
+): Record<string, unknown> | { error: string } {
+  const resolved = resolveParts(doc, engine, partRef);
+  if ("error" in resolved) return resolved;
+
+  const parallel = (g: CoaxialGroup) => {
+    if (!axis) return true;
+    const [ax, ay, az] = axis;
+    const len = Math.hypot(ax, ay, az);
+    if (len < 1e-12) return false;
+    const [bx, by, bz] = g.axis;
+    const dot = (ax * bx + ay * by + az * bz) / len;
+    return Math.abs(Math.abs(dot) - 1) < 1e-6;
+  };
+
+  const parts = resolved.parts.map((p) => {
+    const candidates = p.report.coaxial_groups.filter(parallel);
+    if (candidates.length === 0) {
+      return {
+        part: p.name,
+        node_id: p.node_id,
+        error: axis
+          ? `No cylindrical faces on this part share the axis [${axis.join(", ")}]. ` +
+            `Axes present: ${p.report.coaxial_groups
+              .map((g) => `[${g.axis.map(r6).join(", ")}]`)
+              .join(", ") || "none (no cylindrical faces)"}.`
+          : "This part has no cylindrical faces, so it has no outer diameter.",
+      };
+    }
+    // With an axis given, the biggest cylinder on it is the OD. Without one,
+    // the dominant axis is the group carrying the most lateral area — the
+    // groups arrive in that order.
+    const chosen = axis
+      ? candidates.reduce((a, b) => (b.max_radius_mm > a.max_radius_mm ? b : a))
+      : candidates[0];
+
+    const bboxSpan = (() => {
+      const lo = [0, 1, 2].map((i) =>
+        Math.min(...p.report.faces.map((f) => f.bbox_min_mm[i])),
+      );
+      const hi = [0, 1, 2].map((i) =>
+        Math.max(...p.report.faces.map((f) => f.bbox_max_mm[i])),
+      );
+      return [0, 1, 2].map((i) => r6(hi[i] - lo[i]));
+    })();
+
+    return {
+      part: p.name,
+      node_id: p.node_id,
+      axis_selection: axis ? "requested" : "dominant",
+      ...coaxialPayload(chosen),
+      other_axes: p.report.coaxial_groups
+        .filter((g) => g !== chosen)
+        .slice(0, 5)
+        .map((g) => ({
+          axis: vec(g.axis),
+          outer_diameter_mm: r6(g.max_diameter_mm),
+        })),
+      bbox_size_mm: bboxSpan,
+    };
+  });
+
+  return {
+    units: "mm",
+    parts,
+    note:
+      "Diameters are analytic (exact). `bbox_size_mm` is given for contrast only — a bounding box " +
+      "overstates diameter whenever a boss, connector or flange sticks out, which is why this tool exists.",
+  };
+}
+
+/** `measure_outer_diameter` MCP handler. */
+export function measureOuterDiameter(
+  args: Record<string, unknown>,
+  engine: Engine,
+) {
+  const documentId = String(args.document_id ?? "");
+  if (!documentId) return err("Pass `document_id` (the open CAD session).");
+
+  let doc: Document;
+  try {
+    doc = getSession(documentId);
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
+  let axis: [number, number, number] | undefined;
+  if (args.axis !== undefined) {
+    if (!Array.isArray(args.axis) || args.axis.length !== 3) {
+      return err("Pass `axis` as three numbers, e.g. [0, 1, 0].");
+    }
+    const a = args.axis.map((x) => Number(x));
+    if (a.some((x) => !Number.isFinite(x))) {
+      return err("`axis` components must be finite numbers.");
+    }
+    if (Math.hypot(a[0], a[1], a[2]) < 1e-12) {
+      return err("`axis` must not be the zero vector.");
+    }
+    axis = [a[0], a[1], a[2]];
+  }
+
+  const payload = outerDiameterResult(
+    doc,
+    engine,
+    args.part === undefined ? undefined : String(args.part),
+    axis,
+  );
+  if ("error" in payload) return err(String(payload.error));
+
+  const body = { document_id: documentId, ...payload };
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(body) }],
+    structuredContent: { outer_diameter: body, document_id: documentId },
+  };
+}
+
+export const toolDefs: ToolDef[] = [
+  {
+    name: "inspect_faces",
+    pack: null,
+    description:
+      "List a part's B-rep faces: stable face id, surface type, area, bbox, centroid, plus the exact surface parameters — a cylinder's radius/diameter, axis direction, point on axis and axial extent (and whether it's a bore or a shaft); a plane's outward normal and a point on it. This is the tool for mechanical reasoning an agent can't do from a bounding box: find the mounting face, read a bore diameter, get a shaft axis. Filter with `surface_type` / `radius_mm` / `min_area_mm2`, page with `limit`/`offset`, or start with `summary_only` to get grouped tallies ('17 cylindrical faces at radius 2.1 mm') instead of hundreds of records. Radii, axes and normals are analytic; areas, bboxes and centroids are tessellation-bound. Complements `inspect_cad` and `measure`, which see only the triangle mesh. Requires B-rep geometry — mesh-only parts are refused by name, not guessed at.",
+    inputSchema: inspectFacesSchema,
+    handler: (a, c) => inspectFaces(a, c.engine),
+    behavior: behavior({}),
+  },
+  {
+    name: "measure_outer_diameter",
+    pack: null,
+    description:
+      "Measure a part's true outer diameter: the largest cylinder coaxial with a given axis (omit `axis` to use the part's dominant axis — do not assume Z). This is what 'OD' means on a real part; a bounding box overstates it whenever a connector boss, flange or mounting ear sticks out, so the result reports the bbox size alongside for contrast. Also reports the smallest radius on that axis (the innermost bore), every distinct radius present, and the axial extent. Diameters are analytic, so exact regardless of tessellation.",
+    inputSchema: outerDiameterSchema,
+    handler: (a, c) => measureOuterDiameter(a, c.engine),
+    behavior: behavior({}),
+  },
+];

--- a/packages/mcp/src/tools/tool-metadata.ts
+++ b/packages/mcp/src/tools/tool-metadata.ts
@@ -133,6 +133,22 @@ export const TOOL_METADATA: Record<string, ToolMetadata> = {
   create_cad_loon: { title: "Create CAD (Loon)", annotations: RW },
   export_cad: { title: "Export CAD", annotations: RW },
   inspect_cad: { title: "Inspect CAD", annotations: RO },
+  inspect_faces: {
+    title: "Inspect Faces",
+    annotations: RO,
+    outputSchema: objectOut({
+      faces: { type: "object" },
+      document_id: { type: "string" },
+    }),
+  },
+  measure_outer_diameter: {
+    title: "Measure Outer Diameter",
+    annotations: RO,
+    outputSchema: objectOut({
+      outer_diameter: { type: "object" },
+      document_id: { type: "string" },
+    }),
+  },
   measure: {
     title: "Measure",
     annotations: RO,


### PR DESCRIPTION
## Why

Agents could only ask about a part's *tessellation* — bbox, volume, centre of mass, min distance. That doesn't answer the questions that come up when reasoning about a real part: which face is the mounting plane, what a bore's diameter is, where a shaft axis points.

Worse, the bounding box **actively lies about diameters**. A motor with an 80 mm body and an asymmetric radial connector boss reads ~102 mm across its bbox, so "measure the OD" returns a number that is simply wrong — with no signal that it's wrong.

## What

`vcad_kernel::faces` walks the B-rep directly and reports, per face: a stable id, surface type, area, bbox, centroid, and the **analytic** surface parameters — a cylinder's radius/axis/axial extent, a plane's normal and origin, cone half-angle, sphere and torus radii.

Two MCP tools on top:

| Tool | Answers |
|---|---|
| `inspect_faces` | The face list — filterable by surface type, radius, or axis, with `summary_only` grouping and pagination |
| `measure_outer_diameter` | The true OD about the dominant (or a requested) axis — the bbox question asked correctly |

## Notes for a reviewer

**Accuracy is labelled, not assumed.** Surface type, plane normal, cylinder radius and axis are exact and tessellation-independent. Face area, bbox, centroid and axial extent are tessellation-bound and say so in the schema — same caveat as `inspect_cad`. Mixing the two silently would be the easy mistake here.

**Face identity degrades honestly.** Ids use `vcad_kernel_naming` names when the solid carries them (those survive a parameter change). Solids without names — imported STEP, mesh-derived — fall back to positional `face_<n>` ids flagged `stable: false`, deterministic for a given geometry but not across a rebuild that moves faces.

**Fails closed.** Mesh-only solids get a recovery hint rather than invented surface parameters, and every error names the available parts or axes so the caller can retry without guessing. A requested axis that nothing is built about returns nothing — it does not silently fall back to the dominant axis.

**Booleans split faces.** A test caught this: the boss union breaks the Ø80 body wall into three faces on the same cylinder. Normal boolean behaviour, and precisely why a raw face list is a poor answer to "what is the OD" — the coaxial grouping reassembles them (three faces in, one Ø80.0 and one full 30 mm extent out). `the_split_body_wall_still_answers_as_one_diameter` pins it.

`inspect_faces` is capped by default and reports what it withheld, so a 400-face import doesn't blow the context window.

## Tests

| Suite | Result |
|---|---|
| `vcad-kernel` (7 new `faces::tests`) | 74 passed, 0 failed |
| `vcad-eval` (5 new in `face_queries.rs`) | 96 passed, 0 failed |
| `cargo fmt` / `clippy -D warnings` / `tsc --noEmit` | clean |
| `vitest` MCP face tests (9) | **not run locally — see below** |

`face_queries.rs` exercises the same path the WASM binding takes (`evaluate_root_solids` → `inspect_faces`) on the motor scenario, confirming the numbers the MCP tests assert: OD exactly 80.0, dominant axis **Y** (not Z), bbox X-span >90, boss Ø12 on X, unique face ids, ±Y cap normals.

**The JS end-to-end path is unverified locally.** The MCP tools need `inspectDocumentFaces` in the WASM kernel, and three build attempts each died with `No space left on device` on my machine. Against the stale checked-in kernel the failure mode is at least clean, not a crash: `Error: inspectDocumentFaces is not available in this kernel build — rebuild the WASM kernel`. CI's TypeScript job builds WASM from source, so `faces.test.ts` gets exercised there — **please confirm that job goes green before merging.**

No `packages/kernel-wasm/vcad_kernel_wasm*` artifacts are committed, per the single-writer rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)