### PR TITLE
feat(kernel): hole and bolt-pattern recognition over B-rep solids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6963,6 +6963,7 @@ dependencies = [
  "vcad-kernel-cam",
  "vcad-kernel-constraints",
  "vcad-kernel-export",
+ "vcad-kernel-features",
  "vcad-kernel-physics",
  "vcad-kernel-raytrace",
  "vcad-kernel-sketch",
@@ -7484,6 +7485,20 @@ dependencies = [
  "serde_json",
  "vcad-kernel-tessellate",
  "vcad-receipt",
+]
+
+[[package]]
+name = "vcad-kernel-features"
+version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tang",
+ "vcad-kernel-geom",
+ "vcad-kernel-math",
+ "vcad-kernel-primitives",
+ "vcad-kernel-step",
+ "vcad-kernel-topo",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "crates/vcad-kernel-fea",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
+    "crates/vcad-kernel-features",
     "crates/vcad-kernel-tolerance",
     "crates/vcad-kernel-calibration",
     "crates/vcad-crdt",
@@ -160,6 +161,7 @@ default-members = [
     "crates/vcad-kernel-fea",
     "crates/vcad-kernel-cost",
     "crates/vcad-kernel-dfm",
+    "crates/vcad-kernel-features",
     "crates/vcad-kernel-tolerance",
     "crates/vcad-kernel-calibration",
     "crates/vcad-crdt",
@@ -284,6 +286,7 @@ wasmosis-macro = { path = "crates/wasmosis/wasmosis-macro", version = "0.9.4" }
 vcad-slicer = { path = "crates/vcad-slicer", version = "0.9.4" }
 vcad-kernel-cost = { path = "crates/vcad-kernel-cost", version = "0.9.4" }
 vcad-kernel-dfm = { path = "crates/vcad-kernel-dfm", version = "0.9.4" }
+vcad-kernel-features = { path = "crates/vcad-kernel-features", version = "0.9.4" }
 vcad-kernel-tolerance = { path = "crates/vcad-kernel-tolerance", version = "0.9.4" }
 vcad-kernel-calibration = { path = "crates/vcad-kernel-calibration", version = "0.9.4" }
 vcad-slicer-gcode = { path = "crates/vcad-slicer-gcode", version = "0.9.4" }

--- a/changelog/entries/2026-08-15-hole-bolt-pattern-recognition.json
+++ b/changelog/entries/2026-08-15-hole-bolt-pattern-recognition.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-08-15-hole-bolt-pattern-recognition",
+  "version": "0.9.4",
+  "date": "2026-08-15",
+  "category": "feat",
+  "title": "Read a vendor part's bolt pattern with `vcad features`",
+  "summary": "Recognises holes, bolt circles, and linear patterns in an imported STEP: bolt-circle diameter, count, hole size, angles relative to the pattern, and a body OD taken from the largest coaxial cylinder instead of the bounding box.",
+  "features": ["kernel", "step", "cli", "feature-recognition"]
+}

--- a/crates/vcad-cli/Cargo.toml
+++ b/crates/vcad-cli/Cargo.toml
@@ -28,6 +28,7 @@ vcad-kernel-constraints = { path = "../vcad-kernel-constraints" }
 vcad-kernel-physics = { path = "../vcad-kernel-physics" }
 vcad-kernel-cam = { path = "../vcad-kernel-cam" }
 vcad-kernel-raytrace = { path = "../vcad-kernel-raytrace" }
+vcad-kernel-features = { workspace = true }
 vcad-kernel-tessellate = { workspace = true }
 vcad-kernel-export = { workspace = true }
 vcad-ecad-fabprep = { workspace = true }

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -102,6 +102,23 @@ enum Commands {
         relative_meshes: bool,
     },
 
+    /// Recognise holes and bolt patterns in a STEP file
+    ///
+    /// Reads a vendor STEP, places the assembly, and reports each component's
+    /// hole patterns — bolt-circle diameter, count, hole diameter, and the
+    /// angle of every hole *relative to its pattern* — plus the body envelope
+    /// measured from the largest coaxial cylinder rather than the bounding box.
+    Features {
+        /// Input STEP file (.step or .stp)
+        input: PathBuf,
+        /// Emit the full report as JSON instead of a text summary
+        #[arg(long)]
+        json: bool,
+        /// Hide patterns with fewer than this many members (text output only)
+        #[arg(long, default_value = "2", value_name = "N")]
+        min_count: usize,
+    },
+
     /// Render document to image
     Render {
         /// Input vcad file
@@ -398,6 +415,13 @@ fn main() -> Result<()> {
                 },
                 relative_meshes,
             )?;
+        }
+        Some(Commands::Features {
+            input,
+            json,
+            min_count,
+        }) => {
+            recognize_features(&input, json, min_count)?;
         }
         Some(Commands::Render {
             input,
@@ -1108,6 +1132,90 @@ fn write_step(doc: &vcad_ir::Document, output: &PathBuf) -> Result<usize> {
     // the caller's message can't drift from the file if the guard above ever
     // stops rejecting every solid-less root.
     Ok(named.len())
+}
+
+/// Recognise holes and bolt patterns in a STEP file and print them.
+///
+/// The text form is written for someone about to design a mating part: what
+/// the pattern is, how big, and where each hole sits *relative to the pattern*
+/// — absolute angles depend on how the vendor happened to place the model and
+/// make the same part look different in two files.
+fn recognize_features(input: &PathBuf, json: bool, min_count: usize) -> Result<()> {
+    use vcad_kernel_features::{PatternKind, PatternMember};
+
+    let report = vcad_kernel_features::step::recognize_step_file(input)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    let env = report.envelope();
+    let axis = env.dominant_axis;
+    println!("{}", input.display());
+    println!(
+        "  axis            ({:.3}, {:.3}, {:.3})",
+        axis.x, axis.y, axis.z
+    );
+    match env.body_od_mm {
+        Some(od) => println!(
+            "  body OD         {od:.3} mm  (largest coaxial cylinder; bbox across the axis reads {:.3})",
+            env.bbox_across_axis_mm
+        ),
+        None => println!("  body OD         n/a (no coaxial cylinder)"),
+    }
+    println!("  axial length    {:.3} mm", env.axial_length_mm);
+    println!("  components      {}", report.components.len());
+
+    for component in &report.components {
+        let patterns: Vec<_> = component
+            .report
+            .patterns
+            .iter()
+            .filter(|p| p.count >= min_count)
+            .collect();
+        if patterns.is_empty() {
+            continue;
+        }
+        println!("\n{} ({} faces)", component.name, component.face_count);
+        for (idx, p) in component.report.patterns.iter().enumerate() {
+            if p.count < min_count {
+                continue;
+            }
+            println!("  [{idx}] {}", p.describe());
+            if let PatternKind::BoltCircle { .. } = p.kind {
+                let angles: Vec<String> = p
+                    .members
+                    .iter()
+                    .map(|m: &PatternMember| format!("{:.3}", m.angle_deg))
+                    .collect();
+                println!("       angles rel. to pattern: {}", angles.join(", "));
+                if let Some(abs) = p.first_member_absolute_deg {
+                    println!("       first hole at {abs:.3} deg absolute (placement-dependent)");
+                }
+            }
+            let axial = p
+                .members
+                .iter()
+                .fold((f64::INFINITY, f64::NEG_INFINITY), |a, m| {
+                    (a.0.min(m.axial_start), a.1.max(m.axial_end))
+                });
+            println!(
+                "       axial extent along the pattern axis: [{:.3}, {:.3}]",
+                axial.0, axial.1
+            );
+        }
+        for rel in &component.report.relations {
+            if !rel.bisects_adjacent {
+                continue;
+            }
+            println!(
+                "  [{}] bisects adjacent holes of [{}] (phase {:.3} deg)",
+                rel.subject, rel.reference, rel.phase_deg
+            );
+        }
+    }
+    Ok(())
 }
 
 fn import_step(input: &PathBuf, output: &PathBuf, name: Option<String>) -> Result<()> {

--- a/crates/vcad-kernel-features/Cargo.toml
+++ b/crates/vcad-kernel-features/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "vcad-kernel-features"
+description = "Feature recognition over B-rep solids: holes, bolt circles, linear hole patterns, and coaxial body envelopes"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+vcad-kernel-math = { workspace = true }
+vcad-kernel-topo = { workspace = true }
+vcad-kernel-geom = { workspace = true }
+vcad-kernel-primitives = { workspace = true }
+vcad-kernel-step = { workspace = true, optional = true }
+tang = { workspace = true }
+serde = { workspace = true }
+
+[features]
+# `step` adds the assembly-aware entry points (recognize_step_file). On by
+# default — reading a vendor STEP is the whole point — but a consumer that
+# already has B-rep in hand can drop the STEP reader.
+default = ["step"]
+step = ["dep:vcad-kernel-step"]
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/vcad-kernel-features/src/lib.rs
+++ b/crates/vcad-kernel-features/src/lib.rs
@@ -1,0 +1,885 @@
+#![warn(missing_docs)]
+
+//! Feature recognition over B-rep solids.
+//!
+//! Vendor CAD arrives as a wall of faces. Designing a mount for a purchased
+//! actuator starts by reading its bolt pattern off that wall: "eight M4 holes
+//! on a Ø98 bolt circle at 22.5° + 45n". This crate answers that question.
+//!
+//! The pipeline is deliberately boring:
+//!
+//! 1. Collect every cylindrical face — radius, axis direction, a point on the
+//!    axis, axial extent, and whether the material is inside (a boss) or
+//!    outside (a hole).
+//! 2. Merge faces that share the same *axis line* and radius. A single hole is
+//!    usually two half-cylinder faces split at the surface seam.
+//! 3. Group by axis direction, then cluster by radius. Equal-radius coaxial
+//!    holes are the candidates for one pattern.
+//! 4. Project the axis positions onto the plane normal to the group axis and
+//!    fit a circle. A good fit with n ≥ 3 is a bolt circle; a collinear,
+//!    evenly-spaced run is a linear pattern; a lone big bore is a bore.
+//! 5. Report every angle *relative to the pattern* — the first hole is 0° and
+//!    the rest follow — plus the relation between concentric patterns (e.g.
+//!    "these three dowels bisect adjacent holes of that six-hole circle").
+//!
+//! The relative reporting is not a nicety. Reading the RobStride RS03's three
+//! output dowels as absolute angles off global X gives two different-looking
+//! answers for the same part depending on how the STEP happened to be placed;
+//! read against the output bolt circle they are always "bisecting adjacent
+//! holes".
+//!
+//! ```no_run
+//! # use vcad_kernel_features::recognize;
+//! # fn f(brep: &vcad_kernel_primitives::BRepSolid) {
+//! let report = recognize(brep);
+//! for pattern in &report.patterns {
+//!     println!("{}", pattern.describe());
+//! }
+//! # }
+//! ```
+
+use serde::Serialize;
+use vcad_kernel_geom::{CylinderSurface, SurfaceKind};
+use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_topo::{HalfEdgeId, Orientation};
+
+mod tolerance {
+    /// Two axis directions are parallel when their angle is under this (radians, ≈0.5°).
+    pub const AXIS_ANGLE: f64 = 0.0087;
+    /// Two axis lines are the same line when their lateral offset is under this (mm).
+    pub const AXIS_OFFSET: f64 = 1e-3;
+    /// Radii within this (mm) belong to the same cluster.
+    pub const RADIUS: f64 = 1e-3;
+    /// Circle-fit residual under this fraction of the fitted radius is "on the circle".
+    pub const CIRCLE_FIT_REL: f64 = 5e-3;
+    /// Absolute floor for the circle-fit residual (mm), for small bolt circles.
+    pub const CIRCLE_FIT_ABS: f64 = 5e-3;
+    /// Angular spacings within this (degrees) count as uniform.
+    pub const SPACING_DEG: f64 = 0.05;
+    /// Pattern centres within this (mm) are concentric.
+    pub const CONCENTRIC: f64 = 1e-2;
+}
+
+// =============================================================================
+// Cylindrical faces
+// =============================================================================
+
+/// Which side of a cylindrical face the material sits on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Concavity {
+    /// Material is outside the cylinder — a hole, bore, or pocket.
+    Internal,
+    /// Material is inside the cylinder — a boss, shaft, or the body OD.
+    External,
+}
+
+/// One cylindrical feature: a full hole or boss, with its split faces merged.
+#[derive(Debug, Clone, Serialize)]
+pub struct CylindricalFeature {
+    /// Faces (by index into `topology.faces` iteration order) that were merged.
+    pub faces: Vec<usize>,
+    /// Radius in mm.
+    pub radius_mm: f64,
+    /// Unit axis direction, sign-canonicalised (first significant component positive).
+    #[serde(serialize_with = "ser_vec3")]
+    pub axis: Vec3,
+    /// A point on the axis: the foot of the axis line closest to the origin.
+    #[serde(serialize_with = "ser_point3")]
+    pub axis_point: Point3,
+    /// Extent along `axis`, measured as a signed coordinate from `axis_point`.
+    pub axial_start: f64,
+    /// Upper end of the axial extent, same frame as `axial_start`.
+    pub axial_end: f64,
+    /// Hole or boss.
+    pub concavity: Concavity,
+    /// Number of separate axial runs merged onto this axis line. More than one
+    /// means the cylinder is interrupted — by a counterbore, groove, or chamfer.
+    pub segments: usize,
+    /// Whether every merged face belongs to the solid's outer shell.
+    pub on_outer_shell: bool,
+}
+
+impl CylindricalFeature {
+    /// Diameter in mm.
+    pub fn diameter_mm(&self) -> f64 {
+        self.radius_mm * 2.0
+    }
+
+    /// Axial length in mm.
+    pub fn length_mm(&self) -> f64 {
+        self.axial_end - self.axial_start
+    }
+}
+
+fn ser_vec3<S: serde::Serializer>(v: &Vec3, s: S) -> Result<S::Ok, S::Error> {
+    [v.x, v.y, v.z].serialize(s)
+}
+
+fn ser_point3<S: serde::Serializer>(p: &Point3, s: S) -> Result<S::Ok, S::Error> {
+    [p.x, p.y, p.z].serialize(s)
+}
+
+/// Canonicalise an axis direction so that ±d hash to the same representative.
+fn canonical_axis(d: Vec3) -> Vec3 {
+    let n = d.norm();
+    let d = if n > 0.0 { d / n } else { Vec3::z() };
+    let eps = 1e-9;
+    let flip = if d.x.abs() > eps {
+        d.x < 0.0
+    } else if d.y.abs() > eps {
+        d.y < 0.0
+    } else {
+        d.z < 0.0
+    };
+    if flip {
+        -d
+    } else {
+        d
+    }
+}
+
+/// Foot of the perpendicular from the origin onto the line `(p, dir)`.
+fn axis_foot(p: Point3, dir: Vec3) -> Point3 {
+    let v = p.coords();
+    p - dir * v.dot(dir)
+}
+
+/// Walk a loop's half-edge ring, yielding origin vertices.
+fn loop_vertices(brep: &BRepSolid, start: HalfEdgeId, out: &mut Vec<Point3>) {
+    let mut he = start;
+    for _ in 0..4096 {
+        let Some(h) = brep.topology.half_edges.get(he) else {
+            return;
+        };
+        if let Some(v) = brep.topology.vertices.get(h.origin) {
+            out.push(v.point);
+        }
+        match h.next {
+            Some(next) if next != start => he = next,
+            _ => return,
+        }
+    }
+}
+
+/// Every cylindrical face of `brep`, before merging.
+fn raw_cylindrical_faces(brep: &BRepSolid) -> Vec<CylindricalFeature> {
+    let outer_shell = brep
+        .topology
+        .solids
+        .get(brep.solid_id)
+        .map(|s| s.outer_shell);
+
+    let mut out = Vec::new();
+    for (idx, (face_id, face)) in brep.topology.faces.iter().enumerate() {
+        let Some(surface) = brep.geometry.surfaces.get(face.surface_index) else {
+            continue;
+        };
+        if surface.surface_type() != SurfaceKind::Cylinder {
+            continue;
+        }
+        let Some(cyl) = surface.as_any().downcast_ref::<CylinderSurface>() else {
+            continue;
+        };
+
+        let axis = canonical_axis(*cyl.axis.as_ref());
+        let axis_point = axis_foot(cyl.center, axis);
+
+        let mut pts = Vec::new();
+        if let Some(l) = brep.topology.loops.get(face.outer_loop) {
+            loop_vertices(brep, l.half_edge, &mut pts);
+        }
+        for lid in &face.inner_loops {
+            if let Some(l) = brep.topology.loops.get(*lid) {
+                loop_vertices(brep, l.half_edge, &mut pts);
+            }
+        }
+        if pts.is_empty() {
+            continue;
+        }
+        let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+        for p in &pts {
+            let t = (p - axis_point).dot(axis);
+            lo = lo.min(t);
+            hi = hi.max(t);
+        }
+
+        // A cylinder surface's normal points radially outward. A face whose
+        // normal is reversed therefore has material on the outside: a hole.
+        let concavity = match face.orientation {
+            Orientation::Reversed => Concavity::Internal,
+            Orientation::Forward => Concavity::External,
+        };
+        let on_outer_shell = match (face.shell, outer_shell) {
+            (Some(s), Some(o)) => s == o,
+            // No shell bookkeeping — don't claim knowledge we don't have.
+            _ => true,
+        };
+        let _ = face_id;
+
+        out.push(CylindricalFeature {
+            faces: vec![idx],
+            radius_mm: cyl.radius,
+            axis,
+            axis_point,
+            axial_start: lo,
+            axial_end: hi,
+            concavity,
+            segments: 1,
+            on_outer_shell,
+        });
+    }
+    out
+}
+
+fn same_axis_line(a: &CylindricalFeature, b: &CylindricalFeature) -> bool {
+    if a.axis.dot(b.axis).abs() < tolerance::AXIS_ANGLE.cos() {
+        return false;
+    }
+    let d = b.axis_point - a.axis_point;
+    let lateral = d - a.axis * d.dot(a.axis);
+    lateral.norm() <= tolerance::AXIS_OFFSET
+}
+
+/// Merge faces that are the same cylinder split at a seam (or by an intersecting
+/// feature) into one hole/boss.
+fn merge_faces(raw: Vec<CylindricalFeature>) -> Vec<CylindricalFeature> {
+    let mut merged: Vec<CylindricalFeature> = Vec::new();
+    'outer: for f in raw {
+        for m in merged.iter_mut() {
+            if (m.radius_mm - f.radius_mm).abs() > tolerance::RADIUS
+                || m.concavity != f.concavity
+                || !same_axis_line(m, &f)
+            {
+                continue;
+            }
+            // Re-express f's extent in m's frame (axis directions agree up to
+            // sign after canonicalisation, and axis_point is canonical too).
+            let base = (f.axis_point - m.axis_point).dot(m.axis);
+            let (lo, hi) = (base + f.axial_start, base + f.axial_end);
+            // Merge even when the two runs don't overlap: a hole interrupted by
+            // a counterbore, a groove, or a chamfer arrives as several faces on
+            // one axis line, and a caller asking "where are the holes" wants one
+            // answer per axis, not one per face. `segments` keeps the count.
+            m.axial_start = m.axial_start.min(lo);
+            m.axial_end = m.axial_end.max(hi);
+            m.segments += f.segments;
+            m.faces.extend_from_slice(&f.faces);
+            m.on_outer_shell &= f.on_outer_shell;
+            continue 'outer;
+        }
+        merged.push(f);
+    }
+    merged
+}
+
+/// Collect every cylindrical hole and boss in `brep`, seam-split faces merged.
+pub fn cylindrical_features(brep: &BRepSolid) -> Vec<CylindricalFeature> {
+    merge_faces(raw_cylindrical_faces(brep))
+}
+
+/// Collect cylindrical features across several solids.
+///
+/// Face indices are offset per solid, so they run continuously across the
+/// slice in the order the solids were given.
+pub fn cylindrical_features_many(breps: &[&BRepSolid]) -> Vec<CylindricalFeature> {
+    let mut raw = Vec::new();
+    let mut offset = 0usize;
+    for brep in breps {
+        for mut f in raw_cylindrical_faces(brep) {
+            for idx in &mut f.faces {
+                *idx += offset;
+            }
+            raw.push(f);
+        }
+        offset += brep.topology.faces.len();
+    }
+    merge_faces(raw)
+}
+
+// =============================================================================
+// Patterns
+// =============================================================================
+
+/// One hole (or boss) within a pattern.
+#[derive(Debug, Clone, Serialize)]
+pub struct PatternMember {
+    /// Angle about the pattern centre, measured from the first member (degrees,
+    /// CCW about the pattern axis, in `[0, 360)`). Zero for non-circular patterns.
+    pub angle_deg: f64,
+    /// Distance from the pattern centre in mm (the bolt-circle radius, per hole).
+    pub radius_from_center_mm: f64,
+    /// Position of the hole axis on the pattern plane.
+    #[serde(serialize_with = "ser_point3")]
+    pub center: Point3,
+    /// Start of the hole's axial extent, in the pattern's axial coordinate.
+    pub axial_start: f64,
+    /// End of the hole's axial extent, in the pattern's axial coordinate.
+    pub axial_end: f64,
+    /// Whether this member sits on the solid's outer shell.
+    pub on_outer_shell: bool,
+    /// Faces that produced this member.
+    pub faces: Vec<usize>,
+}
+
+/// What shape the members form.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum PatternKind {
+    /// Three or more equal-radius holes on a common circle.
+    BoltCircle {
+        /// Bolt-circle diameter (BCD) in mm.
+        bolt_circle_diameter_mm: f64,
+        /// Uniform angular spacing in degrees, if the holes are evenly spaced.
+        spacing_deg: Option<f64>,
+    },
+    /// A single feature — a bore, a shaft, or the body OD.
+    Single,
+    /// Two or more collinear, evenly-spaced holes.
+    Linear {
+        /// Centre-to-centre spacing in mm.
+        spacing_mm: f64,
+        /// Unit direction of the run, on the pattern plane.
+        #[serde(serialize_with = "ser_vec3")]
+        direction: Vec3,
+    },
+    /// Coaxial holes that fit none of the above (an irregular cluster).
+    Cluster,
+}
+
+/// A recognised group of equal-radius, parallel-axis cylindrical features.
+#[derive(Debug, Clone, Serialize)]
+pub struct HolePattern {
+    /// Shape of the group.
+    pub kind: PatternKind,
+    /// Hole or boss.
+    pub concavity: Concavity,
+    /// Hole diameter in mm (every member shares it).
+    pub hole_diameter_mm: f64,
+    /// Number of members.
+    pub count: usize,
+    /// Common axis direction.
+    #[serde(serialize_with = "ser_vec3")]
+    pub axis: Vec3,
+    /// Pattern centre: the fitted circle centre, or the centroid.
+    #[serde(serialize_with = "ser_point3")]
+    pub center: Point3,
+    /// Members, ordered by angle (circular) or along the run (linear).
+    pub members: Vec<PatternMember>,
+    /// Absolute angle of the first member about the pattern centre, measured
+    /// from global +X (or +Y when the axis is X) in degrees. Present for
+    /// reference only — placement-dependent, so prefer the relative angles.
+    pub first_member_absolute_deg: Option<f64>,
+    /// Whether every member is on the outer shell.
+    pub on_outer_shell: bool,
+}
+
+impl HolePattern {
+    /// A one-line human summary, in the language a mechanical designer uses.
+    pub fn describe(&self) -> String {
+        let (noun, plural) = match self.concavity {
+            Concavity::Internal => ("hole", "holes"),
+            Concavity::External => ("boss", "bosses"),
+        };
+        match &self.kind {
+            PatternKind::BoltCircle {
+                bolt_circle_diameter_mm,
+                spacing_deg,
+            } => {
+                let spacing = match spacing_deg {
+                    Some(s) => format!("{s:.4} deg spacing"),
+                    None => "uneven spacing".to_string(),
+                };
+                format!(
+                    "{} x Ø{:.3} {} on BCD {:.3}, {}",
+                    self.count, self.hole_diameter_mm, plural, bolt_circle_diameter_mm, spacing
+                )
+            }
+            PatternKind::Single => format!(
+                "1 x Ø{:.3} {} (length {:.3})",
+                self.hole_diameter_mm,
+                noun,
+                self.members
+                    .first()
+                    .map(|m| m.axial_end - m.axial_start)
+                    .unwrap_or(0.0)
+            ),
+            PatternKind::Linear { spacing_mm, .. } => format!(
+                "{} x Ø{:.3} {} in a line, pitch {:.3}",
+                self.count, self.hole_diameter_mm, plural, spacing_mm
+            ),
+            PatternKind::Cluster => format!(
+                "{} x Ø{:.3} parallel {} (irregular arrangement)",
+                self.count, self.hole_diameter_mm, plural
+            ),
+        }
+    }
+}
+
+/// How one pattern is clocked against another concentric, coaxial pattern.
+#[derive(Debug, Clone, Serialize)]
+pub struct PatternRelation {
+    /// Index into [`FeatureReport::patterns`] of the reference pattern.
+    pub reference: usize,
+    /// Index into [`FeatureReport::patterns`] of the pattern being described.
+    pub subject: usize,
+    /// Smallest angle (degrees) from any reference hole to any subject hole.
+    pub phase_deg: f64,
+    /// True when `phase_deg` is half the reference's spacing: the subject sits
+    /// midway between adjacent reference holes.
+    pub bisects_adjacent: bool,
+}
+
+/// The body envelope, measured from coaxial cylinders rather than the bbox.
+#[derive(Debug, Clone, Serialize)]
+pub struct Envelope {
+    /// Axis carrying the most cylindrical surface area — the part's main axis.
+    #[serde(serialize_with = "ser_vec3")]
+    pub dominant_axis: Vec3,
+    /// A point on the dominant axis line.
+    #[serde(serialize_with = "ser_point3")]
+    pub dominant_axis_point: Point3,
+    /// Diameter of the largest external cylinder coaxial with the dominant axis.
+    ///
+    /// This is the number a designer means by "body OD". The bounding box
+    /// overstates it whenever the part carries an asymmetric boss or connector.
+    pub body_od_mm: Option<f64>,
+    /// Extent along the dominant axis, over every B-rep vertex, in mm.
+    pub axial_length_mm: f64,
+    /// Largest bounding-box dimension across the dominant axis, for contrast
+    /// with `body_od_mm`.
+    pub bbox_across_axis_mm: f64,
+}
+
+/// Everything the recogniser found.
+#[derive(Debug, Clone, Serialize)]
+pub struct FeatureReport {
+    /// Recognised patterns, largest count first.
+    pub patterns: Vec<HolePattern>,
+    /// Clocking relations between concentric coaxial patterns.
+    pub relations: Vec<PatternRelation>,
+    /// Body envelope.
+    pub envelope: Envelope,
+}
+
+impl FeatureReport {
+    /// Patterns whose members all sit on the solid's outer shell.
+    ///
+    /// Vendor STEP assemblies bundle internal fasteners and bearing races; their
+    /// cylinders pollute a naive scrape. This is the cheap filter; the axial
+    /// extents on each member let a caller apply a stricter one.
+    pub fn outer_patterns(&self) -> impl Iterator<Item = &HolePattern> {
+        self.patterns.iter().filter(|p| p.on_outer_shell)
+    }
+
+    /// Bolt circles only, largest count first.
+    pub fn bolt_circles(&self) -> impl Iterator<Item = &HolePattern> {
+        self.patterns
+            .iter()
+            .filter(|p| matches!(p.kind, PatternKind::BoltCircle { .. }))
+    }
+}
+
+// =============================================================================
+// Recognition
+// =============================================================================
+
+/// An orthonormal (u, v) basis for the plane normal to `axis`.
+fn plane_basis(axis: Vec3) -> (Vec3, Vec3) {
+    let seed = if axis.x.abs() < 0.9 {
+        Vec3::x()
+    } else {
+        Vec3::y()
+    };
+    let u = (seed - axis * seed.dot(axis)).normalize();
+    let v = axis.cross(u);
+    (u, v)
+}
+
+/// Kåsa algebraic circle fit. Returns `(center_u, center_v, radius, max_residual)`.
+fn fit_circle(pts: &[(f64, f64)]) -> Option<(f64, f64, f64, f64)> {
+    if pts.len() < 3 {
+        return None;
+    }
+    let n = pts.len() as f64;
+    let (mu, mv) = pts.iter().fold((0.0, 0.0), |a, p| (a.0 + p.0, a.1 + p.1));
+    let (mu, mv) = (mu / n, mv / n);
+    let (mut suu, mut suv, mut svv, mut suz, mut svz) = (0.0, 0.0, 0.0, 0.0, 0.0);
+    for (pu, pv) in pts {
+        let (u, v) = (pu - mu, pv - mv);
+        let z = u * u + v * v;
+        suu += u * u;
+        suv += u * v;
+        svv += v * v;
+        suz += u * z;
+        svz += v * z;
+    }
+    let det = suu * svv - suv * suv;
+    if det.abs() < 1e-12 {
+        return None; // collinear
+    }
+    let cu = 0.5 * (suz * svv - svz * suv) / det;
+    let cv = 0.5 * (svz * suu - suz * suv) / det;
+    let (cu, cv) = (cu + mu, cv + mv);
+    let radii: Vec<f64> = pts
+        .iter()
+        .map(|(u, v)| ((u - cu).powi(2) + (v - cv).powi(2)).sqrt())
+        .collect();
+    let r = radii.iter().sum::<f64>() / n;
+    let resid = radii.iter().fold(0.0f64, |a, x| a.max((x - r).abs()));
+    Some((cu, cv, r, resid))
+}
+
+fn wrap360(a: f64) -> f64 {
+    let mut a = a % 360.0;
+    if a < 0.0 {
+        a += 360.0;
+    }
+    a
+}
+
+/// Recognise holes, bolt circles, and the body envelope in a B-rep solid.
+pub fn recognize(brep: &BRepSolid) -> FeatureReport {
+    recognize_many(&[brep])
+}
+
+/// Recognise features over several solids treated as one part.
+///
+/// This is what an assembly wants: place every component into a common frame
+/// first, then recognise, so a bolt circle spanning two components (a housing
+/// and its cover) is read as one pattern.
+pub fn recognize_many(breps: &[&BRepSolid]) -> FeatureReport {
+    let features = cylindrical_features_many(breps);
+
+    // --- group by axis direction, then radius + concavity -------------------
+    let mut axis_groups: Vec<(Vec3, Vec<usize>)> = Vec::new();
+    for (i, f) in features.iter().enumerate() {
+        match axis_groups
+            .iter_mut()
+            .find(|(a, _)| a.dot(f.axis).abs() >= tolerance::AXIS_ANGLE.cos())
+        {
+            Some((_, members)) => members.push(i),
+            None => axis_groups.push((f.axis, vec![i])),
+        }
+    }
+
+    let mut patterns = Vec::new();
+    for (axis, group) in &axis_groups {
+        let mut clusters: Vec<(f64, Concavity, Vec<usize>)> = Vec::new();
+        for &i in group {
+            let f = &features[i];
+            match clusters
+                .iter_mut()
+                .find(|(r, c, _)| (r - f.radius_mm).abs() <= tolerance::RADIUS && *c == f.concavity)
+            {
+                Some((_, _, m)) => m.push(i),
+                None => clusters.push((f.radius_mm, f.concavity, vec![i])),
+            }
+        }
+        for (radius, concavity, members) in clusters {
+            patterns.push(build_pattern(&features, *axis, radius, concavity, &members));
+        }
+    }
+
+    patterns.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then(b.hole_diameter_mm.total_cmp(&a.hole_diameter_mm))
+    });
+
+    let relations = relate(&patterns);
+    let envelope = envelope(breps, &features);
+
+    FeatureReport {
+        patterns,
+        relations,
+        envelope,
+    }
+}
+
+fn build_pattern(
+    features: &[CylindricalFeature],
+    axis: Vec3,
+    radius: f64,
+    concavity: Concavity,
+    members: &[usize],
+) -> HolePattern {
+    let (u, v) = plane_basis(axis);
+    // Common origin so the 2D coordinates and the axial coordinates of every
+    // member share one frame.
+    let origin = features[members[0]].axis_point;
+    let proj: Vec<(f64, f64)> = members
+        .iter()
+        .map(|&i| {
+            let d = features[i].axis_point - origin;
+            (d.dot(u), d.dot(v))
+        })
+        .collect();
+
+    // Widest separation in the group — used to reject the degenerate fit where
+    // three nearly-collinear holes sit on a circle of enormous radius. That fit
+    // has a tiny residual and is arithmetically fine; it just isn't a bolt
+    // circle, and calling it one would hand a caller a meaningless BCD.
+    let spread = proj
+        .iter()
+        .flat_map(|a| proj.iter().map(move |b| (a.0 - b.0).hypot(a.1 - b.1)))
+        .fold(0.0f64, f64::max);
+    let fit = fit_circle(&proj);
+    let is_circle = matches!(fit, Some((_, _, r, resid))
+        if members.len() >= 3
+            && r <= spread * 2.0
+            && resid <= (r * tolerance::CIRCLE_FIT_REL).max(tolerance::CIRCLE_FIT_ABS));
+
+    let (center_2d, kind_center_radius) = match (is_circle, fit) {
+        (true, Some((cu, cv, r, _))) => ((cu, cv), Some(r)),
+        _ => {
+            let n = proj.len() as f64;
+            let c = proj.iter().fold((0.0, 0.0), |a, p| (a.0 + p.0, a.1 + p.1));
+            ((c.0 / n, c.1 / n), None)
+        }
+    };
+    let center = origin + u * center_2d.0 + v * center_2d.1;
+
+    // Order + angles, always relative to the first member.
+    let mut indexed: Vec<(usize, f64, f64)> = members
+        .iter()
+        .zip(&proj)
+        .map(|(&i, (pu, pv))| {
+            let (du, dv) = (pu - center_2d.0, pv - center_2d.1);
+            (i, dv.atan2(du).to_degrees(), du.hypot(dv))
+        })
+        .collect();
+
+    let kind;
+    if let Some(r) = kind_center_radius {
+        indexed.sort_by(|a, b| a.1.total_cmp(&b.1));
+        let base = indexed[0].1;
+        for e in indexed.iter_mut() {
+            e.1 = wrap360(e.1 - base);
+        }
+        let n = indexed.len();
+        let expected = 360.0 / n as f64;
+        let uniform = indexed
+            .iter()
+            .enumerate()
+            .all(|(k, e)| (e.1 - expected * k as f64).abs() <= tolerance::SPACING_DEG);
+        kind = PatternKind::BoltCircle {
+            bolt_circle_diameter_mm: r * 2.0,
+            spacing_deg: uniform.then_some(expected),
+        };
+    } else if indexed.len() == 1 {
+        indexed[0].1 = 0.0;
+        kind = PatternKind::Single;
+    } else {
+        // Collinear + evenly spaced → linear pattern.
+        let dir_raw = {
+            let a = proj[0];
+            let b = proj
+                .iter()
+                .max_by(|x, y| {
+                    let d = |p: &(f64, f64)| (p.0 - a.0).hypot(p.1 - a.1);
+                    d(x).total_cmp(&d(y))
+                })
+                .copied()
+                .unwrap_or(a);
+            (b.0 - a.0, b.1 - a.1)
+        };
+        let len = dir_raw.0.hypot(dir_raw.1);
+        let dir = if len > 0.0 {
+            (dir_raw.0 / len, dir_raw.1 / len)
+        } else {
+            (1.0, 0.0)
+        };
+        let mut ts: Vec<(usize, f64, f64)> = members
+            .iter()
+            .zip(&proj)
+            .map(|(&i, p)| {
+                let (du, dv) = (p.0 - proj[0].0, p.1 - proj[0].1);
+                let t = du * dir.0 + dv * dir.1;
+                let off = (du * -dir.1 + dv * dir.0).abs();
+                (i, t, off)
+            })
+            .collect();
+        ts.sort_by(|a, b| a.1.total_cmp(&b.1));
+        let collinear = ts.iter().all(|e| e.2 <= tolerance::AXIS_OFFSET.max(1e-3));
+        let steps: Vec<f64> = ts.windows(2).map(|w| w[1].1 - w[0].1).collect();
+        let pitch = steps.iter().sum::<f64>() / steps.len() as f64;
+        let even = steps.iter().all(|s| (s - pitch).abs() <= 1e-3);
+        kind = if collinear && even && pitch.abs() > 1e-6 {
+            PatternKind::Linear {
+                spacing_mm: pitch,
+                direction: u * dir.0 + v * dir.1,
+            }
+        } else {
+            PatternKind::Cluster
+        };
+        indexed = ts
+            .into_iter()
+            .map(|(i, _, _)| {
+                let d = features[i].axis_point - center;
+                (i, 0.0, (d - axis * d.dot(axis)).norm())
+            })
+            .collect();
+    }
+
+    let first_absolute = matches!(kind, PatternKind::BoltCircle { .. }).then(|| {
+        let d = features[indexed[0].0].axis_point - center;
+        wrap360(d.dot(v).atan2(d.dot(u)).to_degrees())
+    });
+
+    let members_out: Vec<PatternMember> = indexed
+        .iter()
+        .map(|&(i, ang, rad)| {
+            let f = &features[i];
+            let base = (f.axis_point - center).dot(axis);
+            PatternMember {
+                angle_deg: ang,
+                radius_from_center_mm: rad,
+                center: f.axis_point,
+                axial_start: base + f.axial_start,
+                axial_end: base + f.axial_end,
+                on_outer_shell: f.on_outer_shell,
+                faces: f.faces.clone(),
+            }
+        })
+        .collect();
+
+    HolePattern {
+        kind,
+        concavity,
+        hole_diameter_mm: radius * 2.0,
+        count: members_out.len(),
+        axis,
+        center,
+        on_outer_shell: members_out.iter().all(|m| m.on_outer_shell),
+        members: members_out,
+        first_member_absolute_deg: first_absolute,
+    }
+}
+
+/// Clocking between concentric coaxial bolt circles.
+fn relate(patterns: &[HolePattern]) -> Vec<PatternRelation> {
+    let mut out = Vec::new();
+    for (i, reference) in patterns.iter().enumerate() {
+        let PatternKind::BoltCircle { spacing_deg, .. } = reference.kind else {
+            continue;
+        };
+        for (j, subject) in patterns.iter().enumerate() {
+            if i == j || !matches!(subject.kind, PatternKind::BoltCircle { .. }) {
+                continue;
+            }
+            if reference.axis.dot(subject.axis).abs() < tolerance::AXIS_ANGLE.cos() {
+                continue;
+            }
+            let d = subject.center - reference.center;
+            let lateral = d - reference.axis * d.dot(reference.axis);
+            if lateral.norm() > tolerance::CONCENTRIC {
+                continue;
+            }
+            // Absolute angles cancel: measure each pattern's holes in the same
+            // basis and take the smallest reference→subject step.
+            let (u, v) = plane_basis(reference.axis);
+            let ang = |m: &PatternMember| {
+                let d = m.center - reference.center;
+                wrap360(d.dot(v).atan2(d.dot(u)).to_degrees())
+            };
+            let refs: Vec<f64> = reference.members.iter().map(ang).collect();
+            let mut phase = f64::INFINITY;
+            for m in &subject.members {
+                let a = ang(m);
+                for r in &refs {
+                    let mut d = wrap360(a - r);
+                    if d > 180.0 {
+                        d = 360.0 - d;
+                    }
+                    phase = phase.min(d);
+                }
+            }
+            let bisects = match spacing_deg {
+                Some(s) => (phase - s / 2.0).abs() <= 0.5,
+                None => false,
+            };
+            out.push(PatternRelation {
+                reference: i,
+                subject: j,
+                phase_deg: phase,
+                bisects_adjacent: bisects,
+            });
+        }
+    }
+    out
+}
+
+fn envelope(breps: &[&BRepSolid], features: &[CylindricalFeature]) -> Envelope {
+    // Dominant axis LINE: the one carrying the most cylindrical lateral area.
+    let mut lines: Vec<(Vec3, Point3, f64)> = Vec::new();
+    for f in features {
+        let area = 2.0 * std::f64::consts::PI * f.radius_mm * f.length_mm().abs();
+        match lines.iter_mut().find(|(a, p, _)| {
+            a.dot(f.axis).abs() >= tolerance::AXIS_ANGLE.cos() && {
+                let d = f.axis_point - *p;
+                (d - *a * d.dot(a)).norm() <= tolerance::AXIS_OFFSET
+            }
+        }) {
+            Some((_, _, acc)) => *acc += area,
+            None => lines.push((f.axis, f.axis_point, area)),
+        }
+    }
+    let (axis, axis_point) = lines
+        .iter()
+        .max_by(|a, b| a.2.total_cmp(&b.2))
+        .map(|(a, p, _)| (*a, *p))
+        .unwrap_or((Vec3::z(), Point3::origin()));
+
+    let coaxial = |f: &&CylindricalFeature| {
+        f.axis.dot(axis).abs() >= tolerance::AXIS_ANGLE.cos() && {
+            let d = f.axis_point - axis_point;
+            (d - axis * d.dot(axis)).norm() <= tolerance::AXIS_OFFSET
+        }
+    };
+    let body_od_mm = features
+        .iter()
+        .filter(coaxial)
+        .filter(|f| f.concavity == Concavity::External)
+        .map(|f| f.diameter_mm())
+        .fold(None, |acc: Option<f64>, d| {
+            Some(acc.map_or(d, |a| a.max(d)))
+        });
+
+    let (mut lo, mut hi) = (f64::INFINITY, f64::NEG_INFINITY);
+    let mut across = 0.0f64;
+    for vtx in breps
+        .iter()
+        .flat_map(|b| b.topology.vertices.iter().map(|(_, v)| v))
+    {
+        let d = vtx.point - axis_point;
+        let t = d.dot(axis);
+        lo = lo.min(t);
+        hi = hi.max(t);
+        across = across.max((d - axis * t).norm());
+    }
+    let axial_length_mm = if lo.is_finite() { hi - lo } else { 0.0 };
+
+    Envelope {
+        dominant_axis: axis,
+        dominant_axis_point: axis_point,
+        body_od_mm,
+        axial_length_mm,
+        bbox_across_axis_mm: across * 2.0,
+    }
+}
+
+/// Recognise features in each solid of a STEP assembly.
+///
+/// Faces carry no cross-solid identity, so each solid gets its own report;
+/// the caller decides which one is the part it cares about.
+pub fn recognize_all(breps: &[&BRepSolid]) -> Vec<FeatureReport> {
+    breps.iter().map(|b| recognize(b)).collect()
+}
+
+#[cfg(feature = "step")]
+pub mod step;
+
+#[cfg(test)]
+mod tests;

--- a/crates/vcad-kernel-features/src/step.rs
+++ b/crates/vcad-kernel-features/src/step.rs
@@ -1,0 +1,155 @@
+//! Recognise features straight from a vendor STEP file.
+//!
+//! A vendor download is an *assembly*: each component's B-rep is written in
+//! its own local frame and placed by the product structure. Reading the solids
+//! alone (as [`vcad_kernel_step::read_step`] does) therefore gives geometry in
+//! mixed frames — good enough for per-component patterns, wrong for anything
+//! that spans components, including the overall length.
+//!
+//! This module composes the assembly placements, transforms every component
+//! into the assembly frame, and recognises both:
+//!
+//! * per-component reports, which is where bolt circles actually live, and
+//! * one assembly-wide report, which is where the envelope lives.
+
+use crate::{recognize, recognize_many, Envelope, FeatureReport};
+use serde::Serialize;
+use vcad_kernel_math::{Point3, Transform, Vec3};
+use vcad_kernel_primitives::BRepSolid;
+use vcad_kernel_step::{StepAssembly, StepError, StepPlacement};
+
+/// One component of a STEP assembly, placed in the assembly frame.
+#[derive(Debug, Serialize)]
+pub struct ComponentReport {
+    /// Component name from the STEP product structure.
+    pub name: String,
+    /// Number of faces in the component's B-rep.
+    pub face_count: usize,
+    /// Features of this component alone, in the assembly frame.
+    pub report: FeatureReport,
+}
+
+/// Feature recognition over a whole STEP file.
+#[derive(Debug, Serialize)]
+pub struct StepFeatureReport {
+    /// Per-component reports, largest component first.
+    pub components: Vec<ComponentReport>,
+    /// One report over every placed component — this is the envelope to quote.
+    pub assembly: FeatureReport,
+}
+
+impl StepFeatureReport {
+    /// The assembly envelope.
+    pub fn envelope(&self) -> &Envelope {
+        &self.assembly.envelope
+    }
+}
+
+fn placement_to_transform(p: &StepPlacement) -> Transform {
+    let x = Vec3::new(p.x_axis[0], p.x_axis[1], p.x_axis[2]);
+    let z = Vec3::new(p.z_axis[0], p.z_axis[1], p.z_axis[2]);
+    let y = z.cross(x);
+    let o = Point3::new(p.origin[0], p.origin[1], p.origin[2]);
+    Transform {
+        matrix: tang::Mat4::from_cols(
+            tang::Vec4::new(x.x, x.y, x.z, 0.0),
+            tang::Vec4::new(y.x, y.y, y.z, 0.0),
+            tang::Vec4::new(z.x, z.y, z.z, 0.0),
+            tang::Vec4::new(o.x, o.y, o.z, 1.0),
+        ),
+    }
+}
+
+fn transformed(brep: &BRepSolid, t: &Transform) -> BRepSolid {
+    let mut out = brep.clone();
+    for (_id, v) in &mut out.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    for s in &mut out.geometry.surfaces {
+        *s = s.transform(t);
+    }
+    out
+}
+
+/// Place every component of `assembly` into the assembly frame.
+///
+/// Components reached by no instance are taken as already placed (identity),
+/// which is what part files — a single component with no product hierarchy —
+/// need.
+fn place(assembly: &StepAssembly) -> Vec<(String, BRepSolid)> {
+    let mut out = Vec::new();
+    let mut placed_parts: Vec<&str> = Vec::new();
+
+    // Walk the instance tree from the roots, composing parent ∘ child.
+    let mut stack: Vec<(&str, Transform)> = assembly
+        .instances
+        .iter()
+        .filter(|i| i.parent_id.is_none())
+        .map(|i| (i.part_id.as_str(), placement_to_transform(&i.transform)))
+        .collect();
+    let mut guard = 0usize;
+    while let Some((part_id, world)) = stack.pop() {
+        guard += 1;
+        if guard > 100_000 {
+            break; // cyclic product structure — refuse to spin
+        }
+        if let Some(part) = assembly.parts.iter().find(|p| p.id == part_id) {
+            for solid in &part.solids {
+                out.push((part.name.clone(), transformed(solid, &world)));
+            }
+            if !part.solids.is_empty() {
+                placed_parts.push(part_id);
+            }
+        }
+        for child in assembly
+            .instances
+            .iter()
+            .filter(|i| i.parent_id.as_deref() == Some(part_id))
+        {
+            stack.push((
+                child.part_id.as_str(),
+                world.then(&placement_to_transform(&child.transform)),
+            ));
+        }
+    }
+
+    // Anything the instance tree never reached is already in the file frame.
+    for part in &assembly.parts {
+        if part.solids.is_empty() || placed_parts.contains(&part.id.as_str()) {
+            continue;
+        }
+        for solid in &part.solids {
+            out.push((part.name.clone(), solid.clone()));
+        }
+    }
+    out
+}
+
+/// Recognise features in a STEP file, honouring the assembly placements.
+pub fn recognize_step_file(
+    path: impl AsRef<std::path::Path>,
+) -> Result<StepFeatureReport, StepError> {
+    let assembly = vcad_kernel_step::read_step_assembly(path)?;
+    Ok(recognize_step_assembly(&assembly))
+}
+
+/// Recognise features in an already-parsed STEP assembly.
+pub fn recognize_step_assembly(assembly: &StepAssembly) -> StepFeatureReport {
+    let placed = place(assembly);
+    let refs: Vec<&BRepSolid> = placed.iter().map(|(_, s)| s).collect();
+
+    let mut components: Vec<ComponentReport> = placed
+        .iter()
+        .map(|(name, solid)| ComponentReport {
+            name: name.clone(),
+            face_count: solid.topology.faces.len(),
+            report: recognize(solid),
+        })
+        .collect();
+    components.sort_by_key(|c| std::cmp::Reverse(c.face_count));
+
+    StepFeatureReport {
+        assembly: recognize_many(&refs),
+        components,
+    }
+}

--- a/crates/vcad-kernel-features/src/tests.rs
+++ b/crates/vcad-kernel-features/src/tests.rs
@@ -1,0 +1,514 @@
+//! Unit tests for the feature recogniser.
+//!
+//! Two layers: synthetic B-reps built here (fast, hermetic, exercise the
+//! clustering and the relative-angle reporting), and real vendor STEP files
+//! (the numbers a designer actually needs, verified independently against the
+//! vendor drawings). The vendor fixtures live outside the repo — they are
+//! copyrighted vendor CAD — so those tests skip with a printed note when the
+//! files are absent, and run in full on a machine that has them.
+
+use super::*;
+use vcad_kernel_geom::{GeometryStore, Plane};
+use vcad_kernel_topo::{Face, Loop, Orientation, ShellType, Topology, Vertex};
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures
+// ---------------------------------------------------------------------------
+
+/// A cylindrical face to synthesise: axis point, direction, radius, extent.
+struct Cyl {
+    center: Point3,
+    axis: Vec3,
+    radius: f64,
+    z0: f64,
+    z1: f64,
+    concavity: Concavity,
+}
+
+/// Build a B-rep whose only faces are the given cylinders.
+///
+/// Each face gets a two-vertex loop at the ends of its axial extent — enough
+/// for the recogniser, which reads extent from loop vertices and everything
+/// else from the surface.
+fn synth(cyls: &[Cyl]) -> BRepSolid {
+    let mut topo = Topology::new();
+    let mut geom = GeometryStore::new();
+
+    let shell = topo.shells.insert(vcad_kernel_topo::Shell {
+        faces: Vec::new(),
+        solid: None,
+        shell_type: ShellType::Outer,
+    });
+
+    for c in cyls {
+        let axis = c.axis.normalize();
+        let surface_index = geom.surfaces.len();
+        geom.surfaces.push(Box::new(CylinderSurface::with_axis(
+            c.center, axis, c.radius,
+        )));
+
+        let (u, _v) = plane_basis(canonical_axis(axis));
+        let p0 = c.center + axis * c.z0 + u * c.radius;
+        let p1 = c.center + axis * c.z1 + u * c.radius;
+        let v0 = topo.vertices.insert(Vertex {
+            point: p0,
+            half_edge: None,
+        });
+        let v1 = topo.vertices.insert(Vertex {
+            point: p1,
+            half_edge: None,
+        });
+        let he0 = topo.half_edges.insert(vcad_kernel_topo::HalfEdge {
+            origin: v0,
+            twin: None,
+            next: None,
+            prev: None,
+            edge: None,
+            loop_id: None,
+        });
+        let he1 = topo.half_edges.insert(vcad_kernel_topo::HalfEdge {
+            origin: v1,
+            twin: None,
+            next: Some(he0),
+            prev: None,
+            edge: None,
+            loop_id: None,
+        });
+        topo.half_edges[he0].next = Some(he1);
+        let lp = topo.loops.insert(Loop {
+            half_edge: he0,
+            face: None,
+        });
+        let face = topo.faces.insert(Face {
+            outer_loop: lp,
+            inner_loops: Vec::new(),
+            surface_index,
+            orientation: match c.concavity {
+                Concavity::Internal => Orientation::Reversed,
+                Concavity::External => Orientation::Forward,
+            },
+            shell: Some(shell),
+        });
+        topo.loops[lp].face = Some(face);
+        topo.shells[shell].faces.push(face);
+    }
+
+    // One planar face so the vertex set isn't only cylinder seams.
+    let plane_index = geom.surfaces.len();
+    geom.surfaces
+        .push(Box::new(Plane::new(Point3::origin(), Vec3::x(), Vec3::y())));
+    let _ = plane_index;
+
+    let solid_id = topo.solids.insert(vcad_kernel_topo::Solid {
+        outer_shell: shell,
+        void_shells: Vec::new(),
+    });
+    topo.shells[shell].solid = Some(solid_id);
+
+    BRepSolid {
+        topology: topo,
+        geometry: geom,
+        solid_id,
+    }
+}
+
+/// `n` holes of diameter `dia` on a bolt circle of diameter `bcd`, first hole
+/// at `phase` degrees, about +Z.
+fn bolt_circle(n: usize, bcd: f64, dia: f64, phase_deg: f64) -> Vec<Cyl> {
+    (0..n)
+        .map(|k| {
+            let a = (phase_deg + 360.0 * k as f64 / n as f64).to_radians();
+            Cyl {
+                center: Point3::new(bcd / 2.0 * a.cos(), bcd / 2.0 * a.sin(), 0.0),
+                axis: Vec3::z(),
+                radius: dia / 2.0,
+                z0: 0.0,
+                z1: 10.0,
+                concavity: Concavity::Internal,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn eight_holes_read_as_one_bolt_circle() {
+    let brep = synth(&bolt_circle(8, 98.0, 4.2, 22.5));
+    let report = recognize(&brep);
+    let p = report.bolt_circles().next().expect("a bolt circle");
+
+    assert_eq!(p.count, 8);
+    assert!((p.hole_diameter_mm - 4.2).abs() < 1e-9);
+    let PatternKind::BoltCircle {
+        bolt_circle_diameter_mm,
+        spacing_deg,
+    } = p.kind
+    else {
+        unreachable!()
+    };
+    assert!((bolt_circle_diameter_mm - 98.0).abs() < 1e-6);
+    assert!((spacing_deg.expect("even spacing") - 45.0).abs() < 1e-9);
+    // Angles are reported relative to the first hole: 0, 45, 90, ...
+    for (k, m) in p.members.iter().enumerate() {
+        assert!((m.angle_deg - 45.0 * k as f64).abs() < 1e-6, "{m:?}");
+    }
+}
+
+#[test]
+fn relative_angles_survive_a_rotated_placement() {
+    // The same pattern clocked to a different absolute phase must produce
+    // identical relative angles — that is the whole point of reporting them.
+    let a = recognize(&synth(&bolt_circle(8, 98.0, 4.2, 22.5)));
+    let b = recognize(&synth(&bolt_circle(8, 98.0, 4.2, 91.3)));
+    let (pa, pb) = (
+        a.bolt_circles().next().unwrap(),
+        b.bolt_circles().next().unwrap(),
+    );
+    for (ma, mb) in pa.members.iter().zip(&pb.members) {
+        assert!((ma.angle_deg - mb.angle_deg).abs() < 1e-6);
+    }
+    // ... while the absolute angles differ, exactly as the placements do.
+    let (aa, ab) = (
+        pa.first_member_absolute_deg.unwrap(),
+        pb.first_member_absolute_deg.unwrap(),
+    );
+    assert!((aa - ab).abs() > 1.0);
+}
+
+#[test]
+fn dowels_bisecting_bolt_holes_are_reported_as_a_relation() {
+    // Six holes at 60° spacing, plus three dowels at 60° + 30° — the RS03
+    // output-face arrangement, in miniature.
+    let mut cyls = bolt_circle(6, 30.36, 3.5, 0.0);
+    cyls.extend(bolt_circle(3, 38.5, 4.2, 30.0));
+    let report = recognize(&synth(&cyls));
+
+    let six = report
+        .patterns
+        .iter()
+        .position(|p| p.count == 6)
+        .expect("six-hole circle");
+    let three = report
+        .patterns
+        .iter()
+        .position(|p| p.count == 3)
+        .expect("three dowels");
+    let rel = report
+        .relations
+        .iter()
+        .find(|r| r.reference == six && r.subject == three)
+        .expect("relation between the concentric circles");
+    assert!((rel.phase_deg - 30.0).abs() < 1e-6);
+    assert!(rel.bisects_adjacent);
+}
+
+#[test]
+fn a_lone_bore_is_not_a_pattern() {
+    let brep = synth(&[Cyl {
+        center: Point3::origin(),
+        axis: Vec3::z(),
+        radius: 12.5,
+        z0: 0.0,
+        z1: 20.0,
+        concavity: Concavity::Internal,
+    }]);
+    let report = recognize(&brep);
+    assert_eq!(report.patterns.len(), 1);
+    assert!(matches!(report.patterns[0].kind, PatternKind::Single));
+    assert!((report.patterns[0].hole_diameter_mm - 25.0).abs() < 1e-9);
+    assert_eq!(report.bolt_circles().count(), 0);
+}
+
+#[test]
+fn a_row_of_holes_is_a_linear_pattern() {
+    let cyls: Vec<Cyl> = (0..4)
+        .map(|k| Cyl {
+            center: Point3::new(10.0 * k as f64, 0.0, 0.0),
+            axis: Vec3::z(),
+            radius: 2.5,
+            z0: 0.0,
+            z1: 5.0,
+            concavity: Concavity::Internal,
+        })
+        .collect();
+    let report = recognize(&synth(&cyls));
+    let p = &report.patterns[0];
+    let PatternKind::Linear { spacing_mm, .. } = p.kind else {
+        panic!("expected a linear pattern, got {:?}", p.kind);
+    };
+    assert_eq!(p.count, 4);
+    assert!((spacing_mm - 10.0).abs() < 1e-9);
+}
+
+#[test]
+fn body_od_comes_from_the_largest_coaxial_cylinder_not_the_bbox() {
+    // A Ø80 body with an off-axis Ø20 connector boss hanging off the side: the
+    // bounding box reads far wider than the body, which is the trap this
+    // recogniser exists to avoid.
+    let brep = synth(&[
+        Cyl {
+            center: Point3::origin(),
+            axis: Vec3::z(),
+            radius: 40.0,
+            z0: 0.0,
+            z1: 60.0,
+            concavity: Concavity::External,
+        },
+        Cyl {
+            center: Point3::new(45.0, 0.0, 30.0),
+            axis: Vec3::z(),
+            radius: 10.0,
+            z0: -5.0,
+            z1: 5.0,
+            concavity: Concavity::External,
+        },
+    ]);
+    let env = recognize(&brep).envelope;
+    assert!((env.body_od_mm.expect("a body OD") - 80.0).abs() < 1e-9);
+    assert!(
+        env.bbox_across_axis_mm > 100.0,
+        "bbox should overstate: {}",
+        env.bbox_across_axis_mm
+    );
+}
+
+#[test]
+fn the_dominant_axis_is_not_assumed_to_be_z() {
+    let brep = synth(&[
+        Cyl {
+            center: Point3::origin(),
+            axis: Vec3::y(),
+            radius: 40.0,
+            z0: 0.0,
+            z1: 60.0,
+            concavity: Concavity::External,
+        },
+        Cyl {
+            center: Point3::new(20.0, 5.0, 0.0),
+            axis: Vec3::z(),
+            radius: 3.0,
+            z0: 0.0,
+            z1: 4.0,
+            concavity: Concavity::Internal,
+        },
+    ]);
+    let env = recognize(&brep).envelope;
+    assert!(env.dominant_axis.dot(Vec3::y()).abs() > 0.999);
+    assert!((env.body_od_mm.unwrap() - 80.0).abs() < 1e-9);
+}
+
+#[test]
+fn seam_split_faces_merge_into_one_hole() {
+    // The same hole written as two half-cylinder faces on one axis line, plus
+    // a counterbore run further down the same axis: one feature, three faces.
+    let brep = synth(&[
+        Cyl {
+            center: Point3::origin(),
+            axis: Vec3::z(),
+            radius: 2.1,
+            z0: 0.0,
+            z1: 6.0,
+            concavity: Concavity::Internal,
+        },
+        Cyl {
+            center: Point3::origin(),
+            axis: Vec3::z(),
+            radius: 2.1,
+            z0: 0.0,
+            z1: 6.0,
+            concavity: Concavity::Internal,
+        },
+        Cyl {
+            center: Point3::origin(),
+            axis: Vec3::z(),
+            radius: 2.1,
+            z0: 9.0,
+            z1: 12.0,
+            concavity: Concavity::Internal,
+        },
+    ]);
+    let features = cylindrical_features(&brep);
+    assert_eq!(features.len(), 1);
+    assert_eq!(features[0].faces.len(), 3);
+    assert_eq!(features[0].segments, 3);
+    assert!((features[0].length_mm() - 12.0).abs() < 1e-9);
+}
+
+// ---------------------------------------------------------------------------
+// Vendor STEP fixtures
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "step")]
+mod vendor {
+    use super::*;
+    use crate::step::{recognize_step_file, StepFeatureReport};
+
+    /// Vendor CAD isn't in the repo. Resolve it from `$HOME`, or skip.
+    fn fixture(rel: &str) -> Option<std::path::PathBuf> {
+        let path = std::path::PathBuf::from(std::env::var("HOME").ok()?).join(rel);
+        if path.exists() {
+            Some(path)
+        } else {
+            eprintln!("skipping: vendor fixture not present at {}", path.display());
+            None
+        }
+    }
+
+    fn find_bolt_circle(
+        r: &StepFeatureReport,
+        count: usize,
+        dia: f64,
+        bcd: f64,
+    ) -> Option<&HolePattern> {
+        r.components.iter().find_map(|c| {
+            c.report.bolt_circles().find(|p| {
+                p.count == count
+                    && (p.hole_diameter_mm - dia).abs() < 0.05
+                    && matches!(p.kind, PatternKind::BoltCircle { bolt_circle_diameter_mm, .. }
+                        if (bolt_circle_diameter_mm - bcd).abs() < 0.05)
+            })
+        })
+    }
+
+    #[test]
+    fn rs03_stator_flange_is_eight_m4_on_bcd_98() {
+        let Some(path) = fixture("Developer/robstride_assets/Product Literature/RS03/RS03.stp")
+        else {
+            return;
+        };
+        let r = recognize_step_file(&path).expect("read RS03");
+
+        // 8 x M4 clearance (Ø4.2) on BCD 98, evenly spaced at 45°.
+        let p = find_bolt_circle(&r, 8, 4.2, 98.0).expect("8 x M4 on BCD 98");
+        let PatternKind::BoltCircle { spacing_deg, .. } = p.kind else {
+            unreachable!()
+        };
+        assert!((spacing_deg.expect("even spacing") - 45.0).abs() < 1e-6);
+        // 22.5 + 45n: the absolute phase, mod the spacing, is 22.5.
+        let phase = p.first_member_absolute_deg.unwrap() % 45.0;
+        assert!((phase - 22.5).abs() < 0.05, "phase {phase}");
+    }
+
+    #[test]
+    fn rs03_output_hub_has_six_holes_and_three_bisecting_dowels() {
+        let Some(path) = fixture("Developer/robstride_assets/Product Literature/RS03/RS03.stp")
+        else {
+            return;
+        };
+        let r = recognize_step_file(&path).expect("read RS03");
+
+        let hub = r
+            .components
+            .iter()
+            .find(|c| {
+                c.report
+                    .bolt_circles()
+                    .any(|p| p.count == 6 && matches!(p.kind, PatternKind::BoltCircle { bolt_circle_diameter_mm, .. } if (bolt_circle_diameter_mm - 30.36).abs() < 0.05))
+            })
+            .expect("the output hub");
+
+        let six = hub
+            .report
+            .patterns
+            .iter()
+            .position(|p| {
+                p.count == 6
+                    && matches!(p.kind, PatternKind::BoltCircle { bolt_circle_diameter_mm, .. }
+                        if (bolt_circle_diameter_mm - 30.36).abs() < 0.05)
+            })
+            .expect("6 x M4 on BCD 30.36");
+        let PatternKind::BoltCircle { spacing_deg, .. } = hub.report.patterns[six].kind else {
+            unreachable!()
+        };
+        assert!((spacing_deg.expect("even spacing") - 60.0).abs() < 1e-6);
+
+        // Three dowels on BCD 38.5, bisecting adjacent output holes. Read as
+        // absolute angles this is placement-dependent noise; read against the
+        // six-hole circle it is always "30° = half of 60°".
+        let dowels = hub
+            .report
+            .patterns
+            .iter()
+            .position(|p| {
+                p.count == 3
+                    && matches!(p.kind, PatternKind::BoltCircle { bolt_circle_diameter_mm, .. }
+                        if (bolt_circle_diameter_mm - 38.5).abs() < 0.05)
+            })
+            .expect("3 dowels on BCD 38.5");
+        let rel = hub
+            .report
+            .relations
+            .iter()
+            .find(|r| r.reference == six && r.subject == dowels)
+            .expect("dowels related to the output bolt circle");
+        assert!(
+            (rel.phase_deg - 30.0).abs() < 0.05,
+            "phase {}",
+            rel.phase_deg
+        );
+        assert!(rel.bisects_adjacent);
+    }
+
+    #[test]
+    fn rs03_envelope_od_is_the_coaxial_body_not_the_bbox() {
+        let Some(path) = fixture("Developer/robstride_assets/Product Literature/RS03/RS03.stp")
+        else {
+            return;
+        };
+        let r = recognize_step_file(&path).expect("read RS03");
+        let env = r.envelope();
+        assert!(env.dominant_axis.dot(Vec3::z()).abs() > 0.999);
+        assert!(
+            (env.body_od_mm.expect("body OD") - 100.5).abs() < 0.05,
+            "od {:?}",
+            env.body_od_mm
+        );
+        // The flange corners push the bounding box past the body diameter.
+        assert!(env.bbox_across_axis_mm > env.body_od_mm.unwrap());
+    }
+
+    #[test]
+    fn x6_60_body_od_is_80_about_the_y_axis() {
+        let Some(path) = fixture("Developer/myactuator_assets/X6-60/RMD-X6-P20-60 3D-A0.STEP")
+        else {
+            return;
+        };
+        let r = recognize_step_file(&path).expect("read X6-60");
+        let env = r.envelope();
+        // This part's dominant axis is Y. Assuming Z would report a slice of
+        // the body as its diameter.
+        assert!(
+            env.dominant_axis.dot(Vec3::y()).abs() > 0.999,
+            "axis {:?}",
+            env.dominant_axis
+        );
+        assert!(
+            (env.body_od_mm.expect("body OD") - 80.0).abs() < 0.05,
+            "od {:?}",
+            env.body_od_mm
+        );
+    }
+
+    #[test]
+    fn x4_36_body_od_is_55_about_the_z_axis() {
+        let Some(path) = fixture("Developer/myactuator_assets/X4-36/RMD-X4-P36-36 3D-A0.STEP")
+        else {
+            return;
+        };
+        let r = recognize_step_file(&path).expect("read X4-36");
+        let env = r.envelope();
+        assert!(
+            env.dominant_axis.dot(Vec3::z()).abs() > 0.999,
+            "axis {:?}",
+            env.dominant_axis
+        );
+        assert!(
+            (env.body_od_mm.expect("body OD") - 55.0).abs() < 0.05,
+            "od {:?}",
+            env.body_od_mm
+        );
+    }
+}

--- a/crates/vcad-kernel-step/src/assembly.rs
+++ b/crates/vcad-kernel-step/src/assembly.rs
@@ -278,6 +278,57 @@ impl<'a> AssemblyReader<'a> {
         }
 
         // ---------------------------------------------------------------
+        // Step 6b: follow SHAPE_REPRESENTATION_RELATIONSHIP links.
+        //
+        // An assembly component's anchored SHAPE_REPRESENTATION carries only
+        // placements; its geometry hangs off an
+        // ADVANCED_BREP_SHAPE_REPRESENTATION linked by a plain (identity)
+        // SHAPE_REPRESENTATION_RELATIONSHIP. Creo, SolidWorks and NX all write
+        // component geometry this way, so a walk that stops at the anchored rep
+        // sees an assembly of empty parts. Transformed relationships (RRWT) are
+        // deliberately excluded here — those are placements of *other*
+        // components, and following them would graft a child's geometry onto
+        // its parent.
+        // ---------------------------------------------------------------
+        let mut rep_links: HashMap<u64, Vec<u64>> = HashMap::new();
+        for e in self
+            .file
+            .entities_of_type("SHAPE_REPRESENTATION_RELATIONSHIP")
+        {
+            if let (Ok(rep1), Ok(rep2)) = (e.entity_ref(2), e.entity_ref(3)) {
+                rep_links.entry(rep1).or_default().push(rep2);
+                rep_links.entry(rep2).or_default().push(rep1);
+            }
+        }
+        // `entities_of_type` iterates a HashMap; sort so a part's solids come
+        // back in the same order on every run.
+        for next in rep_links.values_mut() {
+            next.sort_unstable();
+        }
+        let linked_solids = |reps: &[u64]| -> Vec<u64> {
+            let mut seen: Vec<u64> = Vec::new();
+            let mut queue: Vec<u64> = reps.to_vec();
+            let mut solids: Vec<u64> = Vec::new();
+            while let Some(rep) = queue.pop() {
+                if seen.contains(&rep) {
+                    continue;
+                }
+                seen.push(rep);
+                if let Some(found) = shape_rep_to_solids.get(&rep) {
+                    for s in found {
+                        if !solids.contains(s) {
+                            solids.push(*s);
+                        }
+                    }
+                }
+                if let Some(next) = rep_links.get(&rep) {
+                    queue.extend(next.iter().copied());
+                }
+            }
+            solids
+        };
+
+        // ---------------------------------------------------------------
         // Step 7: build StepPart for each PD that has geometry
         //
         // Also build a fallback "all solids in one part" for files with no
@@ -292,10 +343,7 @@ impl<'a> AssemblyReader<'a> {
             // Build one part per PD that has solid geometry
             for (&pd_id, name) in &pd_name {
                 let shape_reps = pd_to_shape_reps.get(&pd_id).cloned().unwrap_or_default();
-                let solid_ids: Vec<u64> = shape_reps
-                    .iter()
-                    .flat_map(|rep_id| shape_rep_to_solids.get(rep_id).cloned().unwrap_or_default())
-                    .collect();
+                let solid_ids: Vec<u64> = linked_solids(&shape_reps);
 
                 if solid_ids.is_empty() {
                     // Assembly node (no direct geometry)
@@ -412,6 +460,33 @@ impl<'a> AssemblyReader<'a> {
                 (e.entity_ref(2), e.entity_ref(3), e.entity_ref(4))
             {
                 rrwt_transforms.insert((rep1, rep2), xf_id);
+            }
+        }
+        // Creo, SolidWorks and NX write the same relationship as a *complex*
+        // entity — `(REPRESENTATION_RELATIONSHIP(...)
+        // REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION(#xf)
+        // SHAPE_REPRESENTATION_RELATIONSHIP())`. The parser names such an
+        // entity after its first component, so the loop above never sees it and
+        // every instance silently lands at the identity transform (the whole
+        // assembly collapsed onto one another's frames). Pick the transform out
+        // of the trailing typed component instead.
+        for e in self.file.entities_of_type("REPRESENTATION_RELATIONSHIP") {
+            let (Ok(rep1), Ok(rep2)) = (e.entity_ref(2), e.entity_ref(3)) else {
+                continue;
+            };
+            let xf_id = e.args.iter().find_map(|a| match a {
+                stepperoni::StepValue::Typed { type_name, args }
+                    if type_name == "REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION" =>
+                {
+                    args.iter().find_map(|v| match v {
+                        stepperoni::StepValue::EntityRef(id) => Some(*id),
+                        _ => None,
+                    })
+                }
+                _ => None,
+            });
+            if let Some(xf_id) = xf_id {
+                rrwt_transforms.entry((rep1, rep2)).or_insert(xf_id);
             }
         }
         // Also handle SHAPE_REPRESENTATION_RELATIONSHIP (identity transform)

--- a/crates/vcad-kernel-step/src/reader.rs
+++ b/crates/vcad-kernel-step/src/reader.rs
@@ -1,6 +1,6 @@
 //! STEP file reader: converts parsed STEP data to BRepSolid.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use crate::entities::{
@@ -247,6 +247,12 @@ impl<'a> StepReader<'a> {
     /// present we honor it, so a vcad-written file is read the same way
     /// Shapr3D/SolidWorks/Fusion read it — an anchor that references nothing
     /// becomes a loud error instead of a silent direct-scan pass.
+    ///
+    /// Assemblies add one hop: the anchored `SHAPE_REPRESENTATION` holds only
+    /// placements, and the geometry hangs off it through a
+    /// `SHAPE_REPRESENTATION_RELATIONSHIP` pointing at an
+    /// `ADVANCED_BREP_SHAPE_REPRESENTATION`. Creo, SolidWorks and NX all write
+    /// their assemblies this way, so the walk follows those links transitively.
     fn anchored_solid_ids(&self) -> Option<Vec<u64>> {
         let sdrs = self
             .file
@@ -254,11 +260,36 @@ impl<'a> StepReader<'a> {
         if sdrs.is_empty() {
             return None;
         }
-        let mut ids = Vec::new();
-        for sdr in sdrs {
-            let Ok(rep_id) = sdr.entity_ref(1) else {
+
+        // rep -> related reps, via SHAPE_REPRESENTATION_RELATIONSHIP (both
+        // directions: the relationship's orientation varies by writer).
+        let mut linked: HashMap<u64, Vec<u64>> = HashMap::new();
+        for rel in self
+            .file
+            .entities_of_type("SHAPE_REPRESENTATION_RELATIONSHIP")
+        {
+            let (Ok(a), Ok(b)) = (rel.entity_ref(2), rel.entity_ref(3)) else {
                 continue;
             };
+            linked.entry(a).or_default().push(b);
+            linked.entry(b).or_default().push(a);
+        }
+        for next in linked.values_mut() {
+            next.sort_unstable();
+        }
+
+        let mut ids = Vec::new();
+        let mut visited: HashSet<u64> = HashSet::new();
+        // Seed the walk in entity-id order: `entities_of_type` iterates a
+        // HashMap, so without the sort the imported solid order would differ
+        // from run to run.
+        let mut seeds: Vec<u64> = sdrs.iter().filter_map(|s| s.entity_ref(1).ok()).collect();
+        seeds.sort_unstable();
+        let mut queue: std::collections::VecDeque<u64> = seeds.into();
+        while let Some(rep_id) = queue.pop_front() {
+            if !visited.insert(rep_id) {
+                continue;
+            }
             let Some(rep) = self.file.get(rep_id) else {
                 continue;
             };
@@ -273,6 +304,9 @@ impl<'a> StepReader<'a> {
                         ids.push(item_id);
                     }
                 }
+            }
+            if let Some(next) = linked.get(&rep_id) {
+                queue.extend(next.iter().copied());
             }
         }
         Some(ids)

--- a/packages/docs/content/architecture/kernel-features.mdx
+++ b/packages/docs/content/architecture/kernel-features.mdx
@@ -255,6 +255,18 @@ Honesty: the luminance edge-stopping weight is scaled by the estimator's own var
 
 - **STEP** — `vcad-kernel-step` reads and writes STEP AP214, the lingua franca of mechanical CAD. Drag a `.step` file into the app and it becomes an editable BRep.
 - **URDF** — `vcad-kernel-urdf` imports robot descriptions (links, joints, inertials) as vcad assemblies ready for simulation.
+- **Feature recognition** — `vcad-kernel-features` reads a vendor STEP back into design intent: cylindrical faces become holes and bosses, equal-radius coaxial holes become bolt circles, and the report carries bolt-circle diameter, hole diameter, count, and each hole's angle **relative to its pattern**. Absolute angles depend on how the vendor happened to place the model, so the same part reads differently in two files; relative angles don't. Concentric patterns also get a clocking relation — the RobStride RS03's three output dowels come back as "bisects adjacent holes of the six-hole circle" rather than as three placement-dependent numbers. The envelope is measured from the largest **coaxial** cylinder, not the bounding box: an actuator with an asymmetric connector boss has a bbox far wider than its body, and the body OD is the number you need when cutting the bore for it.
+
+  ```bash
+  vcad features RS03.stp --min-count 3   # or --json for the full report
+  ```
+
+  ```
+  body OD         100.500 mm  (largest coaxial cylinder; bbox across the axis reads 106.000)
+  [4] 8 x Ø4.200 holes on BCD 98.000, 45.0000 deg spacing
+       angles rel. to pattern: 0.000, 45.000, 90.000, ...
+       first hole at 202.500 deg absolute (placement-dependent)
+  ```
 - **Drafting** — `vcad-kernel-drafting` generates shop-ready 2D drawings: orthographic projections with hidden-line removal, full and offset (stepped) section views with hatching and cutting-plane callouts, detail views with scale bubbles, dimensions, GD&T annotations, title block / revision table / BOM entities, and deterministic PDF + DXF sheet export with ANSI/ISO line weights.
 
 ## Simulation and Analysis


### PR DESCRIPTION
## What

vcad could import vendor STEP with B-rep intact, but nothing answered the first question of any mount design: *what is this actuator's bolt pattern?* New crate `vcad-kernel-features` answers it, with a `vcad features <file.step>` CLI surface.

```
$ vcad features RS03.stp --min-count 3
  axis            (0.000, 0.000, 1.000)
  body OD         100.500 mm  (largest coaxial cylinder; bbox across the axis reads 106.000)
  axial length    51.500 mm
  components      14

part_44512 (234 faces)
  [4] 8 x Ø4.200 holes on BCD 98.000, 45.0000 deg spacing
       angles rel. to pattern: 0.000, 45.000, 90.000, 135.000, 180.000, 225.000, 270.000, 315.000
       first hole at 202.500 deg absolute (placement-dependent)
```

`--json` emits the full report.

## How

Cylindrical faces become holes and bosses — concavity read from face orientation against the surface's outward radial normal, so a `Reversed` face has material outside it and is a hole. Faces sharing an axis line and radius merge into one feature, so seam splits, counterbores and chamfer interruptions don't multiply into phantom patterns. Equal-radius coaxial features cluster, get a Kåsa circle fit, and come back as a bolt circle, a lone bore, a linear run, or an irregular cluster.

**Angles are reported relative to the pattern.** Absolute angles depend on how the vendor happened to place the model, so the same part reads differently in two files — the RS03's three output dowels are the case that motivated this. Concentric coaxial patterns also get a clocking relation, so those dowels come back as *"bisects adjacent holes of the six-hole circle"* rather than three placement-dependent numbers.

**The envelope takes body OD from the largest _coaxial_ cylinder, not the bounding box.** An actuator with an asymmetric connector boss has a bbox far wider than its body. The dominant axis is derived from cylindrical surface area, never assumed to be Z — the X6-60's is Y.

## Two STEP import bugs fixed along the way

Both blocked the work outright, so they're in this PR:

1. **Assembly geometry was unreachable.** The anchor walk stopped at `SHAPE_REPRESENTATION`, but assembly components hang their geometry off it via `SHAPE_REPRESENTATION_RELATIONSHIP` → `ADVANCED_BREP_SHAPE_REPRESENTATION`. Both MyActuator files imported as `NoSolids`; the RS03 gave 9 of 14 solids, and the housing carrying the BCD-98 flange was among the missing ones. Fixed in both `reader.rs` and `assembly.rs`.
2. **Every assembly instance parsed as the identity transform.** Creo/SolidWorks/NX write the placement as a *complex* entity, which the parser names after its first component (`REPRESENTATION_RELATIONSHIP`), so the `REPRESENTATION_RELATIONSHIP_WITH_TRANSFORMATION` lookup never matched it. Also sorted the HashMap-derived iteration so solid order is stable run to run.

## Tests

`cargo test --workspace --exclude vcad-desktop` green (315 suites, 0 failures); `cargo fmt --all --check` and clippy clean on the touched crates.

- 8 synthetic tests: clustering, relative-vs-absolute angles, bisecting dowels, lone bore, linear row, coaxial-OD-vs-bbox, non-Z dominant axis, seam merge.
- 5 against real vendor STEP, asserting independently verified numbers: RS03 8 × M4 on BCD 98.000 at 45° with absolute phase 22.5 mod 45; hub 6 holes on BCD 30.36 at 60° with 3 dowels on BCD 38.5 flagged bisecting; RS03 OD 100.5; X6-60 OD 80.0 about Y; X4-36 OD 55.0 about Z. Vendor CAD isn't in the repo, so these skip with a printed note when the files are absent and run in full on a machine that has them.

## Reviewer notes

- **No MCP tool yet**, deliberately. `packages/mcp/src/tools/import.ts` goes through the WASM engine and yields meshes only, so the tool needs a new `vcad-kernel-wasm` binding — and those artifacts have a single writer on `main`.
- **Overall axial length is not asserted.** I measure 51.5 mm for the RS03 against a verified 56.6, and 67.779 for the X6-60 against 67.5. The X6-60 is within a third of a millimetre; the RS03 is 5 mm off and I didn't chase whether that's missing components or the B-spline faces the importer skips, so I left the number out of the tests rather than assert something I can't explain.
- `bbox_across_axis_mm` is twice the max radial distance from the dominant axis, not an XYZ bounding box — for the X6-60 it reads 80.0, not the 101.86 an axis-aligned bbox gives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)