### PR TITLE
perf(booleans): index the point-in-mesh ray cast and the edge-split scan

### DIFF
--- a/crates/vcad-kernel-booleans/examples/bench_chain.rs
+++ b/crates/vcad-kernel-booleans/examples/bench_chain.rs
@@ -1,0 +1,33 @@
+use std::time::Instant;
+use vcad_kernel_booleans::{boolean_op, BooleanOp};
+use vcad_kernel_math::Transform;
+use vcad_kernel_primitives::{make_cube, make_cylinder, BRepSolid};
+
+fn translate(brep: &mut BRepSolid, dx: f64, dy: f64, dz: f64) {
+    let t = Transform::translation(dx, dy, dz);
+    for (_, v) in &mut brep.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    brep.geometry.surfaces = brep
+        .geometry
+        .surfaces
+        .drain(..)
+        .map(|s| s.transform(&t))
+        .collect();
+}
+
+fn main() {
+    let mut solid = make_cube(100.0, 100.0, 10.0);
+    let t0 = Instant::now();
+    for i in 0..24 {
+        let mut hole = make_cylinder(2.0, 40.0, 24);
+        let x = 10.0 + (i % 6) as f64 * 15.0;
+        let y = 10.0 + (i / 6) as f64 * 20.0;
+        translate(&mut hole, x, y, -10.0);
+        solid = boolean_op(&solid, &hole, BooleanOp::Difference, 32)
+            .unwrap()
+            .into_brep()
+            .expect("brep");
+        println!("{:2} cuts: {:?}", i + 1, t0.elapsed());
+    }
+}

--- a/crates/vcad-kernel-booleans/src/classify.rs
+++ b/crates/vcad-kernel-booleans/src/classify.rs
@@ -10,7 +10,7 @@ use vcad_kernel_primitives::BRepSolid;
 use vcad_kernel_tessellate::{tessellate_brep, TriangleMesh};
 use vcad_kernel_topo::FaceId;
 
-use crate::point_in_mesh;
+use crate::mesh::MeshRayIndex;
 use crate::split::point_to_segment_dist_2d;
 use crate::trim::point_in_face;
 use crate::BooleanOp;
@@ -1225,12 +1225,26 @@ fn extra_probe_points(brep: &BRepSolid, face_id: FaceId, centroid: Point3) -> Ve
 /// when *every* probe lands inside the other solid. This makes the verdict
 /// robust against tangent configurations where the centroid happens to fall
 /// on the boundary of the other solid.
+/// Building the ray index is a pass over `other_mesh`; when classifying many
+/// faces against the same mesh, build it once and call
+/// [`classify_face_indexed`] instead.
 pub fn classify_face(
     brep: &BRepSolid,
     face_id: FaceId,
     other: &BRepSolid,
     other_mesh: &TriangleMesh,
 ) -> FaceClassification {
+    classify_face_indexed(brep, face_id, other, &MeshRayIndex::new(other_mesh))
+}
+
+/// [`classify_face`] against a prebuilt ray index over the other solid's mesh.
+pub fn classify_face_indexed(
+    brep: &BRepSolid,
+    face_id: FaceId,
+    other: &BRepSolid,
+    index: &MeshRayIndex<'_>,
+) -> FaceClassification {
+    let other_mesh = index.mesh();
     let sample = face_sample_point(brep, face_id);
     let oriented_normal = face_oriented_normal(brep, face_id);
     let mut probes = vec![sample];
@@ -1305,8 +1319,8 @@ pub fn classify_face(
                 }
             };
             let inward = *p - eps * normal;
-            let inward_in = point_in_mesh(&inward, other_mesh);
-            let outward_in = point_in_mesh(&(*p + eps * normal), other_mesh);
+            let inward_in = index.contains(&inward);
+            let outward_in = index.contains(&(*p + eps * normal));
             if inward_in != outward_in {
                 None // on the other solid's boundary — abstain
             } else {
@@ -1529,11 +1543,50 @@ pub fn classify_all_faces_with_mesh(
     other: &BRepSolid,
     other_mesh: &TriangleMesh,
 ) -> Vec<(FaceId, FaceClassification)> {
+    // Broadphase. `classify_face` ray-casts every probe against every
+    // triangle of `other_mesh`, so classifying a whole solid costs
+    // O(faces × triangles) — and a cut only ever touches the handful of
+    // faces near the tool. A face whose AABB clears the other mesh's AABB
+    // is Outside by construction: every probe (and every ±1e-4 offset of
+    // one) sits outside the mesh, and it cannot be coincident with a face
+    // of `other`, since `other` is what the mesh was tessellated from.
+    //
+    // The margin is three orders of magnitude above the probe offset and
+    // ~10x the worst split-boundary placement error the confidence vote is
+    // written around (~0.05mm), so no face that classification could
+    // legitimately call anything but Outside is ever skipped.
+    const CLEAR_MARGIN: f64 = 1.0;
+    let mesh_aabb = {
+        let mut aabb = crate::bbox::Aabb3::empty();
+        for v in other_mesh.vertices.chunks(3) {
+            aabb.include_point(&Point3::new(v[0] as f64, v[1] as f64, v[2] as f64));
+        }
+        aabb
+    };
+    let grown = crate::bbox::Aabb3 {
+        min: Point3::new(
+            mesh_aabb.min.x - CLEAR_MARGIN,
+            mesh_aabb.min.y - CLEAR_MARGIN,
+            mesh_aabb.min.z - CLEAR_MARGIN,
+        ),
+        max: Point3::new(
+            mesh_aabb.max.x + CLEAR_MARGIN,
+            mesh_aabb.max.y + CLEAR_MARGIN,
+            mesh_aabb.max.z + CLEAR_MARGIN,
+        ),
+    };
+
+    let index = MeshRayIndex::new(other_mesh);
     brep.topology
         .faces
         .iter()
         .map(|(face_id, _)| {
-            let class = classify_face(brep, face_id, other, other_mesh);
+            if other_mesh.indices.is_empty()
+                || !crate::bbox::face_aabb(brep, face_id).overlaps(&grown)
+            {
+                return (face_id, FaceClassification::Outside);
+            }
+            let class = classify_face_indexed(brep, face_id, other, &index);
             (face_id, class)
         })
         .collect()

--- a/crates/vcad-kernel-booleans/src/lib.rs
+++ b/crates/vcad-kernel-booleans/src/lib.rs
@@ -38,6 +38,7 @@ pub use api::{
 };
 pub use mesh::is_triangle_soup;
 pub use mesh::point_in_mesh;
+pub use mesh::MeshRayIndex;
 pub use ssi::SsiError;
 pub use validate::{mesh_report, mesh_signed_volume, MeshReport, ValidityError};
 
@@ -253,6 +254,42 @@ mod tests {
         assert!(!point_in_mesh(&Point3::new(5.0, 5.0, 10.001), &mesh));
         assert!(!point_in_mesh(&Point3::new(5.0, 10.001, 5.0), &mesh));
         assert!(!point_in_mesh(&Point3::new(10.001, 5.0, 5.0), &mesh));
+    }
+
+    /// The ray index is only a broadphase: it must answer exactly what the
+    /// linear scan does, everywhere. Sweep a grid of probes — interior,
+    /// exterior, and straddling every face, edge and corner — across meshes
+    /// with flat, curved and doubly-curved geometry.
+    #[test]
+    fn mesh_ray_index_matches_linear_scan() {
+        use crate::mesh::MeshRayIndex;
+        use vcad_kernel_primitives::{make_cylinder, make_sphere, make_torus};
+
+        let meshes = [
+            tessellate_brep(&make_cube(10.0, 10.0, 10.0), 32),
+            tessellate_brep(&make_cylinder(4.0, 12.0, 32), 32),
+            tessellate_brep(&make_sphere(6.0, 24), 24),
+            tessellate_brep(&make_torus(8.0, 2.5, 32), 32),
+        ];
+
+        for mesh in &meshes {
+            let index = MeshRayIndex::new(mesh);
+            // Deterministic lattice with irrational-ish steps, so probes land
+            // both well clear of and right on the tessellation's features.
+            let mut disagreements = 0;
+            for i in -14i32..=14 {
+                for j in -14i32..=14 {
+                    for k in -14i32..=14 {
+                        let p =
+                            Point3::new(i as f64 * 0.9137, j as f64 * 0.9137, k as f64 * 0.9137);
+                        if point_in_mesh(&p, mesh) != index.contains(&p) {
+                            disagreements += 1;
+                        }
+                    }
+                }
+            }
+            assert_eq!(disagreements, 0, "index disagreed with the linear scan");
+        }
     }
 
     #[test]

--- a/crates/vcad-kernel-booleans/src/mesh/mod.rs
+++ b/crates/vcad-kernel-booleans/src/mesh/mod.rs
@@ -172,98 +172,302 @@ fn pair_twin_half_edges(topology: &mut Topology) {
 ///
 /// Casts a ray along a tilted direction. Odd crossing count = inside, even = outside.
 pub fn point_in_mesh(point: &Point3, mesh: &TriangleMesh) -> bool {
+    let mut crossings = 0u32;
+    for t in 0..mesh.indices.len() / 3 {
+        match ray_triangle(point, mesh, t) {
+            RayHit::OnBoundary => return true,
+            RayHit::Cross => crossings += 1,
+            RayHit::Miss => {}
+        }
+    }
+    crossings % 2 == 1
+}
+
+/// Slightly tilted ray direction, so the cast avoids hitting edges/vertices
+/// exactly. The exact predicates in [`ray_triangle`] handle what's left.
+const RAY_DIR: [f64; 3] = [1.0, 1e-7, 1.3e-7];
+
+/// Outcome of casting the [`RAY_DIR`] ray from a point at one triangle.
+enum RayHit {
+    /// No forward crossing.
+    Miss,
+    /// One forward crossing — flips the parity.
+    Cross,
+    /// The point lies ON this triangle; the whole query answers `true`.
+    OnBoundary,
+}
+
+/// Cast the fixed ray from `point` at triangle `tri` of `mesh`.
+///
+/// Factored out of [`point_in_mesh`] so the indexed path in [`MeshRayIndex`]
+/// runs the *same* test on the candidates it keeps: the index may only ever
+/// drop triangles that this function would have reported `Miss` for, so
+/// crossing parity is identical either way.
+#[inline]
+fn ray_triangle(point: &Point3, mesh: &TriangleMesh, tri: usize) -> RayHit {
     use vcad_kernel_math::predicates::{orient3d, Sign};
 
     let verts = &mesh.vertices;
-    let indices = &mesh.indices;
-    let mut crossings = 0u32;
+    let idx = |k: usize| mesh.indices[tri * 3 + k] as usize * 3;
+    let (i0, i1, i2) = (idx(0), idx(1), idx(2));
 
-    // Slightly tilted ray direction to avoid hitting edges/vertices exactly
-    // The exact predicates handle remaining boundary cases robustly
-    let ray_dir = [1.0f64, 1e-7, 1.3e-7];
+    let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
+    let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
+    let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
 
-    for tri in indices.chunks(3) {
-        let i0 = tri[0] as usize * 3;
-        let i1 = tri[1] as usize * 3;
-        let i2 = tri[2] as usize * 3;
+    let ray_dir = RAY_DIR;
 
-        let v0 = [verts[i0] as f64, verts[i0 + 1] as f64, verts[i0 + 2] as f64];
-        let v1 = [verts[i1] as f64, verts[i1 + 1] as f64, verts[i1 + 2] as f64];
-        let v2 = [verts[i2] as f64, verts[i2 + 1] as f64, verts[i2 + 2] as f64];
+    // Möller-Trumbore ray-triangle intersection
+    let edge1 = [v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]];
+    let edge2 = [v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]];
 
-        // Möller-Trumbore ray-triangle intersection
-        let edge1 = [v1[0] - v0[0], v1[1] - v0[1], v1[2] - v0[2]];
-        let edge2 = [v2[0] - v0[0], v2[1] - v0[1], v2[2] - v0[2]];
+    // h = ray_dir × edge2
+    let h = [
+        ray_dir[1] * edge2[2] - ray_dir[2] * edge2[1],
+        ray_dir[2] * edge2[0] - ray_dir[0] * edge2[2],
+        ray_dir[0] * edge2[1] - ray_dir[1] * edge2[0],
+    ];
 
-        // h = ray_dir × edge2
-        let h = [
-            ray_dir[1] * edge2[2] - ray_dir[2] * edge2[1],
-            ray_dir[2] * edge2[0] - ray_dir[0] * edge2[2],
-            ray_dir[0] * edge2[1] - ray_dir[1] * edge2[0],
-        ];
+    let a = edge1[0] * h[0] + edge1[1] * h[1] + edge1[2] * h[2];
 
-        let a = edge1[0] * h[0] + edge1[1] * h[1] + edge1[2] * h[2];
+    // Use exact orient3d to robustly check for degenerate cases
+    if a.abs() < 1e-12 {
+        // Ray nearly parallel to triangle - use exact predicate
+        let p0 = Point3::new(v0[0], v0[1], v0[2]);
+        let p1 = Point3::new(v1[0], v1[1], v1[2]);
+        let p2 = Point3::new(v2[0], v2[1], v2[2]);
 
-        // Use exact orient3d to robustly check for degenerate cases
-        if a.abs() < 1e-12 {
-            // Ray nearly parallel to triangle - use exact predicate
-            let p0 = Point3::new(v0[0], v0[1], v0[2]);
-            let p1 = Point3::new(v1[0], v1[1], v1[2]);
-            let p2 = Point3::new(v2[0], v2[1], v2[2]);
-            let far_pt = Point3::new(
-                point.x + ray_dir[0] * 1e10,
-                point.y + ray_dir[1] * 1e10,
-                point.z + ray_dir[2] * 1e10,
-            );
+        // Check if query point is coplanar with triangle
+        let sign = orient3d(point, &p0, &p1, &p2);
+        if matches!(sign, Sign::Zero) && point_in_triangle_coplanar(point, &p0, &p1, &p2) {
+            // Point on boundary - treat as inside (odd crossing)
+            return RayHit::OnBoundary;
+        }
 
-            // Check if query point is coplanar with triangle
-            let sign = orient3d(point, &p0, &p1, &p2);
-            if matches!(sign, Sign::Zero) {
-                // Point is on the triangle plane - check if inside triangle
-                if point_in_triangle_coplanar(point, &p0, &p1, &p2) {
-                    // Point on boundary - treat as inside (odd crossing)
-                    return true;
+        // The ray either misses the plane or pierces it somewhere this
+        // routine has no robust intersection test for; either way it
+        // contributes no counted crossing.
+        return RayHit::Miss;
+    }
+
+    let f = 1.0 / a;
+    let s = [point.x - v0[0], point.y - v0[1], point.z - v0[2]];
+
+    let u = f * (s[0] * h[0] + s[1] * h[1] + s[2] * h[2]);
+    if !(0.0..=1.0).contains(&u) {
+        return RayHit::Miss;
+    }
+
+    // q = s × edge1
+    let q = [
+        s[1] * edge1[2] - s[2] * edge1[1],
+        s[2] * edge1[0] - s[0] * edge1[2],
+        s[0] * edge1[1] - s[1] * edge1[0],
+    ];
+
+    let v = f * (ray_dir[0] * q[0] + ray_dir[1] * q[1] + ray_dir[2] * q[2]);
+    if v < 0.0 || u + v > 1.0 {
+        return RayHit::Miss;
+    }
+
+    let t = f * (edge2[0] * q[0] + edge2[1] * q[1] + edge2[2] * q[2]);
+
+    // Only count forward intersections (t > 0)
+    if t > 1e-10 {
+        RayHit::Cross
+    } else {
+        RayHit::Miss
+    }
+}
+
+/// A reusable broadphase over one mesh for repeated [`point_in_mesh`] queries.
+///
+/// `point_in_mesh` scans every triangle, so classifying a whole solid costs
+/// O(faces × triangles) — the reason a chain of cuts against one growing
+/// subject costs quadratically more than a single batched cut: each cut
+/// re-scans the entire accumulated mesh.
+///
+/// The cast ray is fixed at [`RAY_DIR`], essentially +X, so a triangle can
+/// only be hit if the point's (y, z) falls in the triangle's (y, z) extent
+/// and the triangle reaches forward of the point in x. Bucketing triangles
+/// by their (y, z) box turns each query into a lookup of one or two cells.
+///
+/// The y/z window is widened by the ray's total transverse drift across the
+/// mesh (`1.3e-7` per mm of x-span — about 1e-5 mm on a 100 mm part), so a
+/// triangle the ray *does* reach can never be filtered out. Skipped
+/// triangles are exactly those [`ray_triangle`] would have called `Miss`,
+/// which is why the parity — and so the answer — is unchanged.
+pub struct MeshRayIndex<'m> {
+    mesh: &'m TriangleMesh,
+    /// (y, z) grid origin and inverse cell size.
+    origin: (f64, f64),
+    inv_cell: (f64, f64),
+    dims: (usize, usize),
+    /// Triangle indices per cell, row-major over (y, z).
+    cells: Vec<Vec<u32>>,
+    /// Triangles spanning too many cells to bucket; tested on every query.
+    overflow: Vec<u32>,
+    /// Largest x reached by each triangle — a triangle entirely behind the
+    /// query point cannot produce a forward crossing.
+    tri_max_x: Vec<f64>,
+    /// Transverse drift of the ray across the mesh's full x-span.
+    slack: (f64, f64),
+}
+
+/// Above this many cells a single triangle goes to the overflow list rather
+/// than being written into every cell it covers.
+const MAX_CELLS_PER_TRI: usize = 64;
+
+impl<'m> MeshRayIndex<'m> {
+    /// Build an index over `mesh`. Costs one pass over the triangles.
+    pub fn new(mesh: &'m TriangleMesh) -> Self {
+        let n_tri = mesh.indices.len() / 3;
+        let tri_box = |t: usize| {
+            let mut lo = [f64::INFINITY; 3];
+            let mut hi = [f64::NEG_INFINITY; 3];
+            for k in 0..3 {
+                let i = mesh.indices[t * 3 + k] as usize * 3;
+                for c in 0..3 {
+                    let x = mesh.vertices[i + c] as f64;
+                    lo[c] = lo[c].min(x);
+                    hi[c] = hi[c].max(x);
                 }
             }
+            (lo, hi)
+        };
 
-            // Check if ray pierces the infinite plane containing the triangle
-            let sign_far = orient3d(&far_pt, &p0, &p1, &p2);
-            if sign == sign_far {
-                continue; // Ray doesn't cross plane
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        let mut tri_max_x = Vec::with_capacity(n_tri);
+        let mut boxes = Vec::with_capacity(n_tri);
+        for t in 0..n_tri {
+            let (tlo, thi) = tri_box(t);
+            for c in 0..3 {
+                lo[c] = lo[c].min(tlo[c]);
+                hi[c] = hi[c].max(thi[c]);
             }
-            // Would need more robust intersection test here, skip for now
-            continue;
+            tri_max_x.push(thi[0]);
+            boxes.push((tlo, thi));
         }
 
-        let f = 1.0 / a;
-        let s = [point.x - v0[0], point.y - v0[1], point.z - v0[2]];
+        let span_x = if n_tri == 0 {
+            0.0
+        } else {
+            (hi[0] - lo[0]).max(0.0)
+        };
+        let slack = (RAY_DIR[1] * span_x + 1e-9, RAY_DIR[2] * span_x + 1e-9);
 
-        let u = f * (s[0] * h[0] + s[1] * h[1] + s[2] * h[2]);
-        if !(0.0..=1.0).contains(&u) {
-            continue;
+        // Roughly one triangle per cell, capped so the grid stays small.
+        let dim = ((n_tri as f64).sqrt().ceil() as usize).clamp(1, 256);
+        let dims = (dim, dim);
+        let extent = |c: usize| {
+            let e = hi[c] - lo[c];
+            if e.is_finite() && e > 0.0 {
+                e
+            } else {
+                1.0
+            }
+        };
+        let inv_cell = (dim as f64 / extent(1), dim as f64 / extent(2));
+        let origin = (
+            if lo[1].is_finite() { lo[1] } else { 0.0 },
+            if lo[2].is_finite() { lo[2] } else { 0.0 },
+        );
+
+        let mut cells: Vec<Vec<u32>> = vec![Vec::new(); dim * dim];
+        let mut overflow = Vec::new();
+        let cell_of = |v: f64, o: f64, inv: f64, n: usize| -> usize {
+            (((v - o) * inv).floor().max(0.0) as usize).min(n - 1)
+        };
+        for (t, (tlo, thi)) in boxes.iter().enumerate() {
+            let y0 = cell_of(tlo[1], origin.0, inv_cell.0, dims.0);
+            let y1 = cell_of(thi[1], origin.0, inv_cell.0, dims.0);
+            let z0 = cell_of(tlo[2], origin.1, inv_cell.1, dims.1);
+            let z1 = cell_of(thi[2], origin.1, inv_cell.1, dims.1);
+            if (y1 - y0 + 1) * (z1 - z0 + 1) > MAX_CELLS_PER_TRI {
+                overflow.push(t as u32);
+                continue;
+            }
+            for cy in y0..=y1 {
+                for cz in z0..=z1 {
+                    cells[cy * dims.1 + cz].push(t as u32);
+                }
+            }
         }
 
-        // q = s × edge1
-        let q = [
-            s[1] * edge1[2] - s[2] * edge1[1],
-            s[2] * edge1[0] - s[0] * edge1[2],
-            s[0] * edge1[1] - s[1] * edge1[0],
-        ];
-
-        let v = f * (ray_dir[0] * q[0] + ray_dir[1] * q[1] + ray_dir[2] * q[2]);
-        if v < 0.0 || u + v > 1.0 {
-            continue;
-        }
-
-        let t = f * (edge2[0] * q[0] + edge2[1] * q[1] + edge2[2] * q[2]);
-
-        // Only count forward intersections (t > 0)
-        if t > 1e-10 {
-            crossings += 1;
+        Self {
+            mesh,
+            origin,
+            inv_cell,
+            dims,
+            cells,
+            overflow,
+            tri_max_x,
+            slack,
         }
     }
 
-    crossings % 2 == 1
+    /// The mesh this index was built over.
+    pub fn mesh(&self) -> &'m TriangleMesh {
+        self.mesh
+    }
+
+    /// Test whether `point` is inside the indexed mesh.
+    ///
+    /// Answers exactly what [`point_in_mesh`] would for the same mesh.
+    pub fn contains(&self, point: &Point3) -> bool {
+        if self.mesh.indices.is_empty() {
+            return false;
+        }
+        // The ray leaves the point in +y/+z by at most `slack`; widen the
+        // window by a hair on the near side too, so a triangle whose box
+        // ends exactly at the point still qualifies.
+        let cell_of = |v: f64, o: f64, inv: f64, n: usize| -> usize {
+            (((v - o) * inv).floor().max(0.0) as usize).min(n - 1)
+        };
+        let y0 = cell_of(point.y - 1e-9, self.origin.0, self.inv_cell.0, self.dims.0);
+        let y1 = cell_of(
+            point.y + self.slack.0,
+            self.origin.0,
+            self.inv_cell.0,
+            self.dims.0,
+        );
+        let z0 = cell_of(point.z - 1e-9, self.origin.1, self.inv_cell.1, self.dims.1);
+        let z1 = cell_of(
+            point.z + self.slack.1,
+            self.origin.1,
+            self.inv_cell.1,
+            self.dims.1,
+        );
+
+        // A triangle bucketed into several of the visited cells must be
+        // counted once, or the parity flips. Gather, dedup, then test.
+        let mut cand: Vec<u32> = Vec::with_capacity(32);
+        for cy in y0..=y1 {
+            for cz in z0..=z1 {
+                cand.extend_from_slice(&self.cells[cy * self.dims.1 + cz]);
+            }
+        }
+        if y0 != y1 || z0 != z1 {
+            cand.sort_unstable();
+            cand.dedup();
+        }
+        cand.extend_from_slice(&self.overflow);
+
+        let mut crossings = 0u32;
+        for &t in &cand {
+            // Behind the point: no forward crossing is possible.
+            if self.tri_max_x[t as usize] < point.x {
+                continue;
+            }
+            match ray_triangle(point, self.mesh, t as usize) {
+                RayHit::OnBoundary => return true,
+                RayHit::Cross => crossings += 1,
+                RayHit::Miss => {}
+            }
+        }
+        crossings % 2 == 1
+    }
 }
 
 /// Check if point p is inside triangle (v0, v1, v2) when all are coplanar.

--- a/crates/vcad-kernel-booleans/src/repair.rs
+++ b/crates/vcad-kernel-booleans/src/repair.rs
@@ -163,7 +163,31 @@ fn split_edges_at_interior_vertices_impl(topo: &mut Topology, tolerance: f64, bo
         }
     }
 
+    // Spatial prefilter. The hit test below accepts a vertex only when it
+    // lies within `tolerance` of a point ON the segment, so every hit sits
+    // inside the segment's AABB grown by `tolerance` — yet the scan below
+    // walked ALL of `verts` for every half-edge, i.e. O(E·V). That is the
+    // single dominant cost of a boolean once a solid carries a few dozen
+    // features (a 30-hole plate spent half its wall clock right here), and
+    // it is what makes a chain of cuts against one growing subject cost
+    // quadratically more than one batched cut.
+    //
+    // Sorting the vertex INDICES by x lets each segment binary-search its
+    // own x-slab; re-sorting the surviving candidates by index restores
+    // their original `verts` order, so the hit list — and hence the emitted
+    // half-edge chain — is identical to what the linear scan produced.
+    let mut by_x: Vec<u32> = (0..verts.len() as u32).collect();
+    by_x.sort_by(|&i, &j| {
+        verts[i as usize]
+            .1
+            .x
+            .partial_cmp(&verts[j as usize].1.x)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let xs: Vec<f64> = by_x.iter().map(|&i| verts[i as usize].1.x).collect();
+
     let he_ids: Vec<_> = topo.half_edges.keys().collect();
+    let mut cand: Vec<u32> = Vec::new();
     for he_id in he_ids {
         // Only unpaired half-edges: a paired edge already conforms with its
         // twin, and splitting it would need a synchronized twin split.
@@ -188,9 +212,31 @@ fn split_edges_at_interior_vertices_impl(topo: &mut Topology, tolerance: f64, bo
         }
         let len = len2.sqrt();
 
+        // Candidates: vertices in the segment's tolerance-grown AABB.
+        let (lo, hi) = (
+            Point3::new(
+                a.x.min(b.x) - tolerance,
+                a.y.min(b.y) - tolerance,
+                a.z.min(b.z) - tolerance,
+            ),
+            Point3::new(
+                a.x.max(b.x) + tolerance,
+                a.y.max(b.y) + tolerance,
+                a.z.max(b.z) + tolerance,
+            ),
+        );
+        let slab_start = xs.partition_point(|&x| x < lo.x);
+        let slab_end = xs.partition_point(|&x| x <= hi.x);
+        cand.clear();
+        cand.extend(by_x[slab_start..slab_end].iter().copied().filter(|&i| {
+            let p = verts[i as usize].1;
+            p.y >= lo.y && p.y <= hi.y && p.z >= lo.z && p.z <= hi.z
+        }));
+        cand.sort_unstable();
+
         // Interior vertices within `tolerance` of segment ab, ordered by t.
         let mut hits: Vec<(f64, vcad_kernel_topo::VertexId)> = Vec::new();
-        for &(vid, p) in &verts {
+        for &(vid, p) in cand.iter().map(|&i| &verts[i as usize]) {
             if vid == v0 || vid == v1 {
                 continue;
             }

--- a/crates/vcad-kernel-booleans/src/validate.rs
+++ b/crates/vcad-kernel-booleans/src/validate.rs
@@ -24,7 +24,7 @@ use vcad_kernel_math::Point3;
 use vcad_kernel_tessellate::TriangleMesh;
 
 use crate::api::BooleanOp;
-use crate::mesh::point_in_mesh;
+use crate::mesh::MeshRayIndex;
 
 /// Signed volume of a triangle mesh via the divergence theorem.
 pub fn mesh_signed_volume(mesh: &TriangleMesh) -> f64 {
@@ -278,6 +278,12 @@ pub(crate) fn difference_removed_nothing(
         return false;
     }
 
+    // Thousands of probes against the same pair of meshes: index them
+    // once instead of re-scanning every triangle per probe. The index
+    // answers exactly what `point_in_mesh` does (see `MeshRayIndex`).
+    let idx_a = MeshRayIndex::new(mesh_a);
+    let idx_b = MeshRayIndex::new(mesh_b);
+
     let n = OVERLAP_PROBES;
     let mut both = 0usize;
     for i in 0..n {
@@ -287,7 +293,7 @@ pub(crate) fn difference_removed_nothing(
             min[1] + span[1] * radical_inverse(i + 1, 3),
             min[2] + span[2] * radical_inverse(i + 1, 5),
         );
-        if point_in_mesh(&p, mesh_a) && point_in_mesh(&p, mesh_b) {
+        if idx_a.contains(&p) && idx_b.contains(&p) {
             both += 1;
         }
     }
@@ -373,6 +379,9 @@ pub(crate) fn volume_disagrees_grossly(
         BooleanOp::Intersection => in_a && in_b,
     };
 
+    let idx_a = MeshRayIndex::new(mesh_a);
+    let idx_b = MeshRayIndex::new(mesh_b);
+
     let n = PROBES_PER_AXIS;
     let mut inside = 0usize;
     for i in 0..n {
@@ -384,7 +393,7 @@ pub(crate) fn volume_disagrees_grossly(
                     min[1] + span[1] * frac(j),
                     min[2] + span[2] * frac(k),
                 );
-                if expect(point_in_mesh(&p, mesh_a), point_in_mesh(&p, mesh_b)) {
+                if expect(idx_a.contains(&p), idx_b.contains(&p)) {
                     inside += 1;
                 }
             }


### PR DESCRIPTION
## What

Two unbounded linear scans in the boolean pipeline, replaced with broadphases. Neither changes an answer.

**`point_in_mesh` was O(triangles) per probe.** Classifying a solid is O(faces × triangles), and the validity oracles (`difference_removed_nothing`, `volume_disagrees_grossly`) fire thousands of probes at the same two meshes, re-scanning both every time.

New `MeshRayIndex` buckets triangles by their (y, z) box — legitimate, because the cast ray is fixed at `[1.0, 1e-7, 1.3e-7]`, essentially +X. Two guards keep it exact:

- the y/z lookup window is widened by the ray's *total* transverse drift across the mesh (~1e-5 mm on a 100 mm part), so a triangle the ray does reach can never be filtered out;
- triangles entirely behind the probe in x are dropped — they cannot produce a forward crossing.

Every skipped triangle is therefore one the crossing test would have returned `Miss` for, so parity — and the verdict — is unchanged. `point_in_mesh` and the indexed path now call one shared `ray_triangle`, so the two cannot drift apart later.

**`split_edges_at_interior_vertices` was O(E × V).** It walked all candidate vertices for every half-edge, though a hit must lie within `tolerance` of a point on the segment and so inside the segment's grown AABB. Now: sort vertex *indices* by x once, binary-search each segment's x-slab, box-filter the rest. Candidates are re-sorted by index before the hit test, so the hit list — and hence the emitted half-edge chain — is byte-identical to what the linear scan produced.

**`classify_all_faces_with_mesh` broadphase.** A face whose AABB clears the other mesh's AABB by 1 mm is Outside by construction: every probe and every ±1e-4 offset of one sits outside, and it cannot be coincident with a face of `other` (which is what the mesh was tessellated from). The margin is ~10× the worst split-boundary placement error the confidence vote is written around.

## Why

A chain of cuts against one growing subject cost quadratically more than a single batched cut — each cut re-scanned the entire accumulated mesh. A 30-hole plate spent roughly half its wall clock inside the edge-split scan alone.

## Numbers

24 × 4 mm holes through a 100×100×10 plate, release build:

| | total |
|---|---|
| before | 15.84 s |
| after | 1.11 s |

14×, and per-cut time is near-flat instead of climbing (cut 24 was ~1.5 s before, ~87 ms now). Reproduce with the added example:

```bash
cargo run --release -p vcad-kernel-booleans --example bench_chain
```

## Correctness

New `mesh_ray_index_matches_linear_scan` sweeps a 29³ probe lattice (irrational-ish step, so probes land both well clear of and right on tessellation features) over cube, cylinder, sphere and torus meshes, asserting **zero** disagreement between `MeshRayIndex::contains` and `point_in_mesh`. Flat, singly-curved and doubly-curved geometry; interior, exterior, and probes straddling faces, edges and corners.

The crate's existing suite (180+ tests, including the torture/seam/regression tracks) passes unchanged. `cargo clippy -p vcad-kernel-booleans -- -D warnings` is clean.

## Reviewer notes

- `classify_face` keeps its signature and now just builds an index and delegates; `classify_face_indexed` is the new entry point for callers that classify many faces against one mesh.
- I could not run `cargo test` on `vcad-kernel` / `-fillet` / `-shell` in this worktree: `vcad-kernel-text` `include_bytes!`s a font out of `node_modules`, which isn't installed here. Unrelated to this change, but it means those crates were not exercised locally — CI covers them.
- `bench_chain.rs` is included as a reproducible example rather than a criterion bench; say the word if you'd rather it not land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)