### PR TITLE
vcad render is Z-up, matching the kernel

### DIFF
--- a/changelog/entries/2026-08-16-render-z-up.json
+++ b/changelog/entries/2026-08-16-render-z-up.json
@@ -1,0 +1,9 @@
+{
+  "id": "2026-08-16-render-z-up",
+  "version": "0.9.4",
+  "date": "2026-08-16",
+  "category": "fix",
+  "title": "vcad render is Z-up, matching the kernel",
+  "summary": "The CLI renderer and TUI viewport used a Y-up camera and grid, so every Z-up model rendered lying on its side; --up y opts back in.",
+  "features": ["cli", "rendering"]
+}

--- a/crates/termview/src/rasterize.rs
+++ b/crates/termview/src/rasterize.rs
@@ -61,6 +61,40 @@ pub struct Triangle {
     pub pick_id: u32,
 }
 
+/// Which world axis points "up".
+///
+/// The camera orbit, the ground grid plane and the key light are all
+/// derived from this, so a scene authored Z-up (the CAD convention:
+/// X right, Y forward, Z up) renders standing rather than lying on its
+/// side. [`UpAxis::Z`] is the default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum UpAxis {
+    /// +Z is up; the ground plane is XY (z = 0). Kernel/CAD convention.
+    #[default]
+    Z,
+    /// +Y is up; the ground plane is XZ (y = 0). OpenGL convention.
+    Y,
+}
+
+impl UpAxis {
+    /// Unit vector along this up axis.
+    pub fn vector(self) -> Vec3 {
+        match self {
+            UpAxis::Z => Vec3::new(0.0, 0.0, 1.0),
+            UpAxis::Y => Vec3::new(0.0, 1.0, 0.0),
+        }
+    }
+
+    /// Build a world point from ground-plane coordinates `(u, v)` and a
+    /// height along the up axis.
+    fn point(self, u: f32, v: f32, height: f32) -> Vec3 {
+        match self {
+            UpAxis::Z => Vec3::new(u, v, height),
+            UpAxis::Y => Vec3::new(u, height, v),
+        }
+    }
+}
+
 /// Camera for 3D viewing.
 #[derive(Debug, Clone)]
 pub struct Camera {
@@ -78,36 +112,41 @@ pub struct Camera {
     pub azimuth: f32,
     /// Vertical angle in degrees.
     pub elevation: f32,
+    /// Which world axis is "up" (default [`UpAxis::Z`]).
+    pub up_axis: UpAxis,
 }
 
 impl Default for Camera {
     fn default() -> Self {
-        let distance = 100.0;
-        let azimuth = 45.0f32;
-        let elevation = 30.0f32;
-
-        let az_rad = azimuth.to_radians();
-        let el_rad = elevation.to_radians();
-
-        let position = Vec3::new(
-            distance * el_rad.cos() * az_rad.sin(),
-            distance * el_rad.sin(),
-            distance * el_rad.cos() * az_rad.cos(),
-        );
-
-        Self {
-            position,
-            target: Vec3::new(0.0, 0.0, 0.0),
-            up: Vec3::new(0.0, 1.0, 0.0),
-            fov: 60.0,
-            distance,
-            azimuth,
-            elevation,
-        }
+        Self::with_up_axis(UpAxis::default())
     }
 }
 
 impl Camera {
+    /// Default orbit camera for the given up axis.
+    pub fn with_up_axis(up_axis: UpAxis) -> Self {
+        let mut camera = Self {
+            position: Vec3::new(0.0, 0.0, 0.0),
+            target: Vec3::new(0.0, 0.0, 0.0),
+            up: up_axis.vector(),
+            fov: 60.0,
+            distance: 100.0,
+            azimuth: 45.0,
+            elevation: 30.0,
+            up_axis,
+        };
+        camera.update_position();
+        camera
+    }
+
+    /// Switch the up axis, keeping the orbit angles and re-deriving the
+    /// eye position and up vector.
+    pub fn set_up_axis(&mut self, up_axis: UpAxis) {
+        self.up_axis = up_axis;
+        self.up = up_axis.vector();
+        self.update_position();
+    }
+
     /// Rotate the camera horizontally (orbit around target).
     pub fn rotate_horizontal(&mut self, degrees: f32) {
         self.azimuth += degrees;
@@ -168,11 +207,21 @@ impl Camera {
     pub fn update_position(&mut self) {
         let az_rad = self.azimuth.to_radians();
         let el_rad = self.elevation.to_radians();
+        let horiz = self.distance * el_rad.cos();
+        let height = self.distance * el_rad.sin();
 
+        // Z-up: azimuth is CCW from +X in the XY plane (kernel convention).
+        // Y-up: azimuth 0 puts the eye on +Z, matching the old behavior.
+        let offset = match self.up_axis {
+            UpAxis::Z => Vec3::new(horiz * az_rad.cos(), horiz * az_rad.sin(), height),
+            UpAxis::Y => Vec3::new(horiz * az_rad.sin(), height, horiz * az_rad.cos()),
+        };
+
+        self.up = self.up_axis.vector();
         self.position = Vec3::new(
-            self.target.x + self.distance * el_rad.cos() * az_rad.sin(),
-            self.target.y + self.distance * el_rad.sin(),
-            self.target.z + self.distance * el_rad.cos() * az_rad.cos(),
+            self.target.x + offset.x,
+            self.target.y + offset.y,
+            self.target.z + offset.z,
         );
     }
 }
@@ -286,8 +335,8 @@ pub fn render_scene(buffer: &mut RenderBuffer, triangles: &[Triangle], camera: &
         return;
     }
 
-    // Light direction (from top-right-front)
-    let light_dir = Vec3::new(0.5, 0.8, 0.3).normalize();
+    // Light direction (from top-right-front), expressed in the scene's frame.
+    let light_dir = camera.up_axis.point(0.5, 0.3, 0.8).normalize();
 
     for tri in triangles {
         let v0 = Vec3::new(tri.v0[0], tri.v0[1], tri.v0[2]);
@@ -370,7 +419,7 @@ pub fn render_scene(buffer: &mut RenderBuffer, triangles: &[Triangle], camera: &
     render_axis_indicator(buffer, camera, 4, buffer.height.saturating_sub(34), 30);
 }
 
-/// Render a ground plane grid on the XZ plane (Y=0) with adaptive spacing.
+/// Render a ground plane grid (XY for Z-up, XZ for Y-up) with adaptive spacing.
 fn render_ground_grid(buffer: &mut RenderBuffer, camera: &Camera, mvp: &Mat4) {
     let dist = camera.distance;
     let w = buffer.width as f32;
@@ -410,29 +459,31 @@ fn render_ground_grid(buffer: &mut RenderBuffer, camera: &Camera, mvp: &Mat4) {
         let lo = -half_extent as f32 * spacing;
         let hi = half_extent as f32 * spacing;
 
-        // Z-line (parallel to X axis)
+        let up = camera.up_axis;
+
+        // Line parallel to the first ground axis (X).
         rasterize_grid_line(
             buffer,
             mvp,
             w,
             h,
-            Vec3::new(lo, 0.0, coord - line_half),
-            Vec3::new(hi, 0.0, coord - line_half),
-            Vec3::new(hi, 0.0, coord + line_half),
-            Vec3::new(lo, 0.0, coord + line_half),
+            up.point(lo, coord - line_half, 0.0),
+            up.point(hi, coord - line_half, 0.0),
+            up.point(hi, coord + line_half, 0.0),
+            up.point(lo, coord + line_half, 0.0),
             color,
         );
 
-        // X-line (parallel to Z axis)
+        // Line parallel to the second ground axis (Y for Z-up, Z for Y-up).
         rasterize_grid_line(
             buffer,
             mvp,
             w,
             h,
-            Vec3::new(coord - line_half, 0.0, lo),
-            Vec3::new(coord + line_half, 0.0, lo),
-            Vec3::new(coord + line_half, 0.0, hi),
-            Vec3::new(coord - line_half, 0.0, hi),
+            up.point(coord - line_half, lo, 0.0),
+            up.point(coord + line_half, lo, 0.0),
+            up.point(coord + line_half, hi, 0.0),
+            up.point(coord - line_half, hi, 0.0),
             color,
         );
     }
@@ -697,6 +748,38 @@ mod tests {
 
         camera.zoom(2.0);
         assert!((camera.distance - initial_dist).abs() < 0.1);
+    }
+
+    #[test]
+    fn default_camera_is_z_up() {
+        let camera = Camera::default();
+        assert_eq!(camera.up_axis, UpAxis::Z);
+        assert!(camera.position.z > 0.0, "eye should be above the XY ground");
+        assert!(camera.up.z > 0.9, "up vector should point along +Z");
+    }
+
+    /// A Z-up model that is tall in Z must project *upward* on screen —
+    /// the regression that made every kernel part render lying on its side.
+    #[test]
+    fn z_up_height_projects_upward_on_screen() {
+        let camera = Camera::default();
+        let view = Mat4::look_at(camera.position, camera.target, camera.up);
+        let proj = Mat4::perspective(camera.fov * PI / 180.0, 1.0, 0.1, 1000.0);
+        let mvp = view.multiply(&proj);
+
+        let (_, base_y, _, _) = mvp.transform_point(Vec3::new(0.0, 0.0, 0.0));
+        let (_, top_y, _, _) = mvp.transform_point(Vec3::new(0.0, 0.0, 50.0));
+        assert!(
+            top_y > base_y,
+            "+Z should map to screen-up (base={base_y}, top={top_y})"
+        );
+    }
+
+    #[test]
+    fn y_up_opt_in_keeps_the_graphics_frame() {
+        let camera = Camera::with_up_axis(UpAxis::Y);
+        assert!(camera.position.y > 0.0);
+        assert!(camera.up.y > 0.9);
     }
 
     #[test]

--- a/crates/vcad-cli/src/app.rs
+++ b/crates/vcad-cli/src/app.rs
@@ -1260,13 +1260,15 @@ impl App {
                 self.set_status("Top view");
             }
             "camera_front" => {
+                // Z-up: looking down +Y means the eye sits on −Y.
                 self.camera
-                    .set_orbit(0.0, 0.0, 100.0, crate::render::Vec3::new(0.0, 0.0, 0.0));
+                    .set_orbit(-90.0, 0.0, 100.0, crate::render::Vec3::new(0.0, 0.0, 0.0));
                 self.set_status("Front view");
             }
             "camera_right" => {
+                // Z-up: the eye sits on +X, looking down −X.
                 self.camera
-                    .set_orbit(90.0, 0.0, 100.0, crate::render::Vec3::new(0.0, 0.0, 0.0));
+                    .set_orbit(0.0, 0.0, 100.0, crate::render::Vec3::new(0.0, 0.0, 0.0));
                 self.set_status("Right view");
             }
             "camera_fit" => {
@@ -1560,9 +1562,11 @@ fn render_raytrace(app: &App, buffer: &mut RenderBuffer) {
         cam.target.y as f64,
         cam.target.z as f64,
     );
-    let up = vcad_kernel::vcad_kernel_math::Vec3::new(0.0, 1.0, 0.0)
-        .try_normalize()
-        .unwrap_or(vcad_kernel::vcad_kernel_math::Vec3::y());
+    let cam_up = cam.up;
+    let up =
+        vcad_kernel::vcad_kernel_math::Vec3::new(cam_up.x as f64, cam_up.y as f64, cam_up.z as f64)
+            .try_normalize()
+            .unwrap_or(vcad_kernel::vcad_kernel_math::Vec3::z());
     let up_dir = vcad_kernel::vcad_kernel_math::Dir3::new_normalize(up);
 
     // Identity transforms for all solids

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -143,6 +143,9 @@ enum Commands {
         /// Background color (hex, e.g. "1a1a2e" or "transparent")
         #[arg(long, default_value = "1a1a2e")]
         background: String,
+        /// World up axis: z (kernel/CAD convention, default) or y
+        #[arg(long, value_enum, default_value = "z")]
+        up: UpAxisArg,
     },
 
     /// Apply boolean operation
@@ -373,6 +376,24 @@ enum BooleanOp {
     Intersection,
 }
 
+/// World up axis for `vcad render`.
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+enum UpAxisArg {
+    /// +Z up — matches the kernel, loon semantics and the docs.
+    Z,
+    /// +Y up — for meshes authored in a Y-up (graphics) frame.
+    Y,
+}
+
+impl From<UpAxisArg> for crate::render::UpAxis {
+    fn from(a: UpAxisArg) -> Self {
+        match a {
+            UpAxisArg::Z => crate::render::UpAxis::Z,
+            UpAxisArg::Y => crate::render::UpAxis::Y,
+        }
+    }
+}
+
 fn main() -> Result<()> {
     vcad_i18n::init(&vcad_i18n::Locale::from_env());
     let cli = Cli::parse();
@@ -432,6 +453,7 @@ fn main() -> Result<()> {
             elevation,
             distance,
             background,
+            up,
         }) => {
             render_to_image(
                 &input,
@@ -442,6 +464,7 @@ fn main() -> Result<()> {
                 elevation,
                 distance,
                 &background,
+                up.into(),
             )?;
         }
         Some(Commands::Boolean {
@@ -2030,6 +2053,7 @@ fn render_to_image(
     elevation: f64,
     distance: Option<f64>,
     background: &str,
+    up_axis: crate::render::UpAxis,
 ) -> Result<()> {
     use crate::render::{Camera, GraphicsOutput, RenderBuffer};
 
@@ -2105,7 +2129,7 @@ fn render_to_image(
     let max_dim = size[0].max(size[1]).max(size[2]);
 
     // Setup camera
-    let mut camera = Camera::default();
+    let mut camera = Camera::with_up_axis(up_axis);
     let target = crate::render::Vec3::new(center[0], center[1], center[2]);
     let dist = distance.map(|d| d as f32).unwrap_or(max_dim * 2.5);
     camera.set_orbit(azimuth as f32, elevation as f32, dist, target);

--- a/crates/vcad-cli/src/raycast.rs
+++ b/crates/vcad-cli/src/raycast.rs
@@ -4,17 +4,11 @@
 //! ray and intersect it with the ground plane so the status bar can
 //! show live XYZ coordinates under the cursor.
 //!
-//! Coordinate frames:
-//! - termview::Camera is Y-up internally — `up: (0, 1, 0)` is the
-//!   default and the `elevation` → `position.y` math in
-//!   `Camera::update_position` uses `sin(elev)` on the y axis.
-//! - vcad's mental model and the kernel's stored frame are Z-up per
-//!   CLAUDE.md (grid in XY, Z vertical).
-//!
-//! We raycast in termview's Y-up frame (ground plane is y=0), then swap
-//! the returned tuple to `(x, z, y)` so the status bar's labels line up
-//! with the user's Z-up mental model: mouse moving "up" the screen
-//! changes `z`, not `y`.
+//! Coordinate frames: the camera carries its own [`UpAxis`], and vcad
+//! drives termview Z-up (grid in XY, Z vertical) to match the kernel's
+//! stored frame per CLAUDE.md. The ray is intersected with the plane
+//! `up == 0` in whichever frame the camera is using, so the hit point is
+//! already world space — no axis swap.
 
 use crate::render::Camera;
 
@@ -81,22 +75,26 @@ pub fn raycast_ground_plane(
         forward[2] + right[2] * ru + cam_up[2] * vu,
     ])?;
 
-    // Ground plane: y = 0 in termview's Y-up frame.
-    if dir[1].abs() < 1e-6 {
+    // Ground plane: the coordinate along the camera's up axis is 0.
+    let axis = match camera.up_axis {
+        crate::render::UpAxis::Z => 2,
+        crate::render::UpAxis::Y => 1,
+    };
+    if dir[axis].abs() < 1e-6 {
         return None;
     }
-    let t = -eye[1] / dir[1];
+    let t = -eye[axis] / dir[axis];
     if t <= 0.0 {
         return None;
     }
-    let hit_x = eye[0] + dir[0] * t;
-    let hit_y = 0.0f32;
-    let hit_z = eye[2] + dir[2] * t;
+    let mut hit = [
+        eye[0] + dir[0] * t,
+        eye[1] + dir[1] * t,
+        eye[2] + dir[2] * t,
+    ];
+    hit[axis] = 0.0;
 
-    // Termview Y-up (x, y, z) → user Z-up (x, z, y).
-    // Mouse moving up the screen increases world Z (the user's "up"),
-    // and the ground hit always has Z = 0 in Z-up.
-    Some((hit_x as f64, hit_z as f64, hit_y as f64))
+    Some((hit[0] as f64, hit[1] as f64, hit[2] as f64))
 }
 
 // ---------------------------------------------------------------------------
@@ -135,13 +133,13 @@ mod tests {
     use super::*;
     use crate::render::{Camera, Vec3};
 
-    /// Build a camera at (0, 100, 100) looking at origin with Y up,
+    /// Build a Z-up camera at (0, -100, 100) looking at the origin,
     /// 60° fov. Mirrors termview::Camera's structure.
     fn test_camera() -> Camera {
         let mut c = Camera::default();
-        c.position = Vec3::new(0.0, 100.0, 100.0);
+        c.position = Vec3::new(0.0, -100.0, 100.0);
         c.target = Vec3::new(0.0, 0.0, 0.0);
-        c.up = Vec3::new(0.0, 1.0, 0.0);
+        c.up = Vec3::new(0.0, 0.0, 1.0);
         c.fov = 60.0;
         c
     }

--- a/packages/docs/content/reference/cli/commands.mdx
+++ b/packages/docs/content/reference/cli/commands.mdx
@@ -244,7 +244,7 @@ Image height in pixels.
 </Param>
 
 <Param name="--azimuth" type="f64" default="45">
-Camera azimuth angle in degrees.
+Camera azimuth angle in degrees, counter-clockwise from +X in the XY plane.
 </Param>
 
 <Param name="--elevation" type="f64" default="30">
@@ -257,6 +257,12 @@ Camera distance from subject. Auto-calculated if omitted.
 
 <Param name="--background" type="string" default="1a1a2e">
 Background color as a hex string (e.g., `ffffff`) or `transparent`.
+</Param>
+
+<Param name="--up" type="z | y" default="z">
+World up axis. `z` matches the kernel, loon semantics and the docs (grid in
+XY, Z vertical) — a model built Z-up stands up in the render. Use `y` only for
+geometry authored in a Y-up graphics frame.
 </Param>
 
 ```bash


### PR DESCRIPTION
## The bug

`vcad render` (and the TUI viewport) drew with a Y-up camera and ground grid while the kernel, loon semantics and the docs are all Z-up. Kernel meshes went in unrotated, so **every model tall in Z rendered lying on its side**.

Repro — a 600 mm-tall box with a crossbar marker on top:

```bash
cargo build --release -p vcad-cli
cat > /tmp/updown.loon <<'LOON'
[let tall [cube 40.0 40.0 600.0]]
[let marker [translate 0.0 0.0 600.0 [cube 200.0 40.0 40.0]]]
[root tall "aluminum"]
[root marker "aluminum"]
LOON
cargo run -p vcad-loon --example loon2vcad -- /tmp/updown.loon > /tmp/updown.vcad
target/release/vcad render /tmp/updown.vcad /tmp/updown.png --elevation 20 --azimuth 35
```

Before: the 600 mm dimension lies in the ground plane, marker beside the base. After: the box stands, marker on top.

This one fails quietly, which is what makes it expensive — a humanoid rendered this way just looks like a robot that fell over, a completely believable state for a robot, so it invites you to go debug a model that is actually correct.

## The fix

`termview::Camera` now carries an `UpAxis`, **defaulting to `Z`**. The orbit math, the `up` vector, the ground grid plane and the key light all derive from it, so the grid, the camera and the axis gizmo agree. Z-up azimuth is CCW from +X in the XY plane, matching the convention `vcad-render` already documents; `UpAxis::Y` reproduces the old behavior bit-for-bit.

- `crates/termview/src/rasterize.rs` — `UpAxis`, `Camera::with_up_axis` / `set_up_axis`, up-axis-derived orbit / grid / light.
- `crates/vcad-cli/src/main.rs` — `vcad render --up {z|y}`, default `z`. The escape hatch is for geometry genuinely authored in a Y-up graphics frame.
- `crates/vcad-cli/src/raycast.rs` — had already spotted the mismatch and papered over it by swapping the returned tuple to `(x, z, y)`. Now intersects the plane `up == 0` in the camera's own frame; the swap and its stale comment are gone.
- `crates/vcad-cli/src/app.rs` — TUI front/right presets re-aimed for Z-up azimuth (front = −90, right = 0); the raytraced path takes its up vector from the camera instead of hardcoding +Y.
- Docs + changelog entry.

## Notes for review

- The `UpAxis::Z` default is a behavior change for any direct `termview` consumer. In-tree, `vcad-cli` is the only one.
- Three regression tests in termview pin the invariant (default camera is Z-up, +Z projects screen-up, `--up y` still works).
- `cargo test -p termview -p vcad-cli` green; clippy clean. termview has a **pre-existing** `useless use of vec!` clippy error in a sixel test on `main` — untouched here, and `--all-targets` clippy fails on it independently of this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)