### PR TITLE
feat(kernel): fillet, chamfer, blend and shell report failure

### DIFF
--- a/changelog/entries/2026-08-15-fillet-failure-is-reported.json
+++ b/changelog/entries/2026-08-15-fillet-failure-is-reported.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-08-15-fillet-failure-is-reported",
+  "version": "0.9.4",
+  "date": "2026-08-15",
+  "category": "breaking",
+  "title": "Fillet, chamfer, blend and shell now report failure",
+  "summary": "A fillet that can't be applied is an error naming the cause instead of a silently unfilleted solid, multi-edge blends report per edge, and best-effort behavior moved to explicit *_lenient variants.",
+  "features": ["fillet", "chamfer", "shell", "kernel", "validation"]
+}

--- a/crates/vcad-app/src/evaluate.rs
+++ b/crates/vcad-app/src/evaluate.rs
@@ -174,17 +174,26 @@ fn evaluate_node(doc: &Document, node_id: NodeId) -> Result<Option<Solid>> {
                 )
             })
         }
+        // Blends are fail-closed: the kernel would hand back the
+        // *unmodified* solid, so a document asking for radii would
+        // silently evaluate to square edges. Surface it instead.
         CsgOp::Shell { child, thickness } => {
             let c = evaluate_node(doc, *child)?;
             c.map(|s| s.shell(*thickness))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("shell of node {child} did not apply: {e}"))?
         }
         CsgOp::Fillet { child, radius } => {
             let c = evaluate_node(doc, *child)?;
             c.map(|s| s.fillet(*radius))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("fillet of node {child} did not apply: {e}"))?
         }
         CsgOp::Chamfer { child, distance } => {
             let c = evaluate_node(doc, *child)?;
             c.map(|s| s.chamfer(*distance))
+                .transpose()
+                .map_err(|e| anyhow::anyhow!("chamfer of node {child} did not apply: {e}"))?
         }
         CsgOp::EdgeBlend {
             child,
@@ -205,6 +214,8 @@ fn evaluate_node(doc: &Document, node_id: NodeId) -> Result<Option<Solid>> {
             } else {
                 let (query, keys) = kernel_blend_args(edges, profile);
                 c.map(|s| s.edge_blend(&query, &keys))
+                    .transpose()
+                    .map_err(|e| anyhow::anyhow!("edge blend of node {child} did not apply: {e}"))?
             }
         }
         CsgOp::StepImport { path } => Solid::from_step(path).ok(),

--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -458,6 +458,29 @@ fn evaluate_node_timed(
     Ok(result)
 }
 
+/// Lift a kernel blend result into the evaluator's error channel.
+///
+/// The kernel used to hand back the *unmodified* solid when a fillet,
+/// chamfer, blend, or shell couldn't be applied — a wrong answer with no
+/// signal attached. Surfacing it as an `EvalError` means a document with
+/// an inapplicable radius fails loudly instead of quietly exporting
+/// square edges.
+fn blend_result(
+    r: Option<Result<Solid, vcad_kernel::BlendError>>,
+    op: &'static str,
+    child: NodeId,
+) -> Result<Option<Solid>, EvalError> {
+    match r {
+        None => Ok(None),
+        Some(Ok(s)) => Ok(Some(s)),
+        Some(Err(e)) => Err(EvalError::Blend {
+            op,
+            child,
+            message: e.to_string(),
+        }),
+    }
+}
+
 fn evaluate_op(
     op: &CsgOp,
     nodes: &HashMap<NodeId, vcad_ir::Node>,
@@ -601,17 +624,17 @@ fn evaluate_op_timed(
 
         CsgOp::Shell { child, thickness } => {
             let c = eval_child(*child, cache)?;
-            Ok(c.map(|s| s.shell(*thickness)))
+            blend_result(c.map(|s| s.shell(*thickness)), "shell", *child)
         }
 
         CsgOp::Fillet { child, radius } => {
             let c = eval_child(*child, cache)?;
-            Ok(c.map(|s| s.fillet(*radius)))
+            blend_result(c.map(|s| s.fillet(*radius)), "fillet", *child)
         }
 
         CsgOp::Chamfer { child, distance } => {
             let c = eval_child(*child, cache)?;
-            Ok(c.map(|s| s.chamfer(*distance)))
+            blend_result(c.map(|s| s.chamfer(*distance)), "chamfer", *child)
         }
 
         CsgOp::EdgeBlend {
@@ -635,7 +658,7 @@ fn evaluate_op_timed(
                 };
             }
             let (query, keys) = kernel_blend_args(edges, profile);
-            Ok(c.map(|s| s.edge_blend(&query, &keys)))
+            blend_result(c.map(|s| s.edge_blend(&query, &keys)), "edge blend", *child)
         }
 
         CsgOp::Sketch2D { .. } => {

--- a/crates/vcad-eval/src/lib.rs
+++ b/crates/vcad-eval/src/lib.rs
@@ -188,6 +188,23 @@ pub enum EvalError {
     /// Sheet-metal flange/fold construction failed.
     #[error("sheet-metal error: {0}")]
     SheetMetal(String),
+
+    /// A fillet / chamfer / edge-blend / shell node declined to apply.
+    ///
+    /// Fail-closed: the kernel would hand back the *unmodified* solid
+    /// here, and a document that silently evaluates to square edges where
+    /// it asked for radii is a wrong answer nobody sees. The child id
+    /// identifies the subtree the operation was applied to.
+    #[error("{op} of node {child} did not apply: {message}")]
+    Blend {
+        /// Which operation declined (`fillet`, `chamfer`, `edge blend`,
+        /// `shell`).
+        op: &'static str,
+        /// The operand the blend was applied to.
+        child: vcad_ir::NodeId,
+        /// The kernel's reason.
+        message: String,
+    },
 }
 
 /// Triangle mesh output from evaluation.

--- a/crates/vcad-eval/tests/fillet_torture.rs
+++ b/crates/vcad-eval/tests/fillet_torture.rs
@@ -188,8 +188,12 @@ fn run_kernel_case(name: &str, query: EdgeQuery, keys: Vec<BlendKey>) -> CaseRes
     let outcome = catch_unwind(AssertUnwindSafe(|| {
         let cube = Solid::cube(10.0, 10.0, 10.0);
         let ref_volume = cube.volume();
-        let blended = cube.edge_blend(&query, &keys);
-        classify_solid(&blended, ref_volume)
+        match cube.edge_blend(&query, &keys) {
+            Ok(blended) => classify_solid(&blended, ref_volume),
+            // The kernel now names its refusals instead of silently
+            // returning the input — that's `Refused`, not `NoOp`.
+            Err(e) => (Outcome::Refused, e.to_string()),
+        }
     }));
     match outcome {
         Ok((outcome, detail)) => CaseResult {

--- a/crates/vcad-ffi/src/lib.rs
+++ b/crates/vcad-ffi/src/lib.rs
@@ -224,7 +224,13 @@ pub extern "C" fn vcad_solid_fillet(solid: *const VcadSolid, radius: f64) -> *mu
     catch_unwind(AssertUnwindSafe(|| {
         let s: &VcadSolid = unsafe { &*solid };
         Box::into_raw(Box::new(VcadSolid {
-            inner: s.inner.fillet(radius),
+            inner: match s.inner.fillet(radius) {
+                Ok(f) => f,
+                // The C ABI has no error channel here; a null return is
+                // the honest answer — better than handing back an
+                // unfilleted solid the caller believes is filleted.
+                Err(_) => return ptr::null_mut(),
+            },
         }))
     }))
     .unwrap_or(ptr::null_mut())
@@ -239,7 +245,10 @@ pub extern "C" fn vcad_solid_chamfer(solid: *const VcadSolid, distance: f64) -> 
     catch_unwind(AssertUnwindSafe(|| {
         let s: &VcadSolid = unsafe { &*solid };
         Box::into_raw(Box::new(VcadSolid {
-            inner: s.inner.chamfer(distance),
+            inner: match s.inner.chamfer(distance) {
+                Ok(c) => c,
+                Err(_) => return ptr::null_mut(),
+            },
         }))
     }))
     .unwrap_or(ptr::null_mut())
@@ -2199,7 +2208,11 @@ mod tests {
     fn evaluates_a_loon_program() {
         // The AI-intent path: a loon program (as an agent would emit) compiles
         // and evaluates to geometry just like a loaded .vcad file.
-        let src = "[root [fillet 2.0 [cylinder 10 30]] \"brass\"]";
+        // A cube, not a cylinder: the cap-rim blend on a primitive
+        // cylinder is refused by the kernel (it diverges), which the old
+        // silent fail-soft hid — this test used to assert geometry on an
+        // *unfilleted* cylinder.
+        let src = "[root [fillet 2.0 [cube 10 10 30]] \"brass\"]";
         let scene = vcad_scene_from_loon(src.as_ptr(), src.len());
         assert!(!scene.is_null(), "loon program should compile + evaluate");
         let n = vcad_scene_part_count(scene);

--- a/crates/vcad-kernel-fillet/src/chamfer.rs
+++ b/crates/vcad-kernel-fillet/src/chamfer.rs
@@ -26,11 +26,20 @@ use crate::trim::{build_vertex_faces, compute_trim_vertices, CornerBlend};
 ///
 /// Panics if the solid has no edges or if offset computation fails.
 pub fn chamfer_all_edges(brep: &BRepSolid, distance: f64) -> BRepSolid {
+    chamfer_all_edges_checked(brep, distance).unwrap_or_else(|_| brep.clone())
+}
+
+/// [`chamfer_all_edges`], but a refusal is reported instead of being
+/// disguised as an unchanged solid.
+pub fn chamfer_all_edges_checked(
+    brep: &BRepSolid,
+    distance: f64,
+) -> Result<BRepSolid, crate::BlendRefusal> {
     let faces = extract_faces(brep);
     let edges = extract_edges(brep);
 
     if edges.is_empty() {
-        return brep.clone();
+        return Err(crate::BlendRefusal::NoEdges);
     }
 
     let trims = compute_trim_vertices(&faces, distance);
@@ -149,9 +158,9 @@ pub fn chamfer_all_edges(brep: &BRepSolid, distance: f64) -> BRepSolid {
     let shell = new_topo.add_shell(all_faces, ShellType::Outer);
     let solid_id = new_topo.add_solid(shell);
 
-    BRepSolid {
+    Ok(BRepSolid {
         topology: new_topo,
         geometry: new_geom,
         solid_id,
-    }
+    })
 }

--- a/crates/vcad-kernel-fillet/src/fillet_curved.rs
+++ b/crates/vcad-kernel-fillet/src/fillet_curved.rs
@@ -270,7 +270,9 @@ fn fillet_edges_detailed_inner(
                         &mut new_geom,
                         &mut all_faces,
                     ) {
-                        results.push(FilletResult::Success);
+                        results.push(FilletResult::Success {
+                            edge_id: edge_info.edge_id,
+                        });
                     } else {
                         results.push(FilletResult::DegenerateGeometry {
                             edge_id: edge_info.edge_id,
@@ -302,7 +304,9 @@ fn fillet_edges_detailed_inner(
                         &mut new_geom,
                         &mut all_faces,
                     ) {
-                        results.push(FilletResult::Success);
+                        results.push(FilletResult::Success {
+                            edge_id: edge_info.edge_id,
+                        });
                     } else {
                         results.push(FilletResult::DegenerateGeometry {
                             edge_id: edge_info.edge_id,
@@ -329,7 +333,9 @@ fn fillet_edges_detailed_inner(
                         &mut new_geom,
                         &mut all_faces,
                     ) {
-                        results.push(FilletResult::Success);
+                        results.push(FilletResult::Success {
+                            edge_id: edge_info.edge_id,
+                        });
                     } else {
                         results.push(FilletResult::DegenerateGeometry {
                             edge_id: edge_info.edge_id,
@@ -366,7 +372,9 @@ fn fillet_edges_detailed_inner(
                             &mut new_geom,
                             &mut all_faces,
                         ) {
-                            results.push(FilletResult::Success);
+                            results.push(FilletResult::Success {
+                                edge_id: edge_info.edge_id,
+                            });
                         } else {
                             results.push(FilletResult::DegenerateGeometry {
                                 edge_id: edge_info.edge_id,

--- a/crates/vcad-kernel-fillet/src/fillet_planar.rs
+++ b/crates/vcad-kernel-fillet/src/fillet_planar.rs
@@ -38,25 +38,35 @@ const COPLANAR_DIHEDRAL_THRESHOLD: f64 = 170.0 * std::f64::consts::PI / 180.0;
 /// When the B-rep contains non-planar surfaces or any pair of adjacent
 /// faces meeting at a near-coplanar dihedral angle (e.g. the tessellated
 /// side wall of an extruded arc), this function returns the input
-/// unchanged rather than producing broken geometry.
+/// unchanged rather than producing broken geometry. Use
+/// [`fillet_all_edges_checked`] to learn *why* nothing happened.
 pub fn fillet_all_edges(brep: &BRepSolid, radius: f64) -> BRepSolid {
+    fillet_all_edges_checked(brep, radius).unwrap_or_else(|_| brep.clone())
+}
+
+/// [`fillet_all_edges`], but a refusal is reported instead of being
+/// disguised as an unchanged solid.
+pub fn fillet_all_edges_checked(
+    brep: &BRepSolid,
+    radius: f64,
+) -> Result<BRepSolid, crate::BlendRefusal> {
+    use crate::BlendRefusal;
+
     let faces = extract_faces(brep);
     let edges = extract_edges(brep);
 
     if edges.is_empty() {
-        return brep.clone();
+        return Err(BlendRefusal::NoEdges);
     }
 
-    if !is_fillet_safe(brep, &faces, &edges) {
-        return brep.clone();
-    }
+    fillet_safety(brep, &faces, &edges)?;
 
     // Dihedral-correct tangent setbacks: r/tan(θ/2) per edge, capped at
     // 8·r. An infinite entry marks a knife edge — refuse the whole solid
     // rather than crack the shell around it.
     let setbacks = fillet_edge_setbacks(&faces, &edges, radius, 8.0 * radius);
     if setbacks.values().any(|s| !s.is_finite()) {
-        return brep.clone();
+        return Err(BlendRefusal::KnifeEdge);
     }
 
     let trims = compute_trim_vertices_with_setbacks(&faces, radius, &setbacks);
@@ -67,7 +77,7 @@ pub fn fillet_all_edges(brep: &BRepSolid, radius: f64) -> BRepSolid {
     // shell is watertight but *wrong* (it can even gain volume). Refuse
     // cleanly instead.
     if !trimmed_faces_are_valid(&faces, &trims) {
-        return brep.clone();
+        return Err(BlendRefusal::RadiusTooLargeForFeature);
     }
     let face_map: HashMap<FaceId, &FaceInfo> = faces.iter().map(|f| (f.face_id, f)).collect();
 
@@ -232,11 +242,11 @@ pub fn fillet_all_edges(brep: &BRepSolid, radius: f64) -> BRepSolid {
     let shell = new_topo.add_shell(all_faces, ShellType::Outer);
     let solid_id = new_topo.add_solid(shell);
 
-    BRepSolid {
+    Ok(BRepSolid {
         topology: new_topo,
         geometry: new_geom,
         solid_id,
-    }
+    })
 }
 
 /// Check that every trimmed face polygon still faces the same way as the
@@ -275,10 +285,16 @@ fn trimmed_faces_are_valid(faces: &[FaceInfo], trims: &HashMap<TrimKey, Point3>)
 /// geometry for this B-rep. Rejects inputs that would explode the trim
 /// calculation: non-planar surfaces and near-coplanar adjacent faces (the
 /// pattern produced by tessellating an extruded arc profile).
-fn is_fillet_safe(brep: &BRepSolid, faces: &[FaceInfo], edges: &[EdgeInfo]) -> bool {
+fn fillet_safety(
+    brep: &BRepSolid,
+    faces: &[FaceInfo],
+    edges: &[EdgeInfo],
+) -> Result<(), crate::BlendRefusal> {
+    use crate::BlendRefusal;
+
     for surface in &brep.geometry.surfaces {
         if surface.surface_type() != SurfaceKind::Plane {
-            return false;
+            return Err(BlendRefusal::NonPlanarFace);
         }
     }
 
@@ -301,10 +317,10 @@ fn is_fillet_safe(brep: &BRepSolid, faces: &[FaceInfo], edges: &[EdgeInfo]) -> b
         let angle = dot.acos();
         let interior = std::f64::consts::PI - angle;
         if interior > COPLANAR_DIHEDRAL_THRESHOLD {
-            return false;
+            return Err(BlendRefusal::CoplanarAdjacentFaces);
         }
     }
-    true
+    Ok(())
 }
 
 /// Build a plane-plane cylindrical blend (used by fillet_edges_detailed).

--- a/crates/vcad-kernel-fillet/src/fillet_subset.rs
+++ b/crates/vcad-kernel-fillet/src/fillet_subset.rs
@@ -316,7 +316,7 @@ pub(crate) fn fillet_plane_chain_edges(
                 radius,
             },
         );
-        results.push(FilletResult::Success);
+        results.push(FilletResult::Success { edge_id: e.edge_id });
     }
 
     // Selected edges touching each vertex (1 = cap end, 2 = miter corner).

--- a/crates/vcad-kernel-fillet/src/lib.rs
+++ b/crates/vcad-kernel-fillet/src/lib.rs
@@ -23,13 +23,13 @@ pub use blend_loft::{
     apply_edge_blend, find_edge_near, loft_blend_edge, loft_blend_edge_keyed, resolve_edge_query,
     BlendKey, BlendOutcome, BlendSection, EdgeQuery, ResolvedEdge,
 };
-pub use chamfer::chamfer_all_edges;
+pub use chamfer::{chamfer_all_edges, chamfer_all_edges_checked};
 pub use closest_point::closest_point_uv;
 pub use fillet_curved::{
     fillet_edges_detailed, fillet_edges_detailed_with_trace, FilletTrace, JunctionOutcome,
     JunctionTrace,
 };
-pub use fillet_planar::fillet_all_edges;
+pub use fillet_planar::{fillet_all_edges, fillet_all_edges_checked};
 pub use rolling_ball::rolling_ball_blend;
 
 use vcad_kernel_geom::{CylinderSurface, Surface, SurfaceKind};
@@ -52,11 +52,63 @@ pub enum FilletCase {
     Unsupported,
 }
 
+/// Why a whole-solid blend pipeline declined to modify its input.
+///
+/// The all-edges fillet and chamfer builders are fail-soft by
+/// construction: rather than emit a cracked or inverted shell they hand
+/// back the input untouched. That is the right *geometry* decision and
+/// the wrong *reporting* decision — so the `*_checked` entry points
+/// return this instead, and callers decide whether an unmodified solid
+/// is acceptable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlendRefusal {
+    /// The solid has no edges to blend.
+    NoEdges,
+    /// At least one face is non-planar; this pipeline handles planes only.
+    NonPlanarFace,
+    /// Two adjacent faces are nearly coplanar — there is no real edge
+    /// there to round, and blending one cracks the shell.
+    CoplanarAdjacentFaces,
+    /// A knife edge (dihedral so shallow that the tangent setback
+    /// `r/tan(θ/2)` is unbounded) — no finite blend fits.
+    KnifeEdge,
+    /// The radius exceeds what the local feature can host: the inset
+    /// faces cross over and invert. Equivalent to "radius exceeds
+    /// available edge length".
+    RadiusTooLargeForFeature,
+}
+
+impl std::fmt::Display for BlendRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            BlendRefusal::NoEdges => "solid has no edges to blend",
+            BlendRefusal::NonPlanarFace => {
+                "solid has non-planar faces; the planar blend pipeline cannot rebuild it"
+            }
+            BlendRefusal::CoplanarAdjacentFaces => {
+                "adjacent faces are nearly coplanar — no real edge to blend"
+            }
+            BlendRefusal::KnifeEdge => {
+                "knife edge: dihedral too shallow for any finite tangent setback"
+            }
+            BlendRefusal::RadiusTooLargeForFeature => {
+                "radius exceeds available edge length — trimmed faces invert"
+            }
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::error::Error for BlendRefusal {}
+
 /// Result of a single edge fillet operation.
 #[derive(Debug)]
 pub enum FilletResult {
     /// Successfully created a blend surface.
-    Success,
+    Success {
+        /// The edge that was filleted.
+        edge_id: EdgeId,
+    },
     /// Edge pair not supported for fillet.
     Unsupported {
         /// The edge that could not be filleted.
@@ -76,6 +128,37 @@ pub enum FilletResult {
         /// The edge that could not be filleted.
         edge_id: EdgeId,
     },
+}
+
+impl FilletResult {
+    /// The edge this outcome describes.
+    pub fn edge_id(&self) -> EdgeId {
+        match self {
+            FilletResult::Success { edge_id }
+            | FilletResult::Unsupported { edge_id, .. }
+            | FilletResult::RadiusTooLarge { edge_id, .. }
+            | FilletResult::DegenerateGeometry { edge_id } => *edge_id,
+        }
+    }
+
+    /// True when a blend surface was actually created for this edge.
+    pub fn is_success(&self) -> bool {
+        matches!(self, FilletResult::Success { .. })
+    }
+
+    /// A human-readable reason, or `None` when the edge succeeded.
+    pub fn reason(&self) -> Option<String> {
+        match self {
+            FilletResult::Success { .. } => None,
+            FilletResult::Unsupported { reason, .. } => Some(reason.clone()),
+            FilletResult::RadiusTooLarge { max_radius, .. } => Some(format!(
+                "radius exceeds available edge length (max ≈ {max_radius:.4} mm)"
+            )),
+            FilletResult::DegenerateGeometry { .. } => {
+                Some("degenerate geometry at the edge — blend construction collapsed".into())
+            }
+        }
+    }
 }
 
 /// Classify the fillet case between two faces.
@@ -409,11 +492,7 @@ mod tests {
         let (result, results) = fillet_edges_detailed(&cube, &edge_ids, 1.0);
 
         for r in &results {
-            assert!(
-                matches!(r, FilletResult::Success),
-                "expected Success, got {:?}",
-                r
-            );
+            assert!(r.is_success(), "expected Success, got {:?}", r);
         }
         assert_eq!(results.len(), 12, "should have 12 results for 12 edges");
 
@@ -447,7 +526,7 @@ mod tests {
                 .any(|s| s.surface_type() == SurfaceKind::Torus);
             if has_torus {
                 assert!(
-                    results.iter().any(|r| matches!(r, FilletResult::Success)),
+                    results.iter().any(|r| r.is_success()),
                     "should have at least one successful fillet"
                 );
             }
@@ -509,7 +588,7 @@ mod tests {
 
         let (filleted, results) = fillet_edges_detailed(&cube, &[edge], r);
         assert_eq!(results.len(), 1);
-        assert!(matches!(results[0], FilletResult::Success));
+        assert!(results[0].is_success());
 
         let mesh = vcad_kernel_tessellate::tessellate_brep(&filleted, 32);
         assert_eq!(
@@ -559,7 +638,7 @@ mod tests {
 
         let (filleted, results) = fillet_edges_detailed(&cube, &chosen, r);
         assert_eq!(results.len(), 2);
-        assert!(results.iter().all(|r| matches!(r, FilletResult::Success)));
+        assert!(results.iter().all(|r| r.is_success()));
 
         let mesh = vcad_kernel_tessellate::tessellate_brep(&filleted, 32);
         assert_eq!(

--- a/crates/vcad-kernel-fillet/tests/miter_chain.rs
+++ b/crates/vcad-kernel-fillet/tests/miter_chain.rs
@@ -18,7 +18,6 @@
 
 use std::collections::HashMap;
 use vcad_kernel_fillet::fillet_edges_detailed;
-use vcad_kernel_fillet::FilletResult;
 use vcad_kernel_math::Point3;
 use vcad_kernel_primitives::{make_cube, BRepSolid};
 use vcad_kernel_topo::EdgeId;
@@ -105,7 +104,7 @@ fn run_case(edges: &[EdgeId], cube: &BRepSolid, total_len: f64, corners: usize, 
     let (result, results) = fillet_edges_detailed(cube, edges, R);
     assert_eq!(results.len(), edges.len(), "{label}: one result per edge");
     for r in &results {
-        assert!(matches!(r, FilletResult::Success), "{label}: {r:?}");
+        assert!(r.is_success(), "{label}: {r:?}");
     }
     let mesh = vcad_kernel_tessellate::tessellate_brep(&result, 64);
     assert_watertight(&mesh, label);

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -1591,11 +1591,17 @@ impl Solid {
     // =========================================================================
 
     /// Chamfer all edges of the solid by the given distance.
+    ///
+    /// Throws when the chamfer cannot be applied — the kernel would
+    /// otherwise hand back the unchamfered solid with no signal.
     #[wasm_bindgen(js_name = chamfer)]
-    pub fn chamfer(&self, distance: f64) -> Solid {
-        Solid {
-            inner: self.inner.chamfer(distance),
-        }
+    pub fn chamfer(&self, distance: f64) -> Result<Solid, JsError> {
+        Ok(Solid {
+            inner: self
+                .inner
+                .chamfer(distance)
+                .map_err(|e| JsError::new(&format!("chamfer: {e}")))?,
+        })
     }
 
     /// Per-edge blend on query-selected edges with a keyed profile.
@@ -1624,24 +1630,38 @@ impl Solid {
         }
         let (query, keys) = kernel_blend_args(&spec.edges, &spec.profile);
         Ok(Solid {
-            inner: self.inner.edge_blend(&query, &keys),
+            inner: self
+                .inner
+                .edge_blend(&query, &keys)
+                .map_err(|e| JsError::new(&format!("edge blend: {e}")))?,
         })
     }
 
     /// Fillet all edges of the solid with the given radius.
+    ///
+    /// Throws when the fillet cannot be applied — a radius the geometry
+    /// can't host, a body with boolean holes, a mesh-only solid. The
+    /// alternative is a part that reaches a fabricator with square edges
+    /// where the design called for radii.
     #[wasm_bindgen(js_name = fillet)]
-    pub fn fillet(&self, radius: f64) -> Solid {
-        Solid {
-            inner: self.inner.fillet(radius),
-        }
+    pub fn fillet(&self, radius: f64) -> Result<Solid, JsError> {
+        Ok(Solid {
+            inner: self
+                .inner
+                .fillet(radius)
+                .map_err(|e| JsError::new(&format!("fillet: {e}")))?,
+        })
     }
 
     /// Shell (hollow) the solid by offsetting all faces inward.
     #[wasm_bindgen(js_name = shell)]
-    pub fn shell(&self, thickness: f64) -> Solid {
-        Solid {
-            inner: self.inner.shell(thickness),
-        }
+    pub fn shell(&self, thickness: f64) -> Result<Solid, JsError> {
+        Ok(Solid {
+            inner: self
+                .inner
+                .shell(thickness)
+                .map_err(|e| JsError::new(&format!("shell: {e}")))?,
+        })
     }
 
     // =========================================================================
@@ -2179,7 +2199,7 @@ impl Solid {
 /// This is a standalone wrapper for lazy loading via wasmosis.
 #[module("advanced")]
 #[wasm_bindgen]
-pub fn op_fillet(solid: &Solid, radius: f64) -> Solid {
+pub fn op_fillet(solid: &Solid, radius: f64) -> Result<Solid, JsError> {
     solid.fillet(radius)
 }
 
@@ -2188,7 +2208,7 @@ pub fn op_fillet(solid: &Solid, radius: f64) -> Solid {
 /// This is a standalone wrapper for lazy loading via wasmosis.
 #[module("advanced")]
 #[wasm_bindgen]
-pub fn op_chamfer(solid: &Solid, distance: f64) -> Solid {
+pub fn op_chamfer(solid: &Solid, distance: f64) -> Result<Solid, JsError> {
     solid.chamfer(distance)
 }
 
@@ -2197,7 +2217,7 @@ pub fn op_chamfer(solid: &Solid, distance: f64) -> Solid {
 /// This is a standalone wrapper for lazy loading via wasmosis.
 #[module("advanced")]
 #[wasm_bindgen]
-pub fn op_shell(solid: &Solid, thickness: f64) -> Solid {
+pub fn op_shell(solid: &Solid, thickness: f64) -> Result<Solid, JsError> {
     solid.shell(thickness)
 }
 
@@ -4780,17 +4800,17 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
 
         vcad_ir::CsgOp::Shell { child, thickness } => {
             let c = evaluate_node(doc, *child)?;
-            Ok(c.shell(*thickness))
+            c.shell(*thickness)
         }
 
         vcad_ir::CsgOp::Fillet { child, radius } => {
             let c = evaluate_node(doc, *child)?;
-            Ok(c.fillet(*radius))
+            c.fillet(*radius)
         }
 
         vcad_ir::CsgOp::Chamfer { child, distance } => {
             let c = evaluate_node(doc, *child)?;
-            Ok(c.chamfer(*distance))
+            c.chamfer(*distance)
         }
 
         vcad_ir::CsgOp::EdgeBlend {
@@ -4810,7 +4830,10 @@ fn evaluate_node(doc: &vcad_ir::Document, node_id: vcad_ir::NodeId) -> Result<So
             }
             let (query, keys) = kernel_blend_args(edges, profile);
             Ok(Solid {
-                inner: c.inner.edge_blend(&query, &keys),
+                inner: c
+                    .inner
+                    .edge_blend(&query, &keys)
+                    .map_err(|e| JsError::new(&format!("edge blend: {e}")))?,
             })
         }
 

--- a/crates/vcad-kernel/examples/porkchop_diag.rs
+++ b/crates/vcad-kernel/examples/porkchop_diag.rs
@@ -136,7 +136,7 @@ fn main() {
     write_junctions_csv(&out_dir.join("porkchop_junctions.csv"), &trace);
 
     // Weld + boundary detection on the unified mesh.
-    let full = extruded.fillet(4.0).to_mesh(32);
+    let full = extruded.fillet_lenient(4.0).0.to_mesh(32);
     write_boundary_obj(&out_dir.join("porkchop_boundary.obj"), &full);
 
     let n_built = trace

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -139,6 +139,145 @@ impl std::fmt::Display for NamedEdgeError {
 
 impl std::error::Error for NamedEdgeError {}
 
+/// Why a blend or shell operation declined to modify its input.
+///
+/// The fillet/chamfer/blend pipelines are fail-soft internally: rather
+/// than emit a cracked or inverted shell they hand back the input
+/// untouched. Historically that decision was invisible to the caller —
+/// a part could reach a fabricator with square edges where the design
+/// called for radii. [`Solid::fillet`] and friends now return this
+/// instead, so declining is impossible to miss; the `*_lenient` variants
+/// keep the old best-effort behavior for callers that genuinely want it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BlendError {
+    /// The solid is mesh-backed — there is no topology to blend.
+    NotBRep,
+    /// The solid is empty.
+    EmptySolid,
+    /// The blend profile carried no keys.
+    NoKeys,
+    /// Faces carry inner boundary loops (holes left by a boolean). The
+    /// rebuild reconstructs faces from outer loops only, so running it
+    /// would silently fill the holes back in.
+    InnerLoops {
+        /// How many faces have inner loops.
+        faces: usize,
+    },
+    /// Nothing was eligible: no edge survived target selection (all
+    /// same-surface seams, or the query matched nothing).
+    NoTargetEdges,
+    /// The whole-solid pipeline refused up front, with a specific reason.
+    Refused(vcad_kernel_fillet::BlendRefusal),
+    /// Every edge that was targeted failed individually. The per-edge
+    /// reasons are in the report.
+    AllEdgesFailed(Box<BlendReport>),
+    /// Output vertices escaped the input AABB grown by 2·radius — some
+    /// blend surface diverged, which in practice means the radius does
+    /// not fit the geometry it was asked to round.
+    Diverged {
+        /// The requested radius / setback in mm.
+        radius: f64,
+    },
+    /// The rebuilt shell failed the post-flight validity gate: it is
+    /// cracked (open boundary edges) or gained volume, which a fillet or
+    /// chamfer can never legitimately do.
+    InvalidResult,
+    /// A named-edge reference could not be resolved.
+    NamedEdge(NamedEdgeError),
+    /// The shell operation could not offset the solid.
+    Shell(String),
+}
+
+impl std::fmt::Display for BlendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotBRep => write!(f, "operation needs a B-rep solid; this one is mesh-backed"),
+            Self::EmptySolid => write!(f, "operation needs a non-empty solid"),
+            Self::NoKeys => write!(f, "blend profile has no keys"),
+            Self::InnerLoops { faces } => write!(
+                f,
+                "{faces} face(s) carry inner loops (holes from a boolean); \
+                 the blend rebuild would fill them in"
+            ),
+            Self::NoTargetEdges => write!(f, "no edges were eligible for blending"),
+            Self::Refused(r) => write!(f, "{r}"),
+            Self::AllEdgesFailed(report) => write!(
+                f,
+                "all {} targeted edge(s) failed: {}",
+                report.requested,
+                report.first_reason().unwrap_or_else(|| "no reason".into())
+            ),
+            Self::Diverged { radius } => write!(
+                f,
+                "blend geometry diverged — output escapes the input bounding box grown \
+                 by 2·{radius} mm; the radius exceeds the available edge length"
+            ),
+            Self::InvalidResult => write!(
+                f,
+                "blend produced invalid geometry (cracked shell or volume gain)"
+            ),
+            Self::NamedEdge(e) => write!(f, "named edge: {e}"),
+            Self::Shell(msg) => write!(f, "shell failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for BlendError {}
+
+impl From<NamedEdgeError> for BlendError {
+    fn from(e: NamedEdgeError) -> Self {
+        BlendError::NamedEdge(e)
+    }
+}
+
+/// What happened to one targeted edge during a blend.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EdgeBlendOutcome {
+    /// The edge in the *input* topology.
+    pub edge: vcad_kernel_topo::EdgeId,
+    /// Endpoints of that edge, for callers that need to point at it.
+    pub endpoints: Option<(Point3, Point3)>,
+    /// `None` when the edge was blended; otherwise why it was skipped.
+    pub skipped: Option<String>,
+}
+
+/// Per-edge account of a blend, so partial success is visible rather
+/// than collapsed to one boolean.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct BlendReport {
+    /// Edges the operation targeted.
+    pub requested: usize,
+    /// Edges that actually received a blend surface.
+    pub applied: usize,
+    /// Per-edge outcomes. Empty for pipelines that are all-or-nothing by
+    /// construction (the planar all-edges fillet/chamfer rebuild), where
+    /// `declined` carries the reason for the whole solid.
+    pub edges: Vec<EdgeBlendOutcome>,
+    /// Set when the operation handed back its input unchanged.
+    pub declined: Option<BlendError>,
+}
+
+impl BlendReport {
+    /// True when the operation left the solid untouched.
+    pub fn declined(&self) -> bool {
+        self.declined.is_some()
+    }
+
+    /// True when some but not all targeted edges were blended.
+    pub fn is_partial(&self) -> bool {
+        self.declined.is_none() && self.applied > 0 && self.applied < self.requested
+    }
+
+    /// Outcomes for the edges that were skipped.
+    pub fn skipped(&self) -> impl Iterator<Item = &EdgeBlendOutcome> {
+        self.edges.iter().filter(|e| e.skipped.is_some())
+    }
+
+    fn first_reason(&self) -> Option<String> {
+        self.edges.iter().find_map(|e| e.skipped.clone())
+    }
+}
+
 /// The internal representation of a solid.
 #[derive(Debug, Clone)]
 enum SolidRepr {
@@ -374,6 +513,14 @@ impl Solid {
         self.try_boolean(other, BooleanOp::Intersection)
     }
 
+    /// Which "this isn't blendable topology" error applies to this solid.
+    fn non_brep_error(&self) -> BlendError {
+        match &self.repr {
+            SolidRepr::Empty => BlendError::EmptySolid,
+            _ => BlendError::NotBRep,
+        }
+    }
+
     fn boolean(&self, other: &Solid, op: BooleanOp) -> Solid {
         self.try_boolean(other, op).unwrap_or_else(|_| {
             // Degrade gracefully instead of panicking: a visible-but-crude
@@ -459,25 +606,54 @@ impl Solid {
     /// trimmed inward, and each vertex becomes a triangular face.
     ///
     /// Only works on B-rep solids with planar faces (e.g., cubes, extruded
-    /// prisms). Returns the solid unchanged for mesh-only or empty solids.
-    pub fn chamfer(&self, distance: f64) -> Solid {
-        match &self.repr {
-            SolidRepr::BRep(brep) => {
-                // Same inner-loop hazard as `fillet` — see brep_has_inner_loops.
-                if brep_has_inner_loops(brep) {
-                    return self.clone();
-                }
-                let chamfered = vcad_kernel_fillet::chamfer_all_edges(brep, distance);
-                if !blend_result_is_valid(brep, &chamfered, true) {
-                    return self.clone();
-                }
-                Solid {
-                    names: None,
-                    repr: SolidRepr::BRep(Box::new(chamfered)),
-                    segments: self.segments,
-                }
-            }
-            _ => self.clone(),
+    /// prisms).
+    ///
+    /// Fail-closed: a mesh-only or empty solid, a body with boolean holes,
+    /// or a distance the geometry cannot host is a [`BlendError`], never a
+    /// silently unchamfered solid. Use [`Solid::chamfer_lenient`] for
+    /// best-effort behavior with a report.
+    pub fn chamfer(&self, distance: f64) -> Result<Solid, BlendError> {
+        let SolidRepr::BRep(brep) = &self.repr else {
+            return Err(self.non_brep_error());
+        };
+        // Same inner-loop hazard as `fillet` — see brep_has_inner_loops.
+        let holes = count_inner_loop_faces(brep);
+        if holes > 0 {
+            return Err(BlendError::InnerLoops { faces: holes });
+        }
+        let chamfered = vcad_kernel_fillet::chamfer_all_edges_checked(brep, distance)
+            .map_err(BlendError::Refused)?;
+        if !blend_result_is_valid(brep, &chamfered, true) {
+            return Err(BlendError::InvalidResult);
+        }
+        Ok(Solid {
+            names: None,
+            repr: SolidRepr::BRep(Box::new(chamfered)),
+            segments: self.segments,
+        })
+    }
+
+    /// Best-effort [`Solid::chamfer`]: never fails, but the report says
+    /// whether anything actually happened and why not.
+    pub fn chamfer_lenient(&self, distance: f64) -> (Solid, BlendReport) {
+        match self.chamfer(distance) {
+            Ok(s) => (
+                s,
+                BlendReport {
+                    requested: 1,
+                    applied: 1,
+                    ..Default::default()
+                },
+            ),
+            Err(e) => (
+                self.clone(),
+                BlendReport {
+                    requested: 1,
+                    applied: 0,
+                    edges: Vec::new(),
+                    declined: Some(e),
+                },
+            ),
         }
     }
 
@@ -495,53 +671,138 @@ impl Solid {
     /// surface are skipped since they aren't real geometric edges.
     ///
     /// If the chosen fillet path would produce geometry that escapes the
-    /// input AABB expanded by 2·radius, the blend is deemed degenerate and
-    /// the input is returned unchanged — a clean sharp-edged solid is
-    /// always preferable to a fractured shell with outlying vertices.
+    /// input AABB expanded by 2·radius, the blend is deemed degenerate —
+    /// a clean sharp-edged solid is always preferable to a fractured
+    /// shell with outlying vertices.
     ///
-    /// Returns the solid unchanged for mesh-only or empty solids.
-    pub fn fillet(&self, radius: f64) -> Solid {
-        match &self.repr {
-            SolidRepr::BRep(brep) => {
-                // Faces with inner loops (holes from booleans) can't survive
-                // the rebuild — fail soft rather than fill the holes in.
-                if brep_has_inner_loops(brep) {
-                    return self.clone();
+    /// Fail-closed: every one of those declines is a [`BlendError`], not
+    /// a quietly unfilleted solid. Partial success on the curved
+    /// per-edge path is *not* an error — the returned geometry is real —
+    /// but which edges were skipped, and why, is only visible through
+    /// [`Solid::fillet_reported`]. Use [`Solid::fillet_lenient`] when an
+    /// unfilleted fallback is genuinely acceptable.
+    pub fn fillet(&self, radius: f64) -> Result<Solid, BlendError> {
+        self.fillet_reported(radius).0
+    }
+
+    /// [`Solid::fillet`] plus a per-edge account of what happened.
+    ///
+    /// The report distinguishes "nothing was touched, here's why" from
+    /// "most edges rounded, these three were skipped because …" — the
+    /// second case still returns `Ok`, since the geometry is genuine.
+    pub fn fillet_reported(&self, radius: f64) -> (Result<Solid, BlendError>, BlendReport) {
+        let mut report = BlendReport::default();
+
+        let SolidRepr::BRep(brep) = &self.repr else {
+            let e = self.non_brep_error();
+            report.declined = Some(e.clone());
+            return (Err(e), report);
+        };
+
+        // Faces with inner loops (holes from booleans) can't survive
+        // the rebuild — refuse rather than fill the holes in.
+        let holes = count_inner_loop_faces(brep);
+        if holes > 0 {
+            let e = BlendError::InnerLoops { faces: holes };
+            report.declined = Some(e.clone());
+            return (Err(e), report);
+        }
+
+        let is_planar = brep_is_all_planar(brep);
+        let filleted = if is_planar {
+            // All-or-nothing rebuild: every edge or none.
+            report.requested = brep.topology.edges.len();
+            match vcad_kernel_fillet::fillet_all_edges_checked(brep, radius) {
+                Ok(b) => {
+                    report.applied = report.requested;
+                    b
                 }
-                let is_planar = brep_is_all_planar(brep);
-                let filleted = if is_planar {
-                    vcad_kernel_fillet::fillet_all_edges(brep, radius)
-                } else {
-                    let target_edges = collect_fillet_target_edges(brep);
-                    let (result, _details) =
-                        vcad_kernel_fillet::fillet_edges_detailed(brep, &target_edges, radius);
-                    result
-                };
-                // Sanity check: the fillet output must live inside a box
-                // that's at most 2·radius larger than the input AABB. If
-                // any vertex falls outside, some blend diverged — discard
-                // the result and return the input unchanged.
-                if !fillet_aabb_is_reasonable(brep, &filleted, radius) {
-                    return self.clone();
-                }
-                // A cracked or volume-gaining result is silently-bad
-                // geometry — prefer the clean sharp-edged input. The
-                // planar all-edges pipeline is expected to produce a
-                // perfectly watertight shell; the curved per-edge path
-                // intentionally tolerates residual corner-blend gaps
-                // (arc-extrude sphere vertex blends), so it only gets the
-                // volume-sanity check.
-                if !blend_result_is_valid(brep, &filleted, is_planar) {
-                    return self.clone();
-                }
-                Solid {
-                    names: None,
-                    repr: SolidRepr::BRep(Box::new(filleted)),
-                    segments: self.segments,
+                Err(r) => {
+                    let e = BlendError::Refused(r);
+                    report.declined = Some(e.clone());
+                    return (Err(e), report);
                 }
             }
-            _ => self.clone(),
+        } else {
+            let target_edges = collect_fillet_target_edges(brep);
+            if target_edges.is_empty() {
+                let e = BlendError::NoTargetEdges;
+                report.declined = Some(e.clone());
+                return (Err(e), report);
+            }
+            report.requested = target_edges.len();
+            let (result, details) =
+                vcad_kernel_fillet::fillet_edges_detailed(brep, &target_edges, radius);
+            for detail in &details {
+                let edge = detail.edge_id();
+                if detail.is_success() {
+                    report.applied += 1;
+                }
+                report.edges.push(EdgeBlendOutcome {
+                    edge,
+                    endpoints: edge_endpoints(brep, edge),
+                    skipped: detail.reason(),
+                });
+            }
+            // Edges the pipeline never reported on at all (dropped before
+            // classification) still owe the caller an explanation.
+            for &edge in &target_edges {
+                if !report.edges.iter().any(|o| o.edge == edge) {
+                    report.edges.push(EdgeBlendOutcome {
+                        edge,
+                        endpoints: edge_endpoints(brep, edge),
+                        skipped: Some(
+                            "edge was dropped before blend classification (not found in the \
+                             rebuilt topology)"
+                                .into(),
+                        ),
+                    });
+                }
+            }
+            if report.applied == 0 {
+                let e = BlendError::AllEdgesFailed(Box::new(report.clone()));
+                report.declined = Some(e.clone());
+                return (Err(e), report);
+            }
+            result
+        };
+
+        // Sanity check: the fillet output must live inside a box that's at
+        // most 2·radius larger than the input AABB. If any vertex falls
+        // outside, some blend diverged.
+        if !fillet_aabb_is_reasonable(brep, &filleted, radius) {
+            let e = BlendError::Diverged { radius };
+            report.declined = Some(e.clone());
+            report.applied = 0;
+            return (Err(e), report);
         }
+        // A cracked or volume-gaining result is silently-bad geometry.
+        // The planar all-edges pipeline is expected to produce a
+        // perfectly watertight shell; the curved per-edge path
+        // intentionally tolerates residual corner-blend gaps
+        // (arc-extrude sphere vertex blends), so it only gets the
+        // volume-sanity check.
+        if !blend_result_is_valid(brep, &filleted, is_planar) {
+            report.declined = Some(BlendError::InvalidResult);
+            report.applied = 0;
+            return (Err(BlendError::InvalidResult), report);
+        }
+        (
+            Ok(Solid {
+                names: None,
+                repr: SolidRepr::BRep(Box::new(filleted)),
+                segments: self.segments,
+            }),
+            report,
+        )
+    }
+
+    /// Best-effort [`Solid::fillet`]: on a decline the input is returned
+    /// unchanged and `report.declined` says why. This is the historical
+    /// behavior, now spelled out at the call site.
+    pub fn fillet_lenient(&self, radius: f64) -> (Solid, BlendReport) {
+        let (result, report) = self.fillet_reported(radius);
+        (result.unwrap_or_else(|_| self.clone()), report)
     }
 
     /// Per-edge blend on query-selected edges with a keyed profile.
@@ -558,22 +819,44 @@ impl Solid {
     /// planar blend surfaces with corner patches). Everything else uses
     /// the per-edge loft builder; edges that share a vertex with an
     /// already-blended edge are skipped (miter corners are a follow-up).
-    /// Returns the solid unchanged for mesh-only or empty solids
-    /// (fail-soft, mirroring `fillet`).
+    ///
+    /// Fail-closed, mirroring [`Solid::fillet`]: a decline is a
+    /// [`BlendError`], never a quietly unblended solid. See
+    /// [`Solid::edge_blend_reported`] for the per-edge account and
+    /// [`Solid::edge_blend_lenient`] for best-effort behavior.
     pub fn edge_blend(
         &self,
         query: &vcad_kernel_fillet::EdgeQuery,
         keys: &[vcad_kernel_fillet::BlendKey],
-    ) -> Solid {
+    ) -> Result<Solid, BlendError> {
+        self.edge_blend_reported(query, keys).0
+    }
+
+    /// [`Solid::edge_blend`] plus matched/blended/skipped edge counts.
+    pub fn edge_blend_reported(
+        &self,
+        query: &vcad_kernel_fillet::EdgeQuery,
+        keys: &[vcad_kernel_fillet::BlendKey],
+    ) -> (Result<Solid, BlendError>, BlendReport) {
+        let mut report = BlendReport::default();
+        let decline = |report: &mut BlendReport, e: BlendError| {
+            report.declined = Some(e.clone());
+            e
+        };
+
         let SolidRepr::BRep(brep) = &self.repr else {
-            return self.clone();
+            let e = decline(&mut report, self.non_brep_error());
+            return (Err(e), report);
         };
         if keys.is_empty() {
-            return self.clone();
+            let e = decline(&mut report, BlendError::NoKeys);
+            return (Err(e), report);
         }
-        // Same inner-loop hazard as `fillet` — see brep_has_inner_loops.
-        if brep_has_inner_loops(brep) {
-            return self.clone();
+        // Same inner-loop hazard as `fillet` — see count_inner_loop_faces.
+        let holes = count_inner_loop_faces(brep);
+        if holes > 0 {
+            let e = decline(&mut report, BlendError::InnerLoops { faces: holes });
+            return (Err(e), report);
         }
 
         // Fast path: whole-solid constant fillet/chamfer already have
@@ -582,22 +865,57 @@ impl Solid {
         if matches!(query, vcad_kernel_fillet::EdgeQuery::All) && keys.len() == 1 {
             let s = keys[0].section;
             if s.shape >= 1.0 - 1e-12 {
-                return self.fillet(s.size);
+                return self.fillet_reported(s.size);
             }
             if s.shape <= 1e-12 {
-                return self.chamfer(s.size);
+                let (solid, report) = self.chamfer_lenient(s.size);
+                let result = match &report.declined {
+                    Some(e) => Err(e.clone()),
+                    None => Ok(solid),
+                };
+                return (result, report);
             }
         }
 
-        let (blended, _outcome) = vcad_kernel_fillet::apply_edge_blend(brep, query, keys);
+        let (blended, outcome) = vcad_kernel_fillet::apply_edge_blend(brep, query, keys);
+        report.requested = outcome.matched;
+        report.applied = outcome.blended;
+        if outcome.matched == 0 {
+            let e = decline(&mut report, BlendError::NoTargetEdges);
+            return (Err(e), report);
+        }
+        if outcome.blended == 0 {
+            // `apply_edge_blend` reports counts, not per-edge reasons —
+            // synthesize the one reason it does distinguish.
+            report.edges = Vec::new();
+            let snapshot = Box::new(report.clone());
+            let e = decline(&mut report, BlendError::AllEdgesFailed(snapshot));
+            return (Err(e), report);
+        }
         if !blend_result_is_valid(brep, &blended, true) {
-            return self.clone();
+            report.applied = 0;
+            let e = decline(&mut report, BlendError::InvalidResult);
+            return (Err(e), report);
         }
-        Solid {
-            names: None,
-            repr: SolidRepr::BRep(Box::new(blended)),
-            segments: self.segments,
-        }
+        (
+            Ok(Solid {
+                names: None,
+                repr: SolidRepr::BRep(Box::new(blended)),
+                segments: self.segments,
+            }),
+            report,
+        )
+    }
+
+    /// Best-effort [`Solid::edge_blend`]: on a decline the input comes
+    /// back unchanged with `report.declined` set.
+    pub fn edge_blend_lenient(
+        &self,
+        query: &vcad_kernel_fillet::EdgeQuery,
+        keys: &[vcad_kernel_fillet::BlendKey],
+    ) -> (Solid, BlendReport) {
+        let (result, report) = self.edge_blend_reported(query, keys);
+        (result.unwrap_or_else(|_| self.clone()), report)
     }
 
     // =========================================================================
@@ -665,9 +983,9 @@ impl Solid {
         face_a: &str,
         face_b: &str,
         keys: &[vcad_kernel_fillet::BlendKey],
-    ) -> Result<Solid, NamedEdgeError> {
+    ) -> Result<Solid, BlendError> {
         let (a, b) = self.resolve_named_edge(face_a, face_b)?;
-        Ok(self.edge_blend(&vcad_kernel_fillet::EdgeQuery::Endpoints { a, b }, keys))
+        self.edge_blend(&vcad_kernel_fillet::EdgeQuery::Endpoints { a, b }, keys)
     }
 
     /// Shell (hollow) the solid by offsetting all faces inward.
@@ -682,21 +1000,56 @@ impl Solid {
     ///
     /// # Returns
     ///
-    /// A new solid representing the hollow shell. Returns self unchanged
-    /// for empty solids.
-    pub fn shell(&self, thickness: f64) -> Solid {
+    /// A new solid representing the hollow shell.
+    ///
+    /// Fail-closed on an empty solid — shelling nothing is a no-op the
+    /// caller should hear about, not a silent pass-through. A B-rep whose
+    /// analytic offset fails still succeeds, via the mesh approximation,
+    /// but [`Solid::shell_reported`] flags that degradation so a caller
+    /// that needs analytic surfaces can refuse it.
+    pub fn shell(&self, thickness: f64) -> Result<Solid, BlendError> {
+        self.shell_reported(thickness).0
+    }
+
+    /// [`Solid::shell`], plus the analytic-offset error when the result
+    /// had to fall back to the coarse mesh offset.
+    ///
+    /// `Ok((solid, Some(reason)))` means "you got geometry, but it is the
+    /// tessellated approximation because the analytic offset failed with
+    /// `reason`".
+    #[allow(clippy::type_complexity)]
+    pub fn shell_reported(
+        &self,
+        thickness: f64,
+    ) -> (
+        Result<Solid, BlendError>,
+        Option<vcad_kernel_shell::ShellError>,
+    ) {
         match &self.repr {
-            SolidRepr::Empty => Solid::empty(),
-            SolidRepr::BRep(brep) => Solid {
-                names: None,
-                repr: SolidRepr::BRep(Box::new(vcad_kernel_shell::shell_brep(brep, thickness))),
-                segments: self.segments,
-            },
-            SolidRepr::Mesh(mesh) => Solid {
-                names: None,
-                repr: SolidRepr::Mesh(vcad_kernel_shell::shell_mesh(mesh, thickness)),
-                segments: self.segments,
-            },
+            SolidRepr::Empty => (Err(BlendError::EmptySolid), None),
+            SolidRepr::BRep(brep) => {
+                let (inner, degraded) =
+                    match vcad_kernel_shell::shell_brep_analytical(brep, thickness, &[]) {
+                        Ok(b) => (b, None),
+                        Err(e) => (vcad_kernel_shell::shell_brep(brep, thickness), Some(e)),
+                    };
+                (
+                    Ok(Solid {
+                        names: None,
+                        repr: SolidRepr::BRep(Box::new(inner)),
+                        segments: self.segments,
+                    }),
+                    degraded,
+                )
+            }
+            SolidRepr::Mesh(mesh) => (
+                Ok(Solid {
+                    names: None,
+                    repr: SolidRepr::Mesh(vcad_kernel_shell::shell_mesh(mesh, thickness)),
+                    segments: self.segments,
+                }),
+                None,
+            ),
         }
     }
 
@@ -1477,11 +1830,24 @@ impl std::ops::BitAnd for &Solid {
 /// them on such a body silently fills the holes back in. Callers use this
 /// to fail soft (return the input unchanged) instead of corrupting the
 /// model.
-fn brep_has_inner_loops(brep: &BRepSolid) -> bool {
+fn count_inner_loop_faces(brep: &BRepSolid) -> usize {
     brep.topology
         .faces
         .iter()
-        .any(|(_, f)| !f.inner_loops.is_empty())
+        .filter(|(_, f)| !f.inner_loops.is_empty())
+        .count()
+}
+
+/// Endpoint positions of an edge, for pointing a caller at the edge a
+/// blend outcome refers to.
+fn edge_endpoints(brep: &BRepSolid, edge: vcad_kernel_topo::EdgeId) -> Option<(Point3, Point3)> {
+    let e = brep.topology.edges.get(edge)?;
+    let he = brep.topology.half_edges.get(e.half_edge)?;
+    let twin = brep.topology.half_edges.get(he.twin?)?;
+    Some((
+        brep.topology.vertices.get(he.origin)?.point,
+        brep.topology.vertices.get(twin.origin)?.point,
+    ))
 }
 
 /// Guard against runaway fillet output. Both the topology vertices AND
@@ -2132,7 +2498,7 @@ mod tests {
     #[test]
     fn test_chamfer_cube() {
         let cube = Solid::cube(10.0, 10.0, 10.0);
-        let chamfered = cube.chamfer(1.0);
+        let chamfered = cube.chamfer(1.0).expect("chamfer r=1 fits a 10mm cube");
         assert!(!chamfered.is_empty());
         let vol = chamfered.volume();
         // Chamfered cube: V = L³ - 6d²(L-d) = 1000 - 54 = 946
@@ -2145,7 +2511,7 @@ mod tests {
     #[test]
     fn test_fillet_cube() {
         let cube = Solid::cube(10.0, 10.0, 10.0);
-        let filleted = cube.fillet(1.0);
+        let filleted = cube.fillet(1.0).expect("fillet r=1 fits a 10mm cube");
         assert!(!filleted.is_empty());
         // Fillet should have more triangles than original cube due to curved surfaces
         assert!(
@@ -2156,9 +2522,10 @@ mod tests {
 
     #[test]
     fn test_chamfer_empty() {
+        // Fail-closed: chamfering nothing is reported, not silently
+        // passed through as an empty solid.
         let empty = Solid::empty();
-        let chamfered = empty.chamfer(1.0);
-        assert!(chamfered.is_empty());
+        assert_eq!(empty.chamfer(1.0).unwrap_err(), BlendError::EmptySolid);
     }
 
     #[test]
@@ -2270,7 +2637,7 @@ mod tests {
     #[test]
     fn test_shell_cube() {
         let cube = Solid::cube(10.0, 10.0, 10.0);
-        let shell = cube.shell(2.0);
+        let shell = cube.shell(2.0).expect("2mm shell fits a 10mm cube");
         assert!(!shell.is_empty());
         // Analytical shell creates 12 faces (6 outer + 6 inner)
         let shell_vol = shell.volume();
@@ -2284,8 +2651,7 @@ mod tests {
     #[test]
     fn test_shell_empty() {
         let empty = Solid::empty();
-        let shell = empty.shell(1.0);
-        assert!(shell.is_empty());
+        assert_eq!(empty.shell(1.0).unwrap_err(), BlendError::EmptySolid);
     }
 
     #[test]
@@ -3002,7 +3368,19 @@ mod tests {
         // (plus a small margin from the blend arc). A diverging rolling-ball
         // would push a vertex far outside, so this catches that regression.
         let cyl = Solid::cylinder(10.0, 20.0, 32);
-        let filleted = cyl.fillet(2.0);
+        // The cap-rim torus blend on a primitive cylinder still diverges,
+        // so the kernel refuses. That refusal is the point: before it was
+        // reportable, this test passed *vacuously* on the untouched
+        // cylinder handed back by the AABB guard.
+        assert_eq!(
+            cyl.fillet(2.0).unwrap_err(),
+            BlendError::Diverged { radius: 2.0 },
+            "cylinder cap fillet must report divergence, not return the input silently"
+        );
+        let (filleted, report) = cyl.fillet_lenient(2.0);
+        assert!(matches!(report.declined, Some(BlendError::Diverged { .. })));
+        // Whatever comes back must still be bounded — a diverging blend
+        // that leaked through the guard is the regression to catch.
         let mesh = filleted.to_mesh(32);
         let n = mesh.num_vertices();
         let mut min_x = f64::MAX;
@@ -3093,7 +3471,9 @@ mod tests {
         )
         .expect("valid profile");
         let extruded = Solid::extrude(profile, Vec3::new(0.0, 0.0, 18.0)).expect("extrude ok");
-        let filleted = extruded.fillet(4.0);
+        // Best-effort on purpose: this case is allowed to decline (the AABB
+        // guard), and the assertions below hold either way.
+        let (filleted, _report) = extruded.fillet_lenient(4.0);
 
         let (sphere_surfaces, sphere_faces, shell_face_count) = match &filleted.repr {
             SolidRepr::BRep(b) => {
@@ -3216,7 +3596,9 @@ mod tests {
         )
         .expect("valid profile");
         let extruded = Solid::extrude(profile, Vec3::new(0.0, 0.0, 18.0)).expect("extrude ok");
-        let filleted = extruded.fillet(4.0);
+        // Best-effort on purpose: this case is allowed to decline (the AABB
+        // guard), and the assertions below hold either way.
+        let (filleted, _report) = extruded.fillet_lenient(4.0);
         let mesh = filleted.to_mesh(32);
 
         let boundary = mesh.boundary_edges();
@@ -3404,7 +3786,7 @@ mod tests {
             "expected one analytic cylinder per arc, got {cyl_count_before}"
         );
 
-        let filleted = extruded.fillet(4.0);
+        let (filleted, _report) = extruded.fillet_lenient(4.0);
         let face_count_after = match &filleted.repr {
             SolidRepr::BRep(b) => b.topology.faces.len(),
             _ => 0,
@@ -3458,13 +3840,33 @@ mod tests {
             "difference lost the bore: vol={bored_vol:.1}"
         );
 
+        // A body with a bore has faces carrying inner loops; the blend
+        // rebuild reconstructs faces from outer loops only, so it would
+        // fill the bore back in (the buggy path produced ~23736 — a
+        // filleted *solid* plate). The kernel refuses — and says so,
+        // rather than handing back the input as if it had succeeded.
         for (name, result) in [
             ("fillet", bored.fillet(1.5)),
             ("chamfer", bored.chamfer(1.5)),
         ] {
-            let vol = result.volume();
-            // The buggy path produced ~23736 (a filleted solid plate).
-            // Correct output must stay at or below the bored volume.
+            match result {
+                Err(BlendError::InnerLoops { faces }) => assert!(
+                    faces > 0,
+                    "{name} refused for inner loops but reported none"
+                ),
+                other => panic!("{name} after difference should refuse, got {other:?}"),
+            }
+        }
+
+        // The lenient variants still hand back the untouched body — but
+        // only for a caller that asked for best-effort, and the report
+        // carries the reason.
+        for (name, (solid, report)) in [
+            ("fillet", bored.fillet_lenient(1.5)),
+            ("chamfer", bored.chamfer_lenient(1.5)),
+        ] {
+            assert!(report.declined(), "{name} report should record the decline");
+            let vol = solid.volume();
             assert!(
                 vol <= bored_vol + 1.0,
                 "{name} after difference regrew material: vol={vol:.1} > bored={bored_vol:.1}"

--- a/crates/vcad-kernel/tests/blend_failure_is_reported.rs
+++ b/crates/vcad-kernel/tests/blend_failure_is_reported.rs
@@ -1,0 +1,250 @@
+//! A blend that declines must say so.
+//!
+//! `Solid::fillet` and friends are fail-soft internally: rather than emit
+//! a cracked or inverted shell they keep the input. For a long time that
+//! decision was invisible — the caller got a valid solid back and no
+//! indication anything had failed, so a part could reach a fabricator
+//! with square edges where the design called for radii. These tests pin
+//! the contract that replaced it:
+//!
+//! 1. The default entry points are fail-closed — a decline is an `Err`.
+//! 2. The reason is specific enough to act on, not a bare failure.
+//! 3. Multi-edge blends report per edge, not as one boolean.
+//! 4. The lenient variants still exist, but you have to ask for them.
+
+use vcad_kernel::vcad_kernel_fillet::{BlendKey, BlendRefusal, BlendSection, EdgeQuery};
+use vcad_kernel::vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel::{BlendError, Solid};
+
+fn cube() -> Solid {
+    Solid::cube(10.0, 10.0, 10.0)
+}
+
+fn fillet_key(size: f64) -> BlendKey {
+    BlendKey {
+        t: 0.0,
+        section: BlendSection { size, shape: 1.0 },
+    }
+}
+
+/// The headline case: a radius the geometry cannot host is an error, and
+/// emphatically *not* a quiet identity operation.
+#[test]
+fn a_radius_too_large_for_the_feature_is_an_error_not_a_noop() {
+    // r = 5 on a 10 mm cube: opposing insets meet at the midplane, so the
+    // trimmed faces collapse. The planar pipeline catches it up front.
+    let err = cube()
+        .fillet(5.0)
+        .expect_err("r=5 cannot fit a 10mm cube — this must not silently succeed");
+    assert_eq!(
+        err,
+        BlendError::Refused(BlendRefusal::RadiusTooLargeForFeature)
+    );
+    // The message names the cause, so a caller (or an agent) can act on
+    // it rather than guessing.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("radius exceeds available edge length"),
+        "reason should be actionable, got: {msg}"
+    );
+
+    // A grossly oversized radius gets past the up-front feasibility check
+    // but produces a shell that gains volume — caught by the post-flight
+    // gate. Different reason, same contract: it is never silent.
+    for r in [6.0, 12.0, 20.0] {
+        assert_eq!(
+            cube().fillet(r).unwrap_err(),
+            BlendError::InvalidResult,
+            "r={r} on a 10mm cube must be reported, not quietly skipped"
+        );
+    }
+}
+
+/// The same call through the lenient door: geometry comes back untouched,
+/// but the report records the decline. This is the *old* behavior — now
+/// only reachable by asking for it explicitly.
+#[test]
+fn the_lenient_variant_returns_the_input_but_records_why() {
+    let input = cube();
+    let (solid, report) = input.fillet_lenient(5.0);
+
+    assert!(report.declined(), "report must record the decline");
+    assert_eq!(report.applied, 0);
+    assert_eq!(
+        report.declined,
+        Some(BlendError::Refused(BlendRefusal::RadiusTooLargeForFeature))
+    );
+
+    // Unchanged: same volume, same face count as the input.
+    assert!((solid.volume() - input.volume()).abs() < 1e-9);
+    assert_eq!(
+        solid.as_brep().unwrap().topology.faces.len(),
+        input.as_brep().unwrap().topology.faces.len()
+    );
+}
+
+/// A radius that *does* fit still works, and reports full application.
+#[test]
+fn a_feasible_radius_succeeds_and_reports_every_edge_applied() {
+    let (result, report) = cube().fillet_reported(1.0);
+    let filleted = result.expect("r=1 fits a 10mm cube");
+
+    assert!(!report.declined());
+    assert!(
+        !report.is_partial(),
+        "a 12-edge cube fillet is all-or-nothing"
+    );
+    assert_eq!(report.requested, 12, "a cube has 12 edges");
+    assert_eq!(report.applied, report.requested);
+    assert!(filleted.volume() < cube().volume());
+}
+
+/// Every distinct decline carries a distinct, specific reason — the point
+/// of the exercise is that "it failed" is not an acceptable answer.
+#[test]
+fn each_decline_names_its_own_cause() {
+    // Mesh-backed: no topology to blend.
+    let mesh_solid = Solid::sphere(5.0, 8).union(&Solid::sphere(5.0, 8).translate(1.0, 0.0, 0.0));
+    if mesh_solid.as_brep().is_none() {
+        assert_eq!(mesh_solid.fillet(0.5).unwrap_err(), BlendError::NotBRep);
+    }
+
+    // Empty solid.
+    assert_eq!(
+        Solid::empty().fillet(1.0).unwrap_err(),
+        BlendError::EmptySolid
+    );
+    assert_eq!(
+        Solid::empty().chamfer(1.0).unwrap_err(),
+        BlendError::EmptySolid
+    );
+    assert_eq!(
+        Solid::empty().shell(1.0).unwrap_err(),
+        BlendError::EmptySolid
+    );
+
+    // No keys in the blend profile.
+    assert_eq!(
+        cube().edge_blend(&EdgeQuery::All, &[]).unwrap_err(),
+        BlendError::NoKeys
+    );
+
+    // A query that matches no edge blends nothing — and says so, instead
+    // of handing back a solid the caller believes was blended.
+    assert_eq!(
+        cube()
+            .edge_blend(
+                &EdgeQuery::Endpoints {
+                    a: Point3::new(99.0, 99.0, 99.0),
+                    b: Point3::new(99.0, 99.0, 90.0),
+                },
+                &[fillet_key(1.0)],
+            )
+            .unwrap_err(),
+        BlendError::NoTargetEdges
+    );
+
+    // A body with a bore has faces with inner loops; the rebuild would
+    // fill the bore back in.
+    let bored = Solid::cube(40.0, 40.0, 10.0)
+        .difference(&Solid::cylinder(6.0, 30.0, 24).translate(20.0, 20.0, -10.0));
+    match bored.fillet(1.0).unwrap_err() {
+        BlendError::InnerLoops { faces } => assert!(faces > 0),
+        other => panic!("expected an inner-loop refusal, got {other:?}"),
+    }
+}
+
+/// Partial success on a multi-edge fillet is reportable *per edge*, with
+/// a reason attached to each skipped one.
+#[test]
+fn a_multi_edge_fillet_reports_per_edge_not_as_one_boolean() {
+    use vcad_kernel_sketch::{SketchProfile, SketchSegment};
+
+    // An arc-extruded profile takes the curved per-edge path, where the
+    // kernel blends cap rims and leaves some seams sharp.
+    let p2 = vcad_kernel::vcad_kernel_math::Point2::new;
+    let segments = vec![
+        SketchSegment::Line {
+            start: p2(0.0, 0.0),
+            end: p2(30.0, 0.0),
+        },
+        SketchSegment::Arc {
+            start: p2(30.0, 0.0),
+            end: p2(30.0, 20.0),
+            center: p2(30.0, 10.0),
+            ccw: true,
+        },
+        SketchSegment::Line {
+            start: p2(30.0, 20.0),
+            end: p2(0.0, 20.0),
+        },
+        SketchSegment::Line {
+            start: p2(0.0, 20.0),
+            end: p2(0.0, 0.0),
+        },
+    ];
+    let profile = SketchProfile::new(
+        Point3::new(0.0, 0.0, 0.0),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(0.0, 1.0, 0.0),
+        segments,
+    )
+    .expect("valid profile");
+    let extruded = Solid::extrude(profile, Vec3::new(0.0, 0.0, 15.0)).expect("extrude ok");
+
+    let (_result, report) = extruded.fillet_reported(1.0);
+
+    assert!(
+        report.requested > 1,
+        "expected a multi-edge target set, got {}",
+        report.requested
+    );
+    assert_eq!(
+        report.edges.len(),
+        report.requested,
+        "every targeted edge must appear in the report"
+    );
+
+    // Whatever the split, the accounting is consistent and every skipped
+    // edge carries a reason string rather than a bare flag.
+    let applied = report.edges.iter().filter(|e| e.skipped.is_none()).count();
+    assert_eq!(
+        applied, report.applied,
+        "report.applied must match the rows"
+    );
+    for edge in report.skipped() {
+        let reason = edge.skipped.as_deref().unwrap();
+        assert!(!reason.is_empty(), "a skipped edge must say why");
+        assert!(
+            edge.endpoints.is_some(),
+            "a skipped edge should be locatable in the model"
+        );
+    }
+}
+
+/// `edge_blend_named` was already fail-closed on the name; it stays that
+/// way now that its error type widened to `BlendError`.
+#[test]
+fn a_named_edge_that_cannot_resolve_still_fails_closed() {
+    let err = cube()
+        .edge_blend_named("cube:top", "cube:nope", &[fillet_key(1.0)])
+        .expect_err("an unresolvable name must not fall back to a guessed edge");
+    assert!(
+        matches!(err, BlendError::NamedEdge(_)),
+        "expected a named-edge error, got {err:?}"
+    );
+}
+
+/// `shell` reports when it had to abandon the analytic offset for the
+/// coarse mesh approximation — a quality degradation that used to be
+/// completely invisible.
+#[test]
+fn shell_reports_a_fallback_to_the_mesh_offset() {
+    // The analytic path handles a plain box.
+    let (ok, degraded) = cube().shell_reported(2.0);
+    assert!(ok.is_ok());
+    assert!(
+        degraded.is_none(),
+        "a plain box should shell analytically, got fallback: {degraded:?}"
+    );
+}

--- a/crates/vcad-kernel/tests/chained_curved_boolean_regression.rs
+++ b/crates/vcad-kernel/tests/chained_curved_boolean_regression.rs
@@ -35,7 +35,12 @@ fn zmax(s: &Solid) -> f64 {
 /// to `z≈28` once the boolean kernel trims the curved face correctly.
 #[test]
 fn chained_curved_boolean_resurfaces_sphere() {
-    let body = Solid::cube(90.0, 60.0, 28.0).fillet(14.0);
+    // r=6, not the original r=14: r=14 on a 28 mm-tall body is refused
+    // (`RadiusTooLargeForFeature`), which the old silent fail-soft hid —
+    // this test used to run against a *plain* cube.
+    let body = Solid::cube(90.0, 60.0, 28.0)
+        .fillet(6.0)
+        .expect("r=6 fits a 90x60x28 body");
     let sphere = Solid::sphere(36.0, 0).translate(45.0, 30.0, 58.0);
     let cyl = Solid::cylinder(5.0, 4.0, 0).translate(45.0, 42.0, 25.0);
 
@@ -70,7 +75,9 @@ fn chained_planar_boolean_is_robust() {
 /// pins the failure to *chaining* a further curved cut, not the first one.
 #[test]
 fn single_curved_difference_is_robust() {
-    let body = Solid::cube(90.0, 60.0, 28.0).fillet(14.0);
+    let body = Solid::cube(90.0, 60.0, 28.0)
+        .fillet(6.0)
+        .expect("r=6 fits a 90x60x28 body");
     let sphere = Solid::sphere(36.0, 0).translate(45.0, 30.0, 58.0);
     let z = zmax(&body.difference(&sphere));
     assert!(

--- a/crates/vcad-kernel/tests/curved_trim_conformity.rs
+++ b/crates/vcad-kernel/tests/curved_trim_conformity.rs
@@ -42,7 +42,9 @@ fn bore_through_plain_box_is_watertight() {
 /// cut, so this must be exactly as clean as the plain case.
 #[test]
 fn bore_through_filleted_box_is_watertight() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let bore = Solid::cylinder(10.0, 200.0, 48).translate(50.0, 50.0, -50.0);
     let result = filleted.difference(&bore);
 

--- a/crates/vcad-kernel/tests/fillet_downstream.rs
+++ b/crates/vcad-kernel/tests/fillet_downstream.rs
@@ -31,7 +31,9 @@ fn difference_of_plain_boxes_is_exact() {
 /// Control: shelling a plain box is exact and watertight.
 #[test]
 fn shell_of_plain_box_is_exact() {
-    let result = Solid::cube(40.0, 40.0, 40.0).shell(2.0);
+    let result = Solid::cube(40.0, 40.0, 40.0)
+        .shell(2.0)
+        .expect("2mm shell fits");
     let expected = 40.0f64.powi(3) - 36.0f64.powi(3);
     assert!(
         (result.volume() - expected).abs() < 1e-6,
@@ -46,7 +48,9 @@ fn shell_of_plain_box_is_exact() {
 /// measured against.
 #[test]
 fn filleted_box_is_watertight() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     assert_eq!(open_edges(&filleted), 0);
     assert!(filleted.volume() < 1e6);
 }
@@ -57,9 +61,13 @@ fn filleted_box_is_watertight() {
 /// filleted solids, and the result must be watertight.
 #[test]
 fn shell_of_filleted_box_is_watertight_and_hollow() {
-    let outer = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
-    let inner = Solid::cube(96.0, 96.0, 96.0).fillet(10.0);
-    let shelled = outer.shell(2.0);
+    let outer = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
+    let inner = Solid::cube(96.0, 96.0, 96.0)
+        .fillet(10.0)
+        .expect("r=10 fits a 96mm cube");
+    let shelled = outer.shell(2.0).expect("2mm shell fits");
 
     assert_eq!(open_edges(&shelled), 0, "shell of a filleted box cracked");
     let expected = outer.volume() - inner.volume();
@@ -79,7 +87,9 @@ fn shell_of_filleted_box_is_watertight_and_hollow() {
 /// blends to flat quads and lost 57 mm³ of material per corner.
 #[test]
 fn pocket_in_filleted_box_is_exact() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let pocket = Solid::cube(20.0, 20.0, 20.0).translate(40.0, 40.0, 90.0);
     let result = filleted.difference(&pocket);
 
@@ -114,7 +124,9 @@ fn pocket_in_filleted_box_is_exact() {
 /// asserted by `difference_with_filleted_subject_is_watertight` below.
 #[test]
 fn difference_with_filleted_subject_has_no_duplicate_patches() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let inner = Solid::cube(96.0, 96.0, 96.0).translate(2.0, 2.0, 2.0);
     let result = filleted.difference(&inner);
 
@@ -163,7 +175,9 @@ fn difference_with_filleted_subject_has_no_duplicate_patches() {
 /// rounded-box SDF minus the inner cube.
 #[test]
 fn difference_with_filleted_subject_is_watertight() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let inner = Solid::cube(96.0, 96.0, 96.0).translate(2.0, 2.0, 2.0);
     let result = filleted.difference(&inner);
 
@@ -183,7 +197,9 @@ fn difference_with_filleted_subject_is_watertight() {
 /// the signed sum directly pins the orientation.
 #[test]
 fn boolean_against_filleted_subject_keeps_outward_winding() {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let inner = Solid::cube(96.0, 96.0, 96.0).translate(2.0, 2.0, 2.0);
     for result in [filleted.difference(&inner), filleted.union(&inner)] {
         let mesh = result.to_mesh(SEGMENTS);
@@ -221,15 +237,22 @@ fn boolean_against_filleted_subject_keeps_outward_winding() {
 /// — chamfer emits planar faces only, so it never hit any of this.
 #[test]
 fn chamfered_box_survives_shell_and_difference() {
-    let chamfered = Solid::cube(100.0, 100.0, 100.0).chamfer(12.0);
+    let chamfered = Solid::cube(100.0, 100.0, 100.0)
+        .chamfer(12.0)
+        .expect("12mm chamfer fits a 100mm cube");
     assert_eq!(open_edges(&chamfered), 0);
-    assert_eq!(open_edges(&chamfered.shell(2.0)), 0);
+    assert_eq!(
+        open_edges(&chamfered.shell(2.0).expect("2mm shell fits")),
+        0
+    );
     let inner = Solid::cube(96.0, 96.0, 96.0).translate(2.0, 2.0, 2.0);
     assert_eq!(open_edges(&chamfered.difference(&inner)), 0);
 }
 
 fn fillet_boolean_signature() -> String {
-    let filleted = Solid::cube(100.0, 100.0, 100.0).fillet(12.0);
+    let filleted = Solid::cube(100.0, 100.0, 100.0)
+        .fillet(12.0)
+        .expect("r=12 fits a 100mm cube");
     let inner = Solid::cube(96.0, 96.0, 96.0).translate(2.0, 2.0, 2.0);
     let result = filleted.difference(&inner);
     let brep = result.as_brep().expect("brep result");

--- a/crates/vcad-kernel/tests/shell_difference_volume.rs
+++ b/crates/vcad-kernel/tests/shell_difference_volume.rs
@@ -16,7 +16,7 @@ fn analytic_shell_volume(w: f64) -> f64 {
 #[test]
 fn shelled_box_volume_matches_wall_thickness() {
     for &w in &[0.8, 1.2, 2.0, 3.5, 5.0] {
-        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w);
+        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w).expect("shell fits");
         let vol = hollow.volume();
         let expected = analytic_shell_volume(w);
         assert!(
@@ -31,7 +31,7 @@ fn shell_then_difference_volume_decreases_with_thinner_wall() {
     // Corner cutter from the /prove demo: overlaps the box at
     // x 55..100, y 45..80, z 5..60.
     let part_volume = |w: f64| -> f64 {
-        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w);
+        let hollow = Solid::cube(100.0, 80.0, 60.0).shell(w).expect("shell fits");
         let cutter = Solid::cube(60.0, 50.0, 70.0).translate(55.0, 45.0, 5.0);
         hollow.difference(&cutter).volume()
     };

--- a/crates/vcad-kernel/tests/step_boolean_roundtrip.rs
+++ b/crates/vcad-kernel/tests/step_boolean_roundtrip.rs
@@ -77,7 +77,9 @@ fn filleted_boolean_roundtrips_or_refuses_cleanly() {
     // A boolean against a filleted part exercises the NURBS face path.
     // Whether the kernel keeps BRep here or degrades, the exporter must
     // either produce a re-readable file or refuse — never emit garbage.
-    let plate = Solid::cube(40.0, 40.0, 10.0).fillet(2.0);
+    let plate = Solid::cube(40.0, 40.0, 10.0)
+        .fillet(2.0)
+        .expect("r=2 fits a 40mm plate");
     let bore = Solid::cylinder(5.0, 12.0, 32).translate(20.0, 20.0, -1.0);
     let cut = plate.difference(&bore);
     if cut.can_export_step() {

--- a/crates/vcad-kernel/tests/topo_naming.rs
+++ b/crates/vcad-kernel/tests/topo_naming.rs
@@ -6,7 +6,7 @@
 
 use vcad_kernel::vcad_kernel_fillet::{BlendKey, BlendSection, EdgeQuery};
 use vcad_kernel::vcad_kernel_math::Point3;
-use vcad_kernel::Solid;
+use vcad_kernel::{BlendError, Solid};
 
 fn sorted_names(s: &Solid) -> Vec<String> {
     let mut v: Vec<String> = s
@@ -115,7 +115,7 @@ fn unresolvable_references_fail_closed() {
     assert!(cube.resolve_named_edge("cube:top", "cube:nope").is_err());
     assert!(cube.resolve_named_edge("garbage", "cube:top").is_err());
     // A name map is dropped by ops without a propagation rule.
-    let filleted = cube.fillet(1.0);
+    let filleted = cube.fillet(1.0).expect("r=1 fits a 10mm cube");
     assert!(filleted.names().is_none());
     assert!(filleted
         .resolve_named_edge("cube:top", "cube:right")
@@ -129,13 +129,22 @@ fn unresolvable_references_fail_closed() {
             shape: 1.0,
         },
     }];
-    let noop = cube.edge_blend(
-        &EdgeQuery::Endpoints {
-            a: Point3::new(99.0, 99.0, 99.0),
-            b: Point3::new(99.0, 99.0, 90.0),
-        },
-        &keys,
+    let query = EdgeQuery::Endpoints {
+        a: Point3::new(99.0, 99.0, 99.0),
+        b: Point3::new(99.0, 99.0, 90.0),
+    };
+    // Fail-closed: matching nothing is *reported*, not returned as an
+    // unchanged solid the caller would mistake for a blended one.
+    assert_eq!(
+        cube.edge_blend(&query, &keys).unwrap_err(),
+        BlendError::NoTargetEdges
     );
+
+    // The lenient variant is where "unchanged" lives, and the report
+    // records that nothing was applied.
+    let (noop, report) = cube.edge_blend_lenient(&query, &keys);
+    assert!(report.declined());
+    assert_eq!(report.applied, 0);
     let before = cube.as_brep().unwrap().topology.faces.len();
     let after = noop.as_brep().unwrap().topology.faces.len();
     assert_eq!(before, after);


### PR DESCRIPTION
## The problem

`Solid::fillet` and friends were fail-soft. When a blend couldn't be applied — radius too large, non-planar face, a body with boolean holes, a mesh-backed solid — the kernel returned the **input** solid. The caller got back a valid solid and no indication anything had failed.

For an interactive user that's a mild annoyance: you look at the viewport, see square edges, and try a smaller radius. For an agent driving the MCP server, or a headless `vcad export` in CI, nobody looks. The part ships with square edges where the design called for radii, and the first signal is the box arriving from the fabricator.

## What changed

The default entry points fail closed.

**`vcad-kernel-fillet`** — new `BlendRefusal` enum (`NoEdges`, `NonPlanarFace`, `CoplanarAdjacentFaces`, `KnifeEdge`, `RadiusTooLargeForFeature`) replaces the four bare `return brep.clone()` sites in the planar pipeline. `fillet_all_edges_checked` / `chamfer_all_edges_checked` return it; the old infallible names remain as `unwrap_or_else(clone)` wrappers. `FilletResult::Success` now carries its `edge_id`, which is what makes per-edge attribution possible.

**`vcad-kernel`** — new `BlendError` (11 variants) and `BlendReport` / `EdgeBlendOutcome`.

| API | Behavior |
|---|---|
| `fillet` / `chamfer` / `edge_blend` / `edge_blend_named` / `shell` | `Result<Solid, BlendError>` |
| `fillet_reported` / `edge_blend_reported` / `shell_reported` | adds the per-edge account |
| `fillet_lenient` / `chamfer_lenient` / `edge_blend_lenient` | old best-effort behavior, plus a report saying why |

`shell_reported` also surfaces the analytic→mesh-offset fallback, a quality degradation that was previously completely invisible.

**Callers** — `vcad-eval` gained `EvalError::Blend { op, child, message }`; `vcad-app` maps to `anyhow`; WASM throws `JsError`; the C ABI returns null (no error channel there, but null beats a solid the caller believes is filleted).

## Three tests were passing on unfilleted geometry

This is the part worth a reviewer's attention — the change found real silent failures in the existing suite:

- **`test_fillet_cylinder_produces_bounded_blend`** — r=2 on an r=10 cylinder returns `Diverged`. The test asserting "all vertices stay within the AABB" was satisfied *vacuously* by the identity return. Cap-rim torus blends on a primitive cylinder are genuinely broken; the test now asserts the refusal.
- **`chained_curved_boolean_regression.rs`** — r=14 on a 28 mm-tall body is `RadiusTooLargeForFeature`, so both curved-boolean regression tests were running against a plain cube. Changed to r=6, which actually fillets. They still pass, so the coverage is now real rather than nominal.
- **`vcad-ffi::evaluates_a_loon_program`** — `[fillet 2.0 [cylinder 10 30]]`, explicitly commented as "the AI-intent path: a loon program as an agent would emit", was asserting geometry on an unfilleted cylinder. Exactly the scenario this PR is about. Switched to a cube.

New [`blend_failure_is_reported.rs`](crates/vcad-kernel/tests/blend_failure_is_reported.rs) pins the contract with 7 tests: fail-closed defaults, a specific actionable reason per decline, per-edge reporting on multi-edge blends, and the lenient escape hatch.

## Notes for the reviewer

- **Breaking** for direct kernel/WASM API consumers. Every in-repo caller is updated; the `*_lenient` variants are a one-line migration for anything out-of-tree.
- **No WASM artifacts committed** — `packages/kernel-wasm/*` is untouched, per CLAUDE.md's single-writer rule. The TS signatures don't change (throwing doesn't alter the return type), so no `.d.ts` drift.
- **Unrelated observation, not fixed here:** fillet on a 10 mm cube is non-monotonic in radius — r=5.0 refuses with `RadiusTooLargeForFeature`, r=5.5 *succeeds*, r=6.0+ fails the post-flight validity gate. Pre-existing, worth a separate look.
- **Not attempted:** `build_receipt`/`verify_receipt` are ECAD-only (they operate on `Pcb`), so there's no mechanical-solid receipt to hang a "these edges are filleted" claim on. And DFM's `geom/radii.rs` only measures radii *present* in the B-rep — it has no record of intended radii, so it structurally cannot detect a missing fillet. Intent lives in the document, which is why the assertion went into `vcad-eval`.

## Verification

- `cargo test --workspace --exclude vcad-desktop` — 4127 passed, 0 failed
- `npm test --workspaces` — 1106 + 140 passed
- `cargo fmt --all --check` clean
- Clippy reports 5 lints in `vcad-kernel`; confirmed by stashing that all 5 are pre-existing on the branch base (newer local toolchain lints like `manual_is_multiple_of`). This PR adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
