### PR TITLE
render: built-in PBR materials + photoreal animation mode

### DIFF
--- a/changelog/entries/2026-08-19-builtin-material-library.json
+++ b/changelog/entries/2026-08-19-builtin-material-library.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-19-builtin-material-library",
+  "version": "0.9.4",
+  "date": "2026-08-19",
+  "category": "feat",
+  "title": "Renders know the standard material names",
+  "summary": "A part named \"aluminum\" or \"copper\" with no [material] block rendered as clay grey; named materials now resolve to a built-in PBR library.",
+  "details": "Hand-written .loon documents name a material rather than define one — [root frame-rails \"aluminum\"] and nothing else — so the document's materials table stayed empty and every part fell through to the path tracer's default clay. The renderer now resolves an undeclared name against a built-in library of ~40 well-known materials (metals with measured F0 reflectance, plastics, composites, organics), case- and separator-insensitive so abs-black and abs_black are one material. Document-declared materials always win. Both the photoreal and drafting paths resolve through the same table, so their hues agree.",
+  "features": ["rendering", "photoreal", "materials", "loon"]
+}

--- a/changelog/entries/2026-08-19-photoreal-animation.json
+++ b/changelog/entries/2026-08-19-photoreal-animation.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-19-photoreal-animation",
+  "version": "0.9.4",
+  "date": "2026-08-19",
+  "category": "perf",
+  "title": "Photoreal animation evaluates geometry once",
+  "summary": "vcad-render --photoreal --animate poses a jointed assembly over a timeline, evaluating the document once for the whole sequence instead of once per frame.",
+  "details": "A joint-animated assembly is the same parts in different places, so the expensive half of a photoreal render — evaluating the parametric DAG into BReps and building a BVH over each part — belongs outside the frame loop. --animate puts it there: evaluate once, build one BLAS per part, then per frame solve forward kinematics (the same vcad-eval solver the app's assembly mode and the MCP timeline use), hand each object its new object→world transform, and rebuild only the top-level acceleration structure before tracing. Poses come from the document's own timeline, or from a keyframe file with a joint-track shorthand; joints resolve by id or by authored name and a name that matches nothing fails with the list that does. The camera is framed on the union of every pose, so the subject never swims or clips. Frames land as frame_NNNN.png in the -o directory and are muxed to H.264 when ffmpeg is on PATH. On a 35-part machine at 640px/16spp the once-only evaluation was 215s against ~85s of tracing per frame — previously repaid in full on every frame.",
+  "features": ["rendering", "photoreal", "animation", "assemblies", "joints", "cli"]
+}

--- a/crates/vcad-kernel-raytrace/src/pathtrace.rs
+++ b/crates/vcad-kernel-raytrace/src/pathtrace.rs
@@ -28,7 +28,7 @@
 //!   Clearcoat is what sells anodised aluminium and moulded plastic.
 
 use std::sync::Arc;
-use vcad_kernel_math::{Point3, Vec3};
+use vcad_kernel_math::{Point3, Transform, Vec3};
 
 use crate::bvh::Bvh;
 use crate::tlas::{Instance, Tlas};
@@ -771,6 +771,34 @@ pub struct Object {
     pub bvh: Arc<Bvh>,
     /// Surface description.
     pub material: Pbr,
+    /// Object → world placement of the BVH, which is otherwise traced
+    /// wherever it was built.
+    ///
+    /// Most callers bake placement into the geometry and leave this at the
+    /// identity. An animation instead holds the geometry (and its BVH) still
+    /// and moves this, so a jointed assembly re-poses with no re-evaluation
+    /// and no BLAS rebuild — only the top-level structure is rebuilt.
+    pub transform: Transform,
+}
+
+impl Object {
+    /// A traceable object placed where its BVH was built.
+    pub fn new(bvh: Arc<Bvh>, material: Pbr) -> Self {
+        Self {
+            bvh,
+            material,
+            transform: Transform::identity(),
+        }
+    }
+
+    /// A traceable object placed by an object→world transform.
+    pub fn placed(bvh: Arc<Bvh>, material: Pbr, transform: Transform) -> Self {
+        Self {
+            bvh,
+            material,
+            transform,
+        }
+    }
 }
 
 /// Everything the integrator needs to render a frame.
@@ -1372,15 +1400,17 @@ pub(crate) struct SceneAccel {
 }
 
 impl SceneAccel {
-    /// Place every object at the identity (path-trace objects arrive already
-    /// world-placed) and gather them under one TLAS. Objects already hold
-    /// `Arc<Bvh>`, so repeated parts share a BLAS without any copying.
+    /// Place every object by its own transform (the identity for the usual
+    /// case of geometry that arrives already world-placed) and gather them
+    /// under one TLAS. Objects already hold `Arc<Bvh>`, so repeated parts
+    /// share a BLAS without any copying — and a re-posed frame rebuilds only
+    /// this structure.
     pub(crate) fn build(scene: &Scene) -> Self {
         let instances = scene
             .objects
             .iter()
             .enumerate()
-            .filter_map(|(i, obj)| Instance::identity(Arc::clone(&obj.bvh), i))
+            .filter_map(|(i, obj)| Instance::new(Arc::clone(&obj.bvh), obj.transform.clone(), i))
             .collect();
         Self {
             tlas: Tlas::build(instances),
@@ -2199,10 +2229,10 @@ mod tests {
     fn test_scene() -> Scene {
         let cube = make_cube(10.0, 10.0, 10.0);
         Scene {
-            objects: vec![Object {
-                bvh: Arc::new(Bvh::build(&cube)),
-                material: Pbr::plastic([0.8, 0.3, 0.2], 0.35, 0.0),
-            }],
+            objects: vec![Object::new(
+                Arc::new(Bvh::build(&cube)),
+                Pbr::plastic([0.8, 0.3, 0.2], 0.35, 0.0),
+            )],
             lights: studio_rig(Point3::new(5.0, 5.0, 5.0), 9.0),
             env: Environment::default(),
             ground: None,
@@ -2265,6 +2295,48 @@ mod tests {
         assert_eq!(film.rgb.len(), 24 * 24 * 3);
         let lit = film.rgb.iter().filter(|v| **v > 0.0).count();
         assert!(lit > 0, "path tracer produced an entirely black frame");
+    }
+
+    /// `Object::transform` must actually place the BLAS. This is what an
+    /// animated render leans on: the same BVH, re-posed per frame.
+    #[test]
+    fn object_transform_moves_the_subject() {
+        let cam = test_camera();
+        let coverage = |t: Transform| {
+            let cube = make_cube(10.0, 10.0, 10.0);
+            let scene = Scene {
+                objects: vec![Object::placed(
+                    Arc::new(Bvh::build(&cube)),
+                    Pbr::plastic([0.8, 0.3, 0.2], 0.35, 0.0),
+                    t,
+                )],
+                // No area lights: they are hittable geometry, and a rig that
+                // stays put while the cube moves would muddy the coverage
+                // signal this test reads.
+                lights: Vec::new(),
+                env: Environment::default(),
+                ground: None,
+            };
+            let film = render(
+                &scene,
+                &cam,
+                32,
+                32,
+                &PathTraceOptions {
+                    spp: 2,
+                    ..Default::default()
+                },
+            );
+            film.alpha.iter().map(|a| *a > 0.5).collect::<Vec<_>>()
+        };
+        let here = coverage(Transform::identity());
+        // Far enough out of frame that nothing overlaps.
+        let there = coverage(Transform::translation(400.0, 0.0, 0.0));
+        assert!(here.iter().any(|c| *c), "identity placement lost the cube");
+        assert!(
+            !there.iter().any(|c| *c),
+            "translated placement was ignored — the cube stayed put"
+        );
     }
 
     #[test]
@@ -2812,10 +2884,7 @@ mod tests {
             ..Default::default()
         };
         let scene_with = |env: Environment| Scene {
-            objects: vec![Object {
-                bvh: Arc::new(Bvh::build(&cube)),
-                material,
-            }],
+            objects: vec![Object::new(Arc::new(Bvh::build(&cube)), material)],
             // No area lights: the environment must be the only illuminant,
             // or light sampling would mask a bad environment PDF.
             lights: Vec::new(),

--- a/crates/vcad-render/README.md
+++ b/crates/vcad-render/README.md
@@ -238,3 +238,46 @@ build so it doesn't grow. Use it for marketing screenshots and
 high-fidelity previews. For vector output, `--exact-edges` delivers
 resolution-independent linework straight from the BRep; and SVG remains the
 right pick for the leaderboard's drafting aesthetic.
+
+## Animation mode (`--animate`)
+
+A jointed assembly posed over time is, geometrically, the *same* parts in
+different places — so the expensive half of a photoreal render (evaluating
+the parametric DAG into BReps and building a BVH over each part) belongs
+outside the frame loop. `--animate` puts it there:
+
+```bash
+vcad-render assembly.loon --photoreal --animate cycle.json \
+    --spp 16 --size 640 --azimuth 258 --elevation 14 -o frames/
+```
+
+Evaluate once, build one BLAS per part, then per frame solve forward
+kinematics, hand each object its new object→world transform, and rebuild
+only the top-level acceleration structure before tracing. Frame 1 costs
+evaluation plus a trace; every frame after it costs a trace. On a 35-part
+machine at 640px/16spp that is ~215 s of evaluation against ~12 s of
+tracing — previously repaid in full on every frame, because each frame was
+a separately baked document.
+
+The poses come from the document's own `timeline` (where the MCP `animate`
+tool leaves one) or from a keyframe file. The file is a timeline —
+`durationS`, `fps`, `tracks` — with a shorthand for the common case:
+
+```json
+{ "durationS": 6.0, "fps": 24,
+  "tracks": [ { "joint": "A", "keys": [ { "t": 0, "value": 0 },
+                                        { "t": 6, "value": 1440 } ] } ] }
+```
+
+A joint may be named by id (`joint_0`) or by its authored name (`A`); a
+name matching neither fails with the list that does, rather than silently
+animating nothing. Interpolation is linear by default, with `step` and
+`ease-in-out` available per key. Only joint tracks are supported —
+parameter tracks would change the geometry, which is exactly the cost this
+path exists to avoid.
+
+Frames land as `frame_NNNN.png` in the `-o` directory, and are muxed into
+an H.264 mp4 when ffmpeg is on `PATH` (`--mp4 <path>` to place it,
+`--no-mp4` to skip; when ffmpeg is missing the frames are still written and
+the command is printed). The camera is framed on the union of *every* pose,
+so the subject neither swims in the canvas nor clips at the extremes.

--- a/crates/vcad-render/src/animate.rs
+++ b/crates/vcad-render/src/animate.rs
@@ -25,8 +25,8 @@ use std::time::{Duration, Instant};
 use vcad_ir::animation::{AnimTarget, Timeline};
 
 use crate::photoreal::{
-    build_objects, check_raster_opts, dress_scene, frame_view, object_corners, trace_frame,
-    PhotorealOptions,
+    build_objects, check_raster_opts, dress_scene, frame_view, object_corners, object_corners_with,
+    trace_frame, PhotorealOptions,
 };
 use crate::raster::encode_png;
 use crate::RasterOptions;
@@ -247,13 +247,13 @@ pub fn render_photoreal_animation(
     let instance_ids: Vec<String> = part_solids.iter().map(|s| s.id.clone()).collect();
     objects.extend(build_objects(&part_solids)?);
     let articulated = objects.len() - static_count;
-    if articulated != instance_ids.len() {
-        return Err(format!(
-            "--animate: {} of {} instances have no traceable geometry",
-            instance_ids.len() - articulated,
-            instance_ids.len()
-        ));
-    }
+    // build_objects fails closed on untraceable parts, so counts can only
+    // agree here; keep the invariant visible without implying a live branch.
+    debug_assert_eq!(
+        articulated,
+        instance_ids.len(),
+        "build_objects returned fewer objects than instances without erroring"
+    );
 
     // ── sample the timeline, and pose every frame up front ───────────────
     let mut sequence = timeline.sample_sequence();
@@ -314,9 +314,10 @@ pub fn render_photoreal_animation(
         .flat_map(object_corners)
         .collect();
     for pose in &poses {
-        for (obj, t) in objects[static_count..].iter_mut().zip(pose) {
-            obj.transform = t.clone();
-            corners.extend(object_corners(obj));
+        for (obj, t) in objects[static_count..].iter().zip(pose) {
+            // Bounds under this pose, WITHOUT writing the pose onto the
+            // object — the trace loop owns those transforms.
+            corners.extend(object_corners_with(obj, t));
         }
     }
     let framing = frame_view(&corners, opts, pr)?;

--- a/crates/vcad-render/src/animate.rs
+++ b/crates/vcad-render/src/animate.rs
@@ -1,0 +1,576 @@
+//! Batch (animation) rendering for the photoreal path.
+//!
+//! A jointed assembly posed over time is, geometrically, the *same* parts in
+//! different places. The expensive half of a photoreal render — evaluating
+//! the parametric DAG into BReps and building a BVH over each one — depends
+//! only on the parts, so it belongs outside the frame loop. This module puts
+//! it there: evaluate once, build one BLAS per part, then per frame solve
+//! forward kinematics, hand each object its new object→world transform, and
+//! rebuild only the top-level acceleration structure before tracing.
+//!
+//! The alternative — which this replaces — is to bake one document per frame
+//! and shell out to the renderer N times, paying the full evaluation cost
+//! every frame. On a 35-part machine at 640px/16spp that was ~55 s a frame
+//! against ~10 s of actual tracing.
+//!
+//! The pose source is the document's own [`Timeline`] when it has one, or a
+//! keyframe file passed to `--animate`. Both are sampled by
+//! [`Timeline::sample_sequence`], the same code the MCP `animate` tool and
+//! the app's timeline scrubber use, so a rendered frame and a scrubbed frame
+//! agree by construction.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use vcad_ir::animation::{AnimTarget, Timeline};
+
+use crate::photoreal::{
+    build_objects, check_raster_opts, dress_scene, frame_view, object_corners, trace_frame,
+    PhotorealOptions,
+};
+use crate::raster::encode_png;
+use crate::RasterOptions;
+
+/// What to render, and where to put it.
+#[derive(Debug, Clone)]
+pub struct AnimateOptions {
+    /// Directory the `frame_NNNN.png` files are written to. Created if absent.
+    pub out_dir: PathBuf,
+    /// Keyframes to drive the assembly with. `None` uses the document's own
+    /// timeline, which is where the MCP `animate` tool leaves one.
+    pub timeline: Option<Timeline>,
+    /// Render only the first `n` frames of the sampled sequence. `None`
+    /// renders the whole timeline.
+    pub frames: Option<usize>,
+    /// Override the timeline's own frame rate.
+    pub fps: Option<f64>,
+}
+
+/// What a finished animation cost, frame by frame.
+#[derive(Debug, Clone)]
+pub struct AnimateReport {
+    /// The PNG files written, in order.
+    pub frames: Vec<PathBuf>,
+    /// Effective frame rate (the timeline's, or the `--fps` override).
+    pub fps: f64,
+    /// Time spent evaluating the document — paid exactly once.
+    pub eval: Duration,
+    /// Time spent building per-part BVHs and framing the camera — also once.
+    pub setup: Duration,
+    /// Per-frame trace + encode + write time.
+    pub per_frame: Vec<Duration>,
+    /// Number of traceable parts in the scene.
+    pub parts: usize,
+    /// Number of those parts driven by joints (the rest are static).
+    pub articulated: usize,
+}
+
+impl AnimateReport {
+    /// Total wall time across evaluation, setup, and every frame.
+    pub fn total(&self) -> Duration {
+        self.eval + self.setup + self.per_frame.iter().sum::<Duration>()
+    }
+
+    /// Median per-frame cost — the steady-state number, unpolluted by a
+    /// first frame that warms caches.
+    pub fn median_frame(&self) -> Duration {
+        if self.per_frame.is_empty() {
+            return Duration::ZERO;
+        }
+        let mut v = self.per_frame.clone();
+        v.sort_unstable();
+        v[v.len() / 2]
+    }
+}
+
+/// Parse an `--animate` keyframe file.
+///
+/// Accepts the document's own [`Timeline`] shape verbatim, and additionally a
+/// shorthand for the common case of driving joints:
+///
+/// ```json
+/// { "fps": 24, "durationS": 6,
+///   "tracks": [ { "joint": "A", "keys": [ { "t": 0, "value": 0 },
+///                                         { "t": 6, "value": 1440 } ] } ] }
+/// ```
+///
+/// `"joint"` may name a joint by id (`joint_0`) or by its authored name
+/// (`A`); resolution against the document happens later, in
+/// [`render_photoreal_animation`], so a typo fails with the list of joints
+/// that do exist rather than silently animating nothing.
+pub fn parse_timeline_spec(json: &str) -> Result<Timeline, String> {
+    let mut value: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| format!("--animate: not valid JSON: {e}"))?;
+
+    // Rewrite the shorthand into real `AnimTarget`s before deserializing, so
+    // the IR type stays the single definition of a track.
+    if let Some(tracks) = value.get_mut("tracks").and_then(|t| t.as_array_mut()) {
+        for track in tracks {
+            let Some(obj) = track.as_object_mut() else {
+                continue;
+            };
+            if obj.contains_key("target") {
+                continue;
+            }
+            let sugar = ["joint", "parameter", "visibility"]
+                .into_iter()
+                .find_map(|k| obj.remove(k).map(|v| (k, v)));
+            let target = match sugar {
+                Some(("joint", v)) => serde_json::json!({ "type": "Joint", "jointId": v }),
+                Some(("parameter", v)) => serde_json::json!({ "type": "Parameter", "name": v }),
+                Some(("visibility", v)) => {
+                    serde_json::json!({ "type": "Visibility", "instanceId": v })
+                }
+                _ => {
+                    return Err("--animate: each track needs a `target`, or the \
+                                `joint`/`parameter`/`visibility` shorthand"
+                        .to_string())
+                }
+            };
+            obj.insert("target".to_string(), target);
+        }
+    }
+
+    let timeline: Timeline =
+        serde_json::from_value(value).map_err(|e| format!("--animate: not a timeline: {e}"))?;
+    if !(timeline.duration_s.is_finite() && timeline.duration_s > 0.0) {
+        return Err("--animate: durationS must be positive".to_string());
+    }
+    if timeline.tracks.is_empty() {
+        return Err("--animate: timeline has no tracks — nothing would move".to_string());
+    }
+    Ok(timeline)
+}
+
+/// Resolve a track's joint reference against the document: joint id first,
+/// then authored joint name. Fails closed, listing what is available.
+fn resolve_joint<'a>(
+    doc: &'a vcad_ir::Document,
+    reference: &str,
+) -> Result<&'a vcad_ir::Joint, String> {
+    let joints = doc.joints.as_deref().unwrap_or(&[]);
+    if let Some(j) = joints.iter().find(|j| j.id == reference) {
+        return Ok(j);
+    }
+    if let Some(j) = joints.iter().find(|j| j.name.as_deref() == Some(reference)) {
+        return Ok(j);
+    }
+    let mut known: Vec<String> = joints
+        .iter()
+        .map(|j| match &j.name {
+            Some(n) => format!("{} ({n})", j.id),
+            None => j.id.clone(),
+        })
+        .collect();
+    known.sort();
+    Err(format!(
+        "--animate: no joint '{reference}' in the document. Available: {}",
+        if known.is_empty() {
+            "none — this document has no joints".to_string()
+        } else {
+            known.join(", ")
+        }
+    ))
+}
+
+/// Render a jointed assembly over a timeline, evaluating geometry once.
+///
+/// Writes `frame_0000.png` … into `an.out_dir` and reports what each stage
+/// cost. `progress` is called after every frame with `(index, total,
+/// elapsed)` so a CLI can stream timings.
+pub fn render_photoreal_animation(
+    raw_vcad: &str,
+    opts: &RasterOptions,
+    pr: &PhotorealOptions,
+    an: &AnimateOptions,
+    progress: &mut dyn FnMut(usize, usize, Duration),
+) -> Result<AnimateReport, String> {
+    check_raster_opts(opts)?;
+
+    // ── evaluate, exactly once ───────────────────────────────────────────
+    let t_eval = Instant::now();
+    let evals_before = crate::document_eval_count();
+    let mut ev = crate::evaluate_vcad_document(raw_vcad)?;
+    let eval = t_eval.elapsed();
+
+    if ev.parts.is_empty() {
+        return Err(
+            "--animate: this document has no assembly instances; only a \
+                    jointed assembly can be posed over time"
+                .to_string(),
+        );
+    }
+
+    let timeline = match an.timeline.clone().or_else(|| ev.doc.timeline.clone()) {
+        Some(t) => t,
+        None => {
+            return Err(
+                "--animate: no timeline. Pass --animate <keyframes.json>, or \
+                        set one on the document"
+                    .to_string(),
+            )
+        }
+    };
+    let timeline = Timeline {
+        fps: an.fps.filter(|f| *f > 0.0).unwrap_or(timeline.fps),
+        ..timeline
+    };
+
+    // Fail closed on a track that names a joint the document doesn't have,
+    // and record the id→state mapping the sampler's keys resolve to.
+    let mut track_joint_ids: Vec<(String, String)> = Vec::new();
+    for track in &timeline.tracks {
+        if let AnimTarget::Joint { joint_id } = &track.target {
+            let j = resolve_joint(&ev.doc, joint_id)?;
+            track_joint_ids.push((joint_id.clone(), j.id.clone()));
+        }
+    }
+    if track_joint_ids.is_empty() {
+        return Err("--animate: no joint tracks. Parameter tracks would need \
+                    per-frame re-evaluation, which this path deliberately does not do"
+            .to_string());
+    }
+
+    let t_setup = Instant::now();
+
+    // ── one BLAS per part, built once ────────────────────────────────────
+    // Static scene roots first (their transforms never change), then the
+    // assembly instances, whose object→world transform is rewritten per
+    // frame.
+    let mut objects = build_objects(&ev.statics).unwrap_or_default();
+    let static_count = objects.len();
+
+    let part_solids: Vec<crate::SceneSolid> = std::mem::take(&mut ev.parts)
+        .into_iter()
+        .map(crate::part_as_local_scene_solid)
+        .collect();
+    let instance_ids: Vec<String> = part_solids.iter().map(|s| s.id.clone()).collect();
+    objects.extend(build_objects(&part_solids)?);
+    let articulated = objects.len() - static_count;
+    if articulated != instance_ids.len() {
+        return Err(format!(
+            "--animate: {} of {} instances have no traceable geometry",
+            instance_ids.len() - articulated,
+            instance_ids.len()
+        ));
+    }
+
+    // ── sample the timeline, and pose every frame up front ───────────────
+    let mut sequence = timeline.sample_sequence();
+    if let Some(n) = an.frames {
+        if n == 0 {
+            return Err("--frames must be at least 1".to_string());
+        }
+        sequence.truncate(n);
+    }
+
+    let fallbacks: std::collections::HashMap<&str, Option<vcad_ir::Transform3D>> = ev
+        .doc
+        .instances
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .map(|i| (i.id.as_str(), i.transform))
+        .collect();
+
+    let mut poses: Vec<Vec<vcad_kernel::vcad_kernel_math::Transform>> =
+        Vec::with_capacity(sequence.len());
+    for frame in &sequence {
+        // Drive the document's joints, then let the shared FK solver do the
+        // rest — chained fixed joints carry their groups along for free.
+        if let Some(joints) = ev.doc.joints.as_mut() {
+            for (reference, id) in &track_joint_ids {
+                let Some(value) = frame.joints.get(reference) else {
+                    continue;
+                };
+                if let Some(j) = joints.iter_mut().find(|j| &j.id == id) {
+                    j.state = *value;
+                }
+            }
+        }
+        let world = crate::assembly_world_transforms(&ev.doc)?;
+        poses.push(
+            instance_ids
+                .iter()
+                .map(|id| {
+                    let t = world
+                        .get(id)
+                        .copied()
+                        .or_else(|| fallbacks.get(id.as_str()).copied().flatten());
+                    match t {
+                        Some(t) => crate::transform3d_to_kernel(&t),
+                        None => vcad_kernel::vcad_kernel_math::Transform::identity(),
+                    }
+                })
+                .collect(),
+        );
+    }
+
+    // ── frame the camera on the union of every pose ──────────────────────
+    // A per-frame fit would make the machine swim about in the canvas; the
+    // union keeps the camera locked and nothing ever leaves the frame.
+    let mut corners: Vec<[f64; 3]> = objects[..static_count]
+        .iter()
+        .flat_map(object_corners)
+        .collect();
+    for pose in &poses {
+        for (obj, t) in objects[static_count..].iter_mut().zip(pose) {
+            obj.transform = t.clone();
+            corners.extend(object_corners(obj));
+        }
+    }
+    let framing = frame_view(&corners, opts, pr)?;
+    let setup = t_setup.elapsed();
+
+    std::fs::create_dir_all(&an.out_dir)
+        .map_err(|e| format!("create {}: {e}", an.out_dir.display()))?;
+
+    // ── trace ────────────────────────────────────────────────────────────
+    let mut report = AnimateReport {
+        frames: Vec::with_capacity(sequence.len()),
+        fps: timeline.fps,
+        eval,
+        setup,
+        per_frame: Vec::with_capacity(sequence.len()),
+        parts: objects.len(),
+        articulated,
+    };
+
+    let total = sequence.len();
+    // `Scene` owns its objects, so hand it a fresh vector each frame built
+    // from the same `Arc<Bvh>` handles — an Arc bump per part, not a rebuild.
+    let blueprint: Vec<(std::sync::Arc<vcad_kernel_raytrace::Bvh>, _)> = objects
+        .iter()
+        .map(|o| (std::sync::Arc::clone(&o.bvh), o.material))
+        .collect();
+    let static_transforms: Vec<_> = objects[..static_count]
+        .iter()
+        .map(|o| o.transform.clone())
+        .collect();
+
+    for (i, pose) in poses.iter().enumerate() {
+        let t_frame = Instant::now();
+        let frame_objects: Vec<vcad_kernel_raytrace::pathtrace::Object> = blueprint
+            .iter()
+            .enumerate()
+            .map(|(k, (bvh, material))| {
+                let transform = if k < static_count {
+                    static_transforms[k].clone()
+                } else {
+                    pose[k - static_count].clone()
+                };
+                vcad_kernel_raytrace::pathtrace::Object::placed(
+                    std::sync::Arc::clone(bvh),
+                    *material,
+                    transform,
+                )
+            })
+            .collect();
+        let scene = dress_scene(frame_objects, &framing, pr)?;
+        let png = encode_png(trace_frame(&scene, &framing, pr, true), opts)?;
+        let path = an.out_dir.join(format!("frame_{i:04}.png"));
+        std::fs::write(&path, png).map_err(|e| format!("write {}: {e}", path.display()))?;
+        let elapsed = t_frame.elapsed();
+        report.frames.push(path);
+        report.per_frame.push(elapsed);
+        progress(i + 1, total, elapsed);
+    }
+
+    // The whole point of this path, asserted rather than asserted-to.
+    let evals = crate::document_eval_count() - evals_before;
+    debug_assert_eq!(evals, 1, "geometry was evaluated {evals} times, not once");
+
+    Ok(report)
+}
+
+/// Assemble `report`'s frames into an H.264 mp4 with ffmpeg.
+///
+/// Returns the ffmpeg command line when ffmpeg is not on `PATH` (or fails),
+/// so a caller can print it rather than losing the frames. Deliberately not
+/// load-bearing: the PNGs are the deliverable, the mp4 is a convenience.
+pub fn assemble_mp4(frame_dir: &Path, fps: f64, out: &Path) -> Result<(), String> {
+    let args: Vec<String> = vec![
+        "-y".into(),
+        "-framerate".into(),
+        format!("{fps}"),
+        "-i".into(),
+        frame_dir.join("frame_%04d.png").display().to_string(),
+        "-vf".into(),
+        "pad=ceil(iw/2)*2:ceil(ih/2)*2".into(),
+        "-c:v".into(),
+        "libx264".into(),
+        "-pix_fmt".into(),
+        "yuv420p".into(),
+        out.display().to_string(),
+    ];
+    let rendered = format!("ffmpeg {}", args.join(" "));
+    match std::process::Command::new("ffmpeg")
+        .args(&args)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+    {
+        Ok(s) if s.success() => Ok(()),
+        Ok(s) => Err(format!("ffmpeg exited {s}; run it yourself:\n  {rendered}")),
+        Err(_) => Err(format!(
+            "ffmpeg not found on PATH; the frames are written — run:\n  {rendered}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vcad_ir::animation::{AnimKey, AnimTrack};
+
+    /// Two cubes, one bolted to the other by `kind`, driven from a timeline.
+    fn jointed_doc(kind: &str, axis: [f64; 3]) -> String {
+        format!(
+            r#"{{
+  "version": "0.1",
+  "nodes": {{
+    "1": {{ "id": 1, "name": "base", "op": {{ "type": "Cube", "size": {{ "x": 20, "y": 20, "z": 4 }} }} }},
+    "2": {{ "id": 2, "name": "arm", "op": {{ "type": "Cube", "size": {{ "x": 40, "y": 6, "z": 6 }} }} }}
+  }},
+  "materials": {{}},
+  "part_materials": {{}},
+  "roots": [],
+  "partDefs": {{
+    "base": {{ "id": "base", "name": "base", "root": 1 }},
+    "arm": {{ "id": "arm", "name": "arm", "root": 2 }}
+  }},
+  "instances": [
+    {{ "id": "base", "partDefId": "base" }},
+    {{ "id": "arm", "partDefId": "arm" }}
+  ],
+  "joints": [
+    {{ "id": "joint_0", "name": "swing", "parentInstanceId": "base",
+       "childInstanceId": "arm",
+       "parentAnchor": {{ "x": 0, "y": 0, "z": 0 }},
+       "childAnchor": {{ "x": 0, "y": 0, "z": 0 }},
+       "kind": {{ "type": "{kind}", "axis": {{ "x": {}, "y": {}, "z": {} }}, "limits": [-1000, 1000] }},
+       "state": 0.0 }}
+  ],
+  "groundInstanceId": "base"
+}}"#,
+            axis[0], axis[1], axis[2]
+        )
+    }
+
+    fn joint_timeline(id: &str, from: f64, to: f64) -> Timeline {
+        Timeline {
+            duration_s: 1.0,
+            fps: 2.0,
+            tracks: vec![AnimTrack {
+                target: AnimTarget::Joint {
+                    joint_id: id.to_string(),
+                },
+                keys: vec![
+                    AnimKey {
+                        t: 0.0,
+                        value: from,
+                        ease: Default::default(),
+                    },
+                    AnimKey {
+                        t: 1.0,
+                        value: to,
+                        ease: Default::default(),
+                    },
+                ],
+            }],
+            camera: Vec::new(),
+        }
+    }
+
+    /// The world pose of a revolute child must actually rotate with the
+    /// joint state, about the anchor — the FK contract the animation path
+    /// leans on for every frame after the first.
+    #[test]
+    fn revolute_state_swings_the_child() {
+        let doc: vcad_ir::Document =
+            serde_json::from_str(&jointed_doc("Revolute", [0.0, 0.0, 1.0])).expect("parse");
+        let pose_at = |deg: f64| {
+            let mut doc = doc.clone();
+            doc.joints.as_mut().unwrap()[0].state = deg;
+            crate::assembly_world_transforms(&doc).expect("fk")["arm"]
+        };
+        assert!(
+            pose_at(0.0).rotation.z.abs() < 1e-9,
+            "zero state must be identity"
+        );
+        let quarter = pose_at(90.0);
+        assert!(
+            (quarter.rotation.z - 90.0).abs() < 1e-6,
+            "expected a 90° Z rotation, got {:?}",
+            quarter.rotation
+        );
+        // Anchor at the origin, so the child stays pinned there.
+        assert!(quarter.translation.x.abs() < 1e-9);
+        assert!(quarter.translation.y.abs() < 1e-9);
+    }
+
+    /// And a slider must translate along its axis by exactly the state.
+    #[test]
+    fn prismatic_state_slides_the_child() {
+        let doc: vcad_ir::Document =
+            serde_json::from_str(&jointed_doc("Slider", [1.0, 0.0, 0.0])).expect("parse");
+        let mut doc = doc.clone();
+        doc.joints.as_mut().unwrap()[0].state = 7.5;
+        let pose = crate::assembly_world_transforms(&doc).expect("fk")["arm"];
+        assert!(
+            (pose.translation.x - 7.5).abs() < 1e-9,
+            "got {:?}",
+            pose.translation
+        );
+        assert!(pose.translation.y.abs() < 1e-9);
+        assert!(pose.rotation.z.abs() < 1e-9, "a slider must not rotate");
+    }
+
+    #[test]
+    fn shorthand_and_native_tracks_parse_the_same() {
+        let sugar = parse_timeline_spec(
+            r#"{"fps":24,"durationS":2,"tracks":[{"joint":"A","keys":[{"t":0,"value":0},{"t":2,"value":90}]}]}"#,
+        )
+        .expect("shorthand");
+        let native = parse_timeline_spec(
+            r#"{"fps":24,"durationS":2,"tracks":[{"target":{"type":"Joint","jointId":"A"},
+                "keys":[{"t":0,"value":0},{"t":2,"value":90}]}]}"#,
+        )
+        .expect("native");
+        assert_eq!(sugar, native);
+    }
+
+    #[test]
+    fn a_track_naming_no_joint_fails_with_the_list() {
+        let doc: vcad_ir::Document =
+            serde_json::from_str(&jointed_doc("Revolute", [0.0, 0.0, 1.0])).expect("parse");
+        let err = resolve_joint(&doc, "nope").expect_err("should fail");
+        assert!(err.contains("joint_0"), "unhelpful error: {err}");
+        assert!(
+            err.contains("swing"),
+            "should offer the authored name: {err}"
+        );
+    }
+
+    /// A joint track may name its joint by authored name as well as by id —
+    /// `.loon` authors write the name, the IR mints the id.
+    #[test]
+    fn joints_resolve_by_name_or_id() {
+        let doc: vcad_ir::Document =
+            serde_json::from_str(&jointed_doc("Revolute", [0.0, 0.0, 1.0])).expect("parse");
+        assert_eq!(resolve_joint(&doc, "swing").unwrap().id, "joint_0");
+        assert_eq!(resolve_joint(&doc, "joint_0").unwrap().id, "joint_0");
+    }
+
+    /// The timeline sampler is shared with the app; check the animation
+    /// path's assumptions about it hold (inclusive of both ends, linear).
+    #[test]
+    fn sequence_covers_both_ends() {
+        let tl = joint_timeline("joint_0", 0.0, 100.0);
+        let seq = tl.sample_sequence();
+        assert_eq!(seq.len(), 3, "1 s at 2 fps is t=0, 0.5, 1.0");
+        assert_eq!(seq[0].joints["joint_0"], 0.0);
+        assert_eq!(seq[1].joints["joint_0"], 50.0);
+        assert_eq!(seq[2].joints["joint_0"], 100.0);
+    }
+}

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -39,6 +39,8 @@
 #![warn(missing_docs)]
 
 #[cfg(feature = "raytrace")]
+pub mod animate;
+#[cfg(feature = "raytrace")]
 pub mod envmap;
 mod exact;
 pub mod materials;
@@ -638,7 +640,127 @@ pub fn with_root_cache<T>(
     f()
 }
 
+// Count of documents evaluated by `evaluate_vcad_document` — the one funnel
+// every render path goes through.
+//
+// Exists so the animation path can *prove* it evaluates geometry once for a
+// whole sequence rather than once per frame; the integration test asserts
+// the counter advances by exactly one across an N-frame render, which is the
+// only thing that would catch a regression putting evaluation back inside
+// the frame loop.
+//
+// Per *thread*, not per process: a render is driven from one thread (rayon
+// parallelism lives inside the tracer, below this level), and a global would
+// be unreadable in a test binary running cases concurrently.
+thread_local! {
+    static DOCUMENT_EVALS: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+/// How many documents this thread has evaluated. See [`DOCUMENT_EVALS`].
+pub fn document_eval_count() -> u64 {
+    DOCUMENT_EVALS.with(|c| c.get())
+}
+
+/// One assembly instance's geometry, still in its part-definition frame.
+///
+/// The world placement is deliberately *not* baked in: an animation re-poses
+/// the same solids every frame, so the geometry (and the BVH built over it)
+/// has to outlive any one pose.
+struct ArticulatedPart {
+    /// Instance id — the key forward kinematics reports world poses under.
+    instance_id: String,
+    /// Local, unplaced geometry. Shared between instances of one part def.
+    solid: Solid,
+    tint: Option<[f64; 3]>,
+    #[cfg_attr(not(feature = "raytrace"), allow(dead_code))]
+    material: Option<vcad_ir::MaterialDef>,
+    name: Option<String>,
+    labels: Vec<String>,
+}
+
+/// A document evaluated once: its static scene roots, world-placed, plus its
+/// assembly instances in local space alongside the document itself (which
+/// carries the joints those instances hang off).
+struct EvaluatedDocument {
+    doc: vcad_ir::Document,
+    statics: Vec<SceneSolid>,
+    parts: Vec<ArticulatedPart>,
+}
+
+/// Forward kinematics for an assembly document — the same solver the app's
+/// assembly mode and the MCP timeline use, so a render agrees with the
+/// viewer by construction rather than by a re-implementation.
+fn assembly_world_transforms(
+    doc: &vcad_ir::Document,
+) -> Result<HashMap<String, vcad_ir::Transform3D>, String> {
+    catch_unwind(AssertUnwindSafe(|| {
+        vcad_eval::solve_forward_kinematics(doc)
+    }))
+    .map_err(|_| "fk panicked".to_string())
+}
+
+/// An articulated part as a scene solid in its *local* frame, keyed by
+/// instance id. The animation path builds its BVHs from these once and then
+/// only ever changes the placement.
+#[cfg(feature = "raytrace")]
+fn part_as_local_scene_solid(part: ArticulatedPart) -> SceneSolid {
+    SceneSolid {
+        solid: part.solid,
+        tint: part.tint,
+        material: part.material,
+        name: part.name,
+        labels: part.labels,
+        id: part.instance_id,
+    }
+}
+
+/// Place an articulated part by the world pose FK gave its instance, falling
+/// back to the instance's own static transform.
+fn place_part(
+    part: ArticulatedPart,
+    world: &HashMap<String, vcad_ir::Transform3D>,
+    fallback: Option<vcad_ir::Transform3D>,
+) -> SceneSolid {
+    let placed = match world.get(&part.instance_id).cloned().or(fallback) {
+        Some(t) => part.solid.apply_transform(&transform3d_to_kernel(&t)),
+        None => part.solid,
+    };
+    SceneSolid {
+        solid: placed,
+        tint: part.tint,
+        material: part.material,
+        name: part.name,
+        labels: part.labels,
+        id: part.instance_id,
+    }
+}
+
 fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
+    let ev = evaluate_vcad_document(raw_vcad)?;
+    let mut solids = ev.statics;
+    if !ev.parts.is_empty() {
+        let world = assembly_world_transforms(&ev.doc)?;
+        let fallbacks: HashMap<&str, Option<vcad_ir::Transform3D>> = ev
+            .doc
+            .instances
+            .as_deref()
+            .unwrap_or_default()
+            .iter()
+            .map(|i| (i.id.as_str(), i.transform))
+            .collect();
+        for part in ev.parts {
+            let fallback = fallbacks
+                .get(part.instance_id.as_str())
+                .copied()
+                .unwrap_or(None);
+            solids.push(place_part(part, &world, fallback));
+        }
+    }
+    Ok(solids)
+}
+
+fn evaluate_vcad_document(raw_vcad: &str) -> Result<EvaluatedDocument, String> {
+    DOCUMENT_EVALS.with(|c| c.set(c.get() + 1));
     let parsed = parse_vcad_file(raw_vcad).map_err(|e| format!("parse: {}", e))?;
     let (root_cache, mesh_segments) = ROOT_CACHE
         .with(|c| c.borrow().clone())
@@ -687,7 +809,7 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
             }
             _ => Default::default(),
         };
-    let mut solids: Vec<SceneSolid> = scene
+    let solids: Vec<SceneSolid> = scene
         .parts
         .iter()
         .enumerate()
@@ -740,32 +862,31 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
 
     // Assembly instances: `evaluate_document` only carries meshes for
     // instances, not BRep solids, so re-evaluate each referenced part
-    // definition once and place a transformed copy per instance. Without
+    // definition once and hand back a local copy per instance. Without
     // this, an assembly-only document (no scene roots) rendered as
     // "no solids produced" despite being perfectly valid.
-    solids.extend(evaluate_assembly_instances(&parsed.document, &scene)?);
-    Ok(solids)
+    let parts = evaluate_assembly_instances(&parsed.document, &scene)?;
+    Ok(EvaluatedDocument {
+        doc: parsed.document,
+        statics: solids,
+        parts,
+    })
 }
 
-/// Evaluate the document's assembly instances (if any) into world-placed
-/// tinted solids. Part-definition solids are evaluated once and shared;
-/// per-instance world poses come from forward kinematics, falling back to
-/// the instance's static transform.
+/// Evaluate the document's assembly instances (if any) into tinted solids in
+/// part-definition space. Part-definition solids are evaluated once and
+/// shared; placement is the caller's job (see [`place_part`]) so an
+/// animation can re-pose the same geometry without re-evaluating it.
 fn evaluate_assembly_instances(
     doc: &vcad_ir::Document,
     scene: &vcad_eval::EvaluatedScene,
-) -> Result<Vec<SceneSolid>, String> {
+) -> Result<Vec<ArticulatedPart>, String> {
     let (Some(part_defs), Some(instances)) = (&doc.part_defs, &doc.instances) else {
         return Ok(Vec::new());
     };
     if part_defs.is_empty() || instances.is_empty() {
         return Ok(Vec::new());
     }
-
-    let world = catch_unwind(AssertUnwindSafe(|| {
-        vcad_eval::solve_forward_kinematics(doc)
-    }))
-    .map_err(|_| "fk panicked".to_string())?;
 
     let mut cache: HashMap<vcad_ir::NodeId, Option<Solid>> = HashMap::new();
     let mut def_solids: HashMap<&str, Option<Solid>> = HashMap::new();
@@ -806,11 +927,6 @@ fn evaluate_assembly_instances(
             .clone();
         let Some(solid) = solid else { continue };
 
-        let placed = match world.get(&inst.id).cloned().or(inst.transform) {
-            Some(t) => solid.apply_transform(&transform3d_to_kernel(&t)),
-            None => solid,
-        };
-
         let material = inst
             .material
             .clone()
@@ -827,13 +943,13 @@ fn evaluate_assembly_instances(
         if let Some(n) = &inst.name {
             labels.push(n.clone());
         }
-        out.push(SceneSolid {
-            solid: placed,
+        out.push(ArticulatedPart {
+            instance_id: inst.id.clone(),
+            solid,
             tint: color,
             material: material_def,
             name,
             labels,
-            id: inst.id.clone(),
         });
     }
     Ok(out)

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -41,6 +41,7 @@
 #[cfg(feature = "raytrace")]
 pub mod envmap;
 mod exact;
+pub mod materials;
 pub mod pcb;
 #[cfg(feature = "raytrace")]
 pub mod photoreal;
@@ -712,6 +713,11 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
                     })
                 })
             });
+            // A named-but-undeclared material (`[root rail "aluminum"]` with
+            // no `[material ...]` block, which is how every hand-written
+            // `.loon` does it) falls back to the built-in library rather than
+            // to the renderer's default clay.
+            let material = materials::resolve(materials, &p.material);
             solid.map(|s| {
                 let name = visible_roots
                     .get(i)
@@ -719,8 +725,8 @@ fn evaluate_vcad(raw_vcad: &str) -> Result<Vec<SceneSolid>, String> {
                     .and_then(|n| n.name.clone());
                 SceneSolid {
                     solid: s,
-                    tint: materials.get(&p.material).map(|m| m.color),
-                    material: materials.get(&p.material).cloned(),
+                    tint: material.as_ref().map(|m| m.color),
+                    material: material.clone(),
                     labels: name.clone().into_iter().collect(),
                     name,
                     id: visible_roots
@@ -810,8 +816,8 @@ fn evaluate_assembly_instances(
             .clone()
             .or_else(|| def.default_material.clone())
             .unwrap_or_else(|| "default".to_string());
-        let color = doc.materials.get(&material).map(|m| m.color);
-        let material_def = doc.materials.get(&material).cloned();
+        let material_def = materials::resolve(&doc.materials, &material);
+        let color = material_def.as_ref().map(|m| m.color);
         let name = inst
             .name
             .clone()

--- a/crates/vcad-render/src/main.rs
+++ b/crates/vcad-render/src/main.rs
@@ -13,6 +13,7 @@
 //!   vcad-render <path.vcad> -o out.jpg [--view ...] [--size <N|WxH>] [--fill <frac>] [--quality <1-100>]
 //!   vcad-render <path.vcad> -o out.png [--auto-aspect] [--trim [--trim-margin <px>]]
 //!   vcad-render <path.vcad> -o out.png [--raytrace]   # RGBA raster, transparent background
+//!   vcad-render <path.vcad> --photoreal --animate [keys.json] -o <dir> [--frames N] [--fps F] [--mp4 out.mp4]
 //!   vcad-render <path.vcad> --sheet [--size <sheet-width-px>] [-o out.svg|out.jpg]
 //!   vcad-render <dir-or-paths...> [--out-dir <dir>] [--format svg|jpeg|png]
 //!
@@ -38,6 +39,17 @@
 //! bounding box instead of the whole document. `--section` renders a cutaway:
 //! the half of the model on the camera's side of the plane is removed and the
 //! exposed cut faces are cross-hatched.
+//!
+//! `--animate` renders a jointed assembly over time instead of a single
+//! image: one `frame_NNNN.png` per timeline sample into the directory named
+//! by `-o`, then an H.264 mp4 if ffmpeg is on PATH. The document is
+//! evaluated — and its per-part BVHs built — exactly *once* for the whole
+//! sequence; each frame only re-solves forward kinematics, re-places the
+//! parts, and re-traces. Poses come from the document's own timeline, or
+//! from the keyframe file given as `--animate <keys.json>`. The camera is
+//! framed on the union of every pose, so the subject neither swims nor
+//! clips. Photoreal only — the tessellated paths are already cheap enough
+//! that per-frame evaluation is not the bottleneck.
 //!
 //! Raster framing: `--size` takes `N` (square) or `WxH`, `--auto-aspect`
 //! fits the canvas to the subject's projected aspect ratio, and `--trim`
@@ -346,6 +358,36 @@ struct Cli {
     /// the noise itself is the thing being measured.
     #[arg(long, requires = "photoreal")]
     no_denoise: bool,
+
+    /// Render a jointed assembly over time (`--photoreal`): one PNG per
+    /// timeline sample into the directory given by `-o`, evaluating the
+    /// document's geometry exactly once for the whole sequence.
+    ///
+    /// Takes an optional keyframe file; bare `--animate` uses the timeline
+    /// stored on the document. The file is a timeline — `durationS`, `fps`,
+    /// `tracks` — with a shorthand for joint tracks:
+    /// `{"joint":"A","keys":[{"t":0,"value":0},{"t":6,"value":1440}]}`.
+    /// A joint may be named by id (`joint_0`) or by its authored name.
+    #[arg(long, value_name = "KEYFRAMES.json", num_args = 0..=1, requires = "photoreal")]
+    animate: Option<Option<PathBuf>>,
+
+    /// Render only the first N frames of the animation (`--animate`).
+    #[arg(long, requires = "animate")]
+    frames: Option<usize>,
+
+    /// Override the timeline's frame rate (`--animate`).
+    #[arg(long, requires = "animate")]
+    fps: Option<f64>,
+
+    /// Assemble the animation into an H.264 mp4 at this path (`--animate`).
+    /// Defaults to `<out-dir>/<input-stem>.mp4`. Needs ffmpeg on PATH; when
+    /// it is missing the frames are still written and the command is printed.
+    #[arg(long, value_name = "OUT.mp4", requires = "animate")]
+    mp4: Option<PathBuf>,
+
+    /// Skip the mp4 assembly and leave the PNG frames (`--animate`).
+    #[arg(long, requires = "animate", conflicts_with = "mp4")]
+    no_mp4: bool,
 }
 
 /// CLI spelling of the photoreal backdrop options.
@@ -445,6 +487,113 @@ fn raster_opts(cli: &Cli, png: bool) -> vcad_render::RasterOptions {
     }
 }
 
+/// The photoreal path's options, as selected on the command line.
+#[cfg(feature = "raytrace")]
+fn photoreal_options(cli: &Cli) -> vcad_render::photoreal::PhotorealOptions {
+    use vcad_render::photoreal::{Backdrop, PhotorealOptions};
+    PhotorealOptions {
+        environment: vcad_render::envmap::parse_env_arg(&cli.env),
+        env_rotation_deg: cli.env_rotation,
+        spp: cli.spp,
+        max_depth: cli.max_depth,
+        exposure: cli.exposure,
+        fov_deg: cli.fov,
+        orthographic: cli.ortho,
+        aperture_frac: cli.aperture,
+        backdrop: match cli.backdrop {
+            BackdropArg::Studio => Backdrop::Studio,
+            BackdropArg::Shadow => Backdrop::ShadowCatcher,
+            BackdropArg::None => Backdrop::None,
+        },
+        seed: cli.seed,
+        denoise: !cli.no_denoise,
+    }
+}
+
+/// Render an animation: one PNG per timeline sample into the `-o` directory,
+/// then (unless told not to) mux them into an mp4.
+///
+/// The point of this path is that the document is evaluated once, so the
+/// timings are printed per frame: frame 1 versus the steady state is the
+/// measurement that shows it working.
+#[cfg(feature = "raytrace")]
+fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
+    use vcad_render::animate::{
+        assemble_mp4, parse_timeline_spec, render_photoreal_animation, AnimateOptions,
+    };
+
+    let spec = cli.animate.as_ref().expect("caller checked --animate");
+    let Some(out_dir) = cli.output.clone() else {
+        return Err("--animate writes a directory of frames: pass -o <dir>".to_string());
+    };
+    if out_dir.extension().is_some() {
+        return Err(format!(
+            "--animate writes a directory of frames, but -o names a file \
+             ({}); pass a directory",
+            out_dir.display()
+        ));
+    }
+
+    let timeline = match spec {
+        Some(path) => {
+            let json = std::fs::read_to_string(path)
+                .map_err(|e| format!("read {}: {e}", path.display()))?;
+            Some(parse_timeline_spec(&json)?)
+        }
+        None => None,
+    };
+
+    let raw = read_document(input)?;
+    let opts = raster_opts(cli, true);
+    let pr = photoreal_options(cli);
+    let an = AnimateOptions {
+        out_dir: out_dir.clone(),
+        timeline,
+        frames: cli.frames,
+        fps: cli.fps,
+    };
+
+    let report = render_photoreal_animation(&raw, &opts, &pr, &an, &mut |i, n, dt| {
+        eprintln!("frame {i}/{n}  {:.1}s", dt.as_secs_f64());
+    })?;
+
+    eprintln!(
+        "evaluated {} part(s) once in {:.1}s ({} articulated), setup {:.1}s",
+        report.parts,
+        report.eval.as_secs_f64(),
+        report.articulated,
+        report.setup.as_secs_f64()
+    );
+    if let (Some(first), median) = (report.per_frame.first(), report.median_frame()) {
+        eprintln!(
+            "frame 1 {:.1}s, steady state {:.1}s, {} frames in {:.1}s total",
+            first.as_secs_f64(),
+            median.as_secs_f64(),
+            report.frames.len(),
+            report.total().as_secs_f64()
+        );
+    }
+
+    if cli.no_mp4 {
+        return Ok(());
+    }
+    let mp4 = cli.mp4.clone().unwrap_or_else(|| {
+        out_dir.join(format!(
+            "{}.mp4",
+            input
+                .file_stem()
+                .map(|s| s.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "animation".to_string())
+        ))
+    });
+    // Never load-bearing: the frames are the deliverable.
+    match assemble_mp4(&out_dir, report.fps, &mp4) {
+        Ok(()) => eprintln!("wrote {}", mp4.display()),
+        Err(e) => eprintln!("{e}"),
+    }
+    Ok(())
+}
+
 /// Render raw `.vcad` to raster bytes in `format` (JPEG or PNG), via the
 /// tessellated path or — when `cli.raytrace` — direct BRep ray tracing.
 #[cfg(feature = "raster")]
@@ -463,24 +612,7 @@ fn render_raster(raw: &str, cli: &Cli, format: Format) -> Result<Vec<u8>, String
         }
         #[cfg(feature = "raytrace")]
         {
-            use vcad_render::photoreal::{Backdrop, PhotorealOptions};
-            let pr = PhotorealOptions {
-                environment: vcad_render::envmap::parse_env_arg(&cli.env),
-                env_rotation_deg: cli.env_rotation,
-                spp: cli.spp,
-                max_depth: cli.max_depth,
-                exposure: cli.exposure,
-                fov_deg: cli.fov,
-                orthographic: cli.ortho,
-                aperture_frac: cli.aperture,
-                backdrop: match cli.backdrop {
-                    BackdropArg::Studio => Backdrop::Studio,
-                    BackdropArg::Shadow => Backdrop::ShadowCatcher,
-                    BackdropArg::None => Backdrop::None,
-                },
-                seed: cli.seed,
-                denoise: !cli.no_denoise,
-            };
+            let pr = photoreal_options(cli);
             return if png {
                 vcad_render::photoreal::render_photoreal_png_str(raw, &opts, &pr)
             } else {
@@ -828,6 +960,16 @@ fn run(cli: &Cli) -> Result<(), String> {
     }
 
     let input = &inputs[0];
+    if cli.animate.is_some() {
+        #[cfg(feature = "raytrace")]
+        {
+            return run_animation(input, cli);
+        }
+        #[cfg(not(feature = "raytrace"))]
+        {
+            return Err("this build of vcad-render lacks the `raytrace` feature".to_string());
+        }
+    }
     // Legacy --jpeg <path> spelling.
     if let Some(path) = &cli.jpeg {
         return render_one(input, Some(path), Format::Jpeg, cli);

--- a/crates/vcad-render/src/materials.rs
+++ b/crates/vcad-render/src/materials.rs
@@ -1,0 +1,210 @@
+//! Built-in material library: PBR values for well-known material names.
+//!
+//! Hardware documents overwhelmingly name a material rather than define one.
+//! A `.loon` file says `[root frame-rails "aluminum"]` and stops there — the
+//! name *is* the spec, the same way a drawing note saying "6061-T6" is. The
+//! document's `materials` table stays empty, so before this module every one
+//! of those parts resolved to `None` and the path tracer fell back to its
+//! default clay grey: an entire machine rendered as one lump of putty.
+//!
+//! This is a **render-time fallback**, deliberately not a parser-time
+//! rewrite. The IR keeps saying exactly what the author wrote — a name, no
+//! def — and the renderer supplies a plausible appearance for names it
+//! recognises. A document that *does* declare `[material aluminum ...]`
+//! always wins; nothing here can override authored intent.
+//!
+//! Both render paths resolve through [`resolve`], so the drafting fills and
+//! the photoreal shading agree on hue by construction.
+//!
+//! Values follow the app's material picker (`packages/app/src/data/
+//! materials.ts`) in hue and intent, with base colours for the metals moved
+//! to measured normal-incidence reflectance — under a path tracer, F0 is what
+//! the number means, and the picker's swatch values render chalky.
+
+use vcad_ir::MaterialDef;
+
+/// Normalise a material key for lookup: case-insensitive, and `-`, `_` and
+/// spaces are all the same separator, so `abs-black`, `abs_black` and
+/// `ABS Black` are one material.
+fn normalize(name: &str) -> String {
+    name.chars()
+        .filter_map(|c| match c {
+            '-' | '_' | ' ' => Some('-'),
+            c if c.is_ascii_alphanumeric() => Some(c.to_ascii_lowercase()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `(key, color, metallic, roughness)`.
+type Entry = (&'static str, [f64; 3], f64, f64);
+
+/// The library. Metals carry measured-ish F0 reflectance; dielectrics carry
+/// albedo. Roughness is perceptual (squared to GGX alpha downstream).
+const LIBRARY: &[Entry] = &[
+    // ── metals ───────────────────────────────────────────────────────────
+    // Bare aluminium's true F0 is ~0.91; a machined part at that value blows
+    // out to white paper in a bright studio and stops reading as metal at
+    // all. Pulled down and roughened until the form shading survives.
+    ("aluminum", [0.86, 0.87, 0.88], 1.0, 0.40),
+    ("steel", [0.68, 0.69, 0.71], 1.0, 0.30),
+    ("stainless", [0.78, 0.79, 0.80], 1.0, 0.22),
+    ("chrome", [0.95, 0.95, 0.95], 1.0, 0.08),
+    ("copper", [0.95, 0.54, 0.33], 1.0, 0.25),
+    ("brass", [0.89, 0.75, 0.39], 1.0, 0.30),
+    ("bronze", [0.80, 0.57, 0.34], 1.0, 0.35),
+    ("gold", [1.00, 0.77, 0.34], 1.0, 0.18),
+    ("silver", [0.97, 0.96, 0.92], 1.0, 0.12),
+    ("titanium", [0.62, 0.60, 0.57], 1.0, 0.42),
+    ("nickel", [0.66, 0.61, 0.53], 1.0, 0.22),
+    // ── plastics ─────────────────────────────────────────────────────────
+    // Injection-moulded and printed plastics are never as dark or as light
+    // as their nominal colour chip: black ABS reflects a few percent, white
+    // reflects ~85%. Pushing to 0/1 is the tell of an untuned render.
+    ("abs-black", [0.03, 0.03, 0.03], 0.0, 0.50),
+    ("abs-white", [0.85, 0.85, 0.84], 0.0, 0.45),
+    ("abs-grey", [0.30, 0.30, 0.31], 0.0, 0.50),
+    ("abs-red", [0.55, 0.06, 0.04], 0.0, 0.50),
+    ("abs-blue", [0.05, 0.12, 0.45], 0.0, 0.50),
+    ("abs-green", [0.07, 0.32, 0.12], 0.0, 0.50),
+    ("abs-yellow", [0.70, 0.52, 0.04], 0.0, 0.50),
+    ("abs-orange", [0.72, 0.26, 0.03], 0.0, 0.50),
+    ("pla", [0.72, 0.72, 0.68], 0.0, 0.45),
+    ("petg", [0.60, 0.68, 0.72], 0.0, 0.35),
+    ("nylon", [0.78, 0.76, 0.70], 0.0, 0.55),
+    ("delrin", [0.80, 0.80, 0.79], 0.0, 0.40),
+    ("pom", [0.80, 0.80, 0.79], 0.0, 0.40),
+    ("resin", [0.48, 0.44, 0.40], 0.0, 0.20),
+    ("acrylic", [0.85, 0.85, 0.88], 0.0, 0.10),
+    ("rubber", [0.05, 0.05, 0.05], 0.0, 0.80),
+    // ── composites & other ───────────────────────────────────────────────
+    ("carbon-fiber", [0.05, 0.05, 0.06], 0.2, 0.30),
+    ("fiberglass", [0.72, 0.72, 0.62], 0.0, 0.40),
+    ("kevlar", [0.58, 0.53, 0.20], 0.0, 0.60),
+    ("fr4", [0.05, 0.35, 0.18], 0.0, 0.80),
+    ("concrete", [0.42, 0.42, 0.40], 0.0, 0.85),
+    ("ceramic", [0.85, 0.83, 0.80], 0.0, 0.25),
+    ("foam", [0.20, 0.20, 0.23], 0.0, 0.95),
+    ("glass", [0.85, 0.88, 0.90], 0.0, 0.05),
+    // ── organic ──────────────────────────────────────────────────────────
+    ("oak", [0.42, 0.30, 0.18], 0.0, 0.70),
+    ("walnut", [0.20, 0.13, 0.09], 0.0, 0.65),
+    ("leather", [0.22, 0.13, 0.08], 0.0, 0.75),
+    ("cork", [0.52, 0.37, 0.24], 0.0, 0.90),
+    ("bamboo", [0.66, 0.54, 0.33], 0.0, 0.60),
+    // ── shorthands the hardware repos actually use ───────────────────────
+    // `actuator` is a whole class of part (servo/gearmotor housing) rather
+    // than a substance, but it is written as a material and it has a
+    // consistent look: dark filled nylon, matte, slightly warm.
+    ("actuator", [0.10, 0.10, 0.11], 0.0, 0.55),
+    ("motor", [0.10, 0.10, 0.11], 0.0, 0.55),
+    ("plastic", [0.55, 0.55, 0.55], 0.0, 0.50),
+    ("metal", [0.85, 0.86, 0.87], 1.0, 0.35),
+    ("default", [0.62, 0.64, 0.67], 0.0, 0.40),
+];
+
+/// PBR values for a well-known material name, or `None` if unrecognised.
+///
+/// Case- and separator-insensitive: `abs-black`, `abs_black` and `ABS Black`
+/// all resolve to the same definition. The returned [`MaterialDef`] carries
+/// the caller's spelling as its `name`, so downstream finish heuristics
+/// (`brushed_aluminum`, `turned_shaft`) still see what the author wrote.
+pub fn builtin(name: &str) -> Option<MaterialDef> {
+    let key = normalize(name);
+    let (_, color, metallic, roughness) = LIBRARY.iter().find(|(k, ..)| *k == key)?;
+    Some(MaterialDef {
+        name: name.to_string(),
+        color: *color,
+        metallic: *metallic,
+        roughness: *roughness,
+        ..Default::default()
+    })
+}
+
+/// Resolve a part's material: the document's own definition if it has one,
+/// otherwise the built-in for that name.
+///
+/// Authored definitions always win — a document that declares `aluminum` as
+/// hot pink renders hot pink.
+pub fn resolve(
+    materials: &std::collections::HashMap<String, MaterialDef>,
+    name: &str,
+) -> Option<MaterialDef> {
+    materials.get(name).cloned().or_else(|| builtin(name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn separator_and_case_insensitive() {
+        let a = builtin("abs-black").expect("abs-black");
+        for spelling in ["abs_black", "ABS-BLACK", "Abs-Black", "abs black"] {
+            let b = builtin(spelling).unwrap_or_else(|| panic!("{spelling} should resolve"));
+            assert_eq!(a.color, b.color, "{spelling} disagrees with abs-black");
+            assert_eq!(b.name, spelling, "the caller's spelling should survive");
+        }
+    }
+
+    #[test]
+    fn metals_are_metallic_and_plastics_are_not() {
+        for m in ["aluminum", "steel", "copper", "brass", "chrome"] {
+            assert_eq!(builtin(m).expect(m).metallic, 1.0, "{m} should be metal");
+        }
+        for m in ["abs-black", "abs-white", "abs-red", "abs-blue", "actuator"] {
+            assert_eq!(
+                builtin(m).expect(m).metallic,
+                0.0,
+                "{m} should be dielectric"
+            );
+        }
+    }
+
+    #[test]
+    fn copper_reads_warm() {
+        let c = builtin("copper").expect("copper");
+        assert!(
+            c.color[0] > c.color[1] && c.color[1] > c.color[2],
+            "copper should fall off r > g > b, got {:?}",
+            c.color
+        );
+    }
+
+    #[test]
+    fn unknown_names_do_not_resolve() {
+        assert!(builtin("unobtainium").is_none());
+        assert!(builtin("").is_none());
+    }
+
+    #[test]
+    fn authored_definitions_beat_builtins() {
+        let mut materials = HashMap::new();
+        materials.insert(
+            "copper".to_string(),
+            MaterialDef {
+                name: "copper".to_string(),
+                color: [1.0, 0.0, 1.0],
+                metallic: 0.0,
+                roughness: 0.9,
+                ..Default::default()
+            },
+        );
+        let resolved = resolve(&materials, "copper").expect("copper");
+        assert_eq!(resolved.color, [1.0, 0.0, 1.0], "authored def must win");
+
+        // …and a name the document says nothing about still gets the builtin.
+        let fallback = resolve(&materials, "brass").expect("brass");
+        assert_eq!(fallback.color, builtin("brass").unwrap().color);
+    }
+
+    #[test]
+    fn every_key_is_already_normalized_and_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for (k, ..) in LIBRARY {
+            assert_eq!(normalize(k), *k, "library key {k} is not in normal form");
+            assert!(seen.insert(*k), "duplicate library key {k}");
+        }
+    }
+}

--- a/crates/vcad-render/src/photoreal.rs
+++ b/crates/vcad-render/src/photoreal.rs
@@ -163,6 +163,16 @@ pub(crate) fn build_objects(solids: &[crate::SceneSolid]) -> Result<Vec<Object>,
 /// The eight corners of an object's BVH root AABB, in world space after
 /// `transform`. These are what framing is computed from.
 pub(crate) fn object_corners(obj: &Object) -> Vec<[f64; 3]> {
+    object_corners_with(obj, &obj.transform)
+}
+
+/// `object_corners` under an explicit transform, so a caller can ask "where
+/// would this object's bounds land under pose `t`" without mutating the
+/// object (the --animate camera framing sweeps every pose this way).
+pub(crate) fn object_corners_with(
+    obj: &Object,
+    transform: &vcad_kernel::vcad_kernel_math::Transform,
+) -> Vec<[f64; 3]> {
     let Some(node) = obj.bvh.root() else {
         return Vec::new();
     };
@@ -177,7 +187,7 @@ pub(crate) fn object_corners(obj: &Object) -> Vec<[f64; 3]> {
                 if i & 2 == 0 { aabb.min.y } else { aabb.max.y },
                 if i & 4 == 0 { aabb.min.z } else { aabb.max.z },
             );
-            let w = obj.transform.apply_point(&p);
+            let w = transform.apply_point(&p);
             [w.x, w.y, w.z]
         })
         .collect()

--- a/crates/vcad-render/src/photoreal.rs
+++ b/crates/vcad-render/src/photoreal.rs
@@ -113,29 +113,17 @@ pub fn render_photoreal_png_str(
     encode_png(rasterize(raw_vcad, opts, pr, true)?, opts)
 }
 
-fn rasterize(
-    raw_vcad: &str,
-    opts: &RasterOptions,
-    pr: &PhotorealOptions,
-    png: bool,
-) -> Result<Frame, String> {
-    let solids = evaluate_vcad(raw_vcad)?;
-    if solids.is_empty() {
-        return Err("no solids produced".to_string());
-    }
-    if opts.size_px < 16 {
-        return Err("size_px too small".to_string());
-    }
-    if !(opts.fill_frac > 0.0 && opts.fill_frac <= 1.0) {
-        return Err("fill_frac must be in (0, 1]".to_string());
-    }
-
-    // One BVH per solid. BRep-backed solids trace analytically; mesh-only
-    // parts (frozen topology-optimization results, imported STL/GLB) trace
-    // as crease-baked triangles, same as the `--raytrace` path.
+/// Build one BVH per solid, world-placed at the identity.
+///
+/// BRep-backed solids trace analytically; mesh-only parts (frozen
+/// topology-optimization results, imported STL/GLB) trace as crease-baked
+/// triangles, same as the `--raytrace` path. Fails closed when any part has
+/// no traceable geometry — a silently missing part reads as a design that
+/// doesn't have it.
+pub(crate) fn build_objects(solids: &[crate::SceneSolid]) -> Result<Vec<Object>, String> {
     let mut objects: Vec<Object> = Vec::new();
     let mut untraceable: Vec<String> = Vec::new();
-    for s in &solids {
+    for s in solids {
         let bvh = match s.solid.as_brep() {
             Some(brep) => Bvh::build(brep),
             None => {
@@ -148,10 +136,10 @@ fn rasterize(
             untraceable.push(s.name.clone().unwrap_or_else(|| s.id.clone()));
             continue;
         }
-        objects.push(Object {
-            bvh: Arc::new(bvh),
-            material: Pbr::from_material_def(s.material.as_ref(), s.tint),
-        });
+        objects.push(Object::new(
+            Arc::new(bvh),
+            Pbr::from_material_def(s.material.as_ref(), s.tint),
+        ));
     }
     if objects.is_empty() {
         return Err(format!(
@@ -162,8 +150,6 @@ fn rasterize(
         ));
     }
     if !untraceable.is_empty() {
-        // Fail closed rather than silently rendering a subset — a missing
-        // part reads as a design that doesn't have it.
         return Err(format!(
             "photoreal: {} part(s) have no traceable geometry (empty or fully \
              degenerate): {}",
@@ -171,11 +157,52 @@ fn rasterize(
             untraceable.join(", ")
         ));
     }
+    Ok(objects)
+}
 
-    // ── framing ──────────────────────────────────────────────────────────
-    // Project the union of BVH root AABBs onto the view basis, exactly as
-    // the drafting and raytrace paths do, so `--view`, `--fill`, `--size`
-    // and `--auto-aspect` all behave identically across styles.
+/// The eight corners of an object's BVH root AABB, in world space after
+/// `transform`. These are what framing is computed from.
+pub(crate) fn object_corners(obj: &Object) -> Vec<[f64; 3]> {
+    let Some(node) = obj.bvh.root() else {
+        return Vec::new();
+    };
+    let aabb = match node {
+        vcad_kernel_raytrace::bvh::BvhNode::Leaf { aabb, .. }
+        | vcad_kernel_raytrace::bvh::BvhNode::Internal { aabb, .. } => aabb,
+    };
+    (0..8)
+        .map(|i| {
+            let p = Point3::new(
+                if i & 1 == 0 { aabb.min.x } else { aabb.max.x },
+                if i & 2 == 0 { aabb.min.y } else { aabb.max.y },
+                if i & 4 == 0 { aabb.min.z } else { aabb.max.z },
+            );
+            let w = obj.transform.apply_point(&p);
+            [w.x, w.y, w.z]
+        })
+        .collect()
+}
+
+/// Camera, canvas, and the floor height a set of world points implies.
+pub(crate) struct Framing {
+    pub(crate) camera: Camera,
+    pub(crate) canvas: crate::raster::Canvas,
+    /// World-space centre of the subject, for the studio rig.
+    pub(crate) center: Point3,
+    /// Bounding-sphere radius, for the rig and the aperture.
+    pub(crate) radius: f64,
+    /// Lowest world Z — where the studio floor sits.
+    pub(crate) floor_z: f64,
+}
+
+/// Frame `points` (world-space corners) exactly as the drafting and raytrace
+/// paths do, so `--view`, `--fill`, `--size` and `--auto-aspect` behave
+/// identically across styles.
+pub(crate) fn frame_view(
+    points: &[[f64; 3]],
+    opts: &RasterOptions,
+    pr: &PhotorealOptions,
+) -> Result<Framing, String> {
     let cam_dir = normalize(opts.view.cam());
     let right = normalize(opts.view.right());
     let down = normalize(opts.view.down());
@@ -184,27 +211,16 @@ fn rasterize(
     let mut max = [f64::NEG_INFINITY; 2];
     let mut world_min = [f64::INFINITY; 3];
     let mut world_max = [f64::NEG_INFINITY; 3];
-    for obj in &objects {
-        let node = obj.bvh.root().expect("empty BVHs were filtered");
-        let aabb = match node {
-            vcad_kernel_raytrace::bvh::BvhNode::Leaf { aabb, .. }
-            | vcad_kernel_raytrace::bvh::BvhNode::Internal { aabb, .. } => aabb,
-        };
-        for i in 0..8 {
-            let c = [
-                if i & 1 == 0 { aabb.min.x } else { aabb.max.x },
-                if i & 2 == 0 { aabb.min.y } else { aabb.max.y },
-                if i & 4 == 0 { aabb.min.z } else { aabb.max.z },
-            ];
-            let s = [dot(c, right), dot(c, down)];
-            for k in 0..2 {
-                min[k] = min[k].min(s[k]);
-                max[k] = max[k].max(s[k]);
-            }
-            for k in 0..3 {
-                world_min[k] = world_min[k].min(c[k]);
-                world_max[k] = world_max[k].max(c[k]);
-            }
+    for c in points {
+        let c = *c;
+        let s = [dot(c, right), dot(c, down)];
+        for k in 0..2 {
+            min[k] = min[k].min(s[k]);
+            max[k] = max[k].max(s[k]);
+        }
+        for k in 0..3 {
+            world_min[k] = world_min[k].min(c[k]);
+            world_max[k] = world_max[k].max(c[k]);
         }
     }
 
@@ -267,14 +283,28 @@ fn rasterize(
     camera.ortho_half_height = pr.orthographic.then_some(half_h_world);
     let _ = half_w_world;
 
-    // ── lighting ─────────────────────────────────────────────────────────
+    Ok(Framing {
+        camera,
+        canvas,
+        center: center_world,
+        radius,
+        floor_z: world_min[2],
+    })
+}
+
+/// Wrap already-built objects in the studio rig, environment, and floor.
+pub(crate) fn dress_scene(
+    objects: Vec<Object>,
+    framing: &Framing,
+    pr: &PhotorealOptions,
+) -> Result<Scene, String> {
     let env = envmap::resolve(&pr.environment, pr.env_rotation_deg)?;
 
     // The softbox rig exists to give the low-frequency analytic gradient
     // something to make highlights with. An HDRI already carries its own
     // lights, so keeping the rig would double-light the subject.
     let lights: Vec<AreaLight> = match env {
-        Environment::Gradient(_) => pathtrace::studio_rig(center_world, radius),
+        Environment::Gradient(_) => pathtrace::studio_rig(framing.center, framing.radius),
         Environment::Image(_) => Vec::new(),
     };
 
@@ -283,7 +313,7 @@ fn rasterize(
         mode => Some(Ground {
             // Sit the floor exactly on the subject's lowest point so parts
             // read as resting on it rather than floating.
-            z: world_min[2],
+            z: framing.floor_z,
             material: Pbr {
                 base_color: [0.55, 0.55, 0.56],
                 metallic: 0.0,
@@ -295,14 +325,16 @@ fn rasterize(
         }),
     };
 
-    let scene = Scene {
+    Ok(Scene {
         objects,
         lights,
         env,
         ground,
-    };
+    })
+}
 
-    let pt_opts = PathTraceOptions {
+pub(crate) fn trace_options(pr: &PhotorealOptions, png: bool) -> PathTraceOptions {
+    PathTraceOptions {
         spp: pr.spp.max(1),
         max_depth: pr.max_depth.max(1),
         rr_start: 3,
@@ -311,9 +343,24 @@ fn rasterize(
         seed: pr.seed,
         denoise: pr.denoise,
         ..PathTraceOptions::default()
-    };
+    }
+}
 
-    let film = pathtrace::render(&scene, &camera, canvas.w as u32, canvas.h as u32, &pt_opts);
+/// Trace one frame of an already-assembled scene.
+pub(crate) fn trace_frame(
+    scene: &Scene,
+    framing: &Framing,
+    pr: &PhotorealOptions,
+    png: bool,
+) -> Frame {
+    let canvas = framing.canvas;
+    let film = pathtrace::render(
+        scene,
+        &framing.camera,
+        canvas.w as u32,
+        canvas.h as u32,
+        &trace_options(pr, png),
+    );
     let rgba = film.to_srgb8(pr.exposure, png && pr.backdrop != Backdrop::Studio);
 
     // Split into the (rgb, mask) pair the shared encoders expect.
@@ -326,8 +373,35 @@ fn rasterize(
         rgb[i * 3 + 2] = rgba[i * 4 + 2];
         mask[i] = rgba[i * 4 + 3];
     }
+    Frame { rgb, mask, canvas }
+}
 
-    Ok(Frame { rgb, mask, canvas })
+fn rasterize(
+    raw_vcad: &str,
+    opts: &RasterOptions,
+    pr: &PhotorealOptions,
+    png: bool,
+) -> Result<Frame, String> {
+    check_raster_opts(opts)?;
+    let solids = evaluate_vcad(raw_vcad)?;
+    if solids.is_empty() {
+        return Err("no solids produced".to_string());
+    }
+    let objects = build_objects(&solids)?;
+    let corners: Vec<[f64; 3]> = objects.iter().flat_map(object_corners).collect();
+    let framing = frame_view(&corners, opts, pr)?;
+    let scene = dress_scene(objects, &framing, pr)?;
+    Ok(trace_frame(&scene, &framing, pr, png))
+}
+
+pub(crate) fn check_raster_opts(opts: &RasterOptions) -> Result<(), String> {
+    if opts.size_px < 16 {
+        return Err("size_px too small".to_string());
+    }
+    if !(opts.fill_frac > 0.0 && opts.fill_frac <= 1.0) {
+        return Err("fill_frac must be in (0, 1]".to_string());
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/vcad-render/src/photoreal.rs
+++ b/crates/vcad-render/src/photoreal.rs
@@ -358,6 +358,71 @@ mod tests {
         .to_string()
     }
 
+    /// A document that *names* a material without defining one — how every
+    /// hand-written `.loon` does it — must still shade as that material
+    /// rather than dropping to the path tracer's default clay.
+    fn cube_doc_named(material: &str, defs: &str) -> String {
+        format!(
+            r#"{{
+  "version": "0.1",
+  "nodes": {{
+    "1": {{
+      "id": 1,
+      "name": "Cube",
+      "op": {{ "type": "Cube", "size": {{ "x": 20, "y": 20, "z": 20 }} }}
+    }}
+  }},
+  "materials": {{{defs}}},
+  "part_materials": {{}},
+  "roots": [{{ "root": 1, "material": "{material}" }}]
+}}"#
+        )
+    }
+
+    #[test]
+    fn undeclared_material_name_resolves_to_the_builtin() {
+        let solids = evaluate_vcad(&cube_doc_named("copper", "")).expect("eval");
+        let def = solids[0].material.as_ref().expect("copper should resolve");
+        assert_eq!(
+            def.color,
+            crate::materials::builtin("copper").unwrap().color
+        );
+
+        let pbr = Pbr::from_material_def(solids[0].material.as_ref(), solids[0].tint);
+        assert_eq!(pbr.metallic, 1.0, "copper must trace as a metal");
+        assert!(
+            pbr.base_color[0] > pbr.base_color[2] + 0.3,
+            "copper must read warm, got {:?}",
+            pbr.base_color
+        );
+        assert_ne!(
+            pbr.base_color,
+            Pbr::default().base_color,
+            "copper fell through to default clay"
+        );
+    }
+
+    #[test]
+    fn authored_material_overrides_the_builtin() {
+        let doc = cube_doc_named(
+            "copper",
+            r#""copper": { "name": "copper", "color": [0.0, 1.0, 0.0],
+                          "metallic": 0.0, "roughness": 0.9 }"#,
+        );
+        let solids = evaluate_vcad(&doc).expect("eval");
+        let pbr = Pbr::from_material_def(solids[0].material.as_ref(), solids[0].tint);
+        assert_eq!(pbr.base_color, [0.0, 1.0, 0.0], "authored def must win");
+        assert_eq!(pbr.metallic, 0.0);
+    }
+
+    #[test]
+    fn unknown_material_name_still_falls_back_to_clay() {
+        let solids = evaluate_vcad(&cube_doc_named("unobtainium", "")).expect("eval");
+        assert!(solids[0].material.is_none());
+        let pbr = Pbr::from_material_def(None, solids[0].tint);
+        assert_eq!(pbr.base_color, Pbr::default().base_color);
+    }
+
     #[test]
     fn renders_a_cube_to_png() {
         let opts = RasterOptions {

--- a/crates/vcad-render/tests/photoreal_animation.rs
+++ b/crates/vcad-render/tests/photoreal_animation.rs
@@ -1,0 +1,218 @@
+//! `--animate` renders a jointed assembly over time while evaluating the
+//! document's geometry exactly once.
+//!
+//! The two things worth asserting are that the frames actually differ (the
+//! joint moved) and that the one-evaluation promise holds — the whole reason
+//! this path exists instead of baking a document per frame.
+#![cfg(all(feature = "raytrace", feature = "cli"))]
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+use vcad_render::animate::{render_photoreal_animation, AnimateOptions};
+use vcad_render::photoreal::{Backdrop, PhotorealOptions};
+use vcad_render::RasterOptions;
+
+/// A scratch directory unique to this test, cleaned up on the way out.
+struct TempDir(PathBuf);
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        let dir =
+            std::env::temp_dir().join(format!("vcad-render-anim-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        TempDir(dir)
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+/// A post with an arm bolted to it by a revolute joint about +Z, plus a
+/// second, fixed-jointed block riding on the arm — so the test also covers
+/// FK carrying a group along, which is how every real assembly is built.
+const JOINTED_ASSEMBLY: &str = r#"{
+  "version": "0.1",
+  "nodes": {
+    "1": { "id": 1, "name": "post", "op": { "type": "Cube", "size": { "x": 12, "y": 12, "z": 30 } } },
+    "2": { "id": 2, "name": "arm",  "op": { "type": "Cube", "size": { "x": 60, "y": 8, "z": 8 } } }
+  },
+  "materials": {},
+  "part_materials": {},
+  "roots": [],
+  "partDefs": {
+    "post": { "id": "post", "name": "post", "root": 1 },
+    "arm":  { "id": "arm",  "name": "arm",  "root": 2 }
+  },
+  "instances": [
+    { "id": "post", "partDefId": "post", "material": "aluminum" },
+    { "id": "arm",  "partDefId": "arm",  "material": "copper" }
+  ],
+  "joints": [
+    { "id": "joint_0", "name": "swing", "parentInstanceId": "post",
+      "childInstanceId": "arm",
+      "parentAnchor": { "x": 6, "y": 6, "z": 30 },
+      "childAnchor":  { "x": 6, "y": 6, "z": 30 },
+      "kind": { "type": "Revolute", "axis": { "x": 0, "y": 0, "z": 1 },
+                "limits": [-180, 180] },
+      "state": 0.0 }
+  ],
+  "groundInstanceId": "post"
+}"#;
+
+const SWEEP: &str = r#"{
+  "durationS": 1.0,
+  "fps": 2.0,
+  "tracks": [
+    { "joint": "swing", "keys": [ { "t": 0, "value": 0 }, { "t": 1, "value": 90 } ] }
+  ]
+}"#;
+
+fn tiny_options() -> (RasterOptions, PhotorealOptions) {
+    (
+        RasterOptions {
+            size_px: 48,
+            ..Default::default()
+        },
+        PhotorealOptions {
+            spp: 2,
+            backdrop: Backdrop::ShadowCatcher,
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn three_frames_move_and_the_document_is_evaluated_once() {
+    let dir = TempDir::new("once");
+    let (opts, pr) = tiny_options();
+    let an = AnimateOptions {
+        out_dir: dir.0.clone(),
+        timeline: Some(vcad_render::animate::parse_timeline_spec(SWEEP).expect("spec")),
+        frames: None,
+        fps: None,
+    };
+
+    let before = vcad_render::document_eval_count();
+    let report = render_photoreal_animation(
+        JOINTED_ASSEMBLY,
+        &opts,
+        &pr,
+        &an,
+        &mut |_, _, _: Duration| {},
+    )
+    .expect("animate");
+
+    assert_eq!(report.frames.len(), 3, "1 s at 2 fps is t=0, 0.5, 1.0");
+    assert_eq!(
+        vcad_render::document_eval_count() - before,
+        1,
+        "the document must be evaluated once for the whole sequence, not once \
+         per frame — that is the entire point of this path"
+    );
+    assert_eq!(report.articulated, 2, "both instances are joint-placed");
+
+    let bytes: Vec<Vec<u8>> = report
+        .frames
+        .iter()
+        .map(|p| std::fs::read(p).expect("frame written"))
+        .collect();
+    for (i, b) in bytes.iter().enumerate() {
+        assert_eq!(&b[1..4], b"PNG", "frame {i} is not a PNG");
+    }
+    assert_ne!(
+        bytes[0], bytes[1],
+        "the arm did not move between frames 0-1"
+    );
+    assert_ne!(
+        bytes[1], bytes[2],
+        "the arm did not move between frames 1-2"
+    );
+
+    // The subject must actually be in frame at both ends — a camera framed
+    // on one pose only would clip the swing.
+    for (i, b) in bytes.iter().enumerate() {
+        let img = image::load_from_memory(b).expect("decode").to_rgba8();
+        let covered = img.pixels().filter(|p| p.0[3] > 8).count();
+        assert!(covered > 40, "frame {i} is nearly empty ({covered} px)");
+    }
+}
+
+#[test]
+fn frames_flag_truncates_the_sequence() {
+    let dir = TempDir::new("trunc");
+    let (opts, pr) = tiny_options();
+    let an = AnimateOptions {
+        out_dir: dir.0.clone(),
+        timeline: Some(vcad_render::animate::parse_timeline_spec(SWEEP).expect("spec")),
+        frames: Some(2),
+        fps: None,
+    };
+    let report = render_photoreal_animation(JOINTED_ASSEMBLY, &opts, &pr, &an, &mut |_, _, _| {})
+        .expect("animate");
+    assert_eq!(report.frames.len(), 2);
+}
+
+/// A document with no joints is a static model; asking to animate it must
+/// say so rather than quietly writing N identical frames.
+#[test]
+fn a_document_without_joints_is_rejected() {
+    let dir = TempDir::new("nojoints");
+    let (opts, pr) = tiny_options();
+    let an = AnimateOptions {
+        out_dir: dir.0.clone(),
+        timeline: Some(vcad_render::animate::parse_timeline_spec(SWEEP).expect("spec")),
+        frames: None,
+        fps: None,
+    };
+    let static_doc = r#"{
+      "version": "0.1",
+      "nodes": { "1": { "id": 1, "name": "Cube",
+                        "op": { "type": "Cube", "size": { "x": 10, "y": 10, "z": 10 } } } },
+      "materials": {}, "part_materials": {},
+      "roots": [{ "root": 1, "material": "aluminum" }]
+    }"#;
+    let err = render_photoreal_animation(static_doc, &opts, &pr, &an, &mut |_, _, _| {})
+        .expect_err("should refuse");
+    assert!(err.contains("assembly instances"), "unhelpful error: {err}");
+}
+
+/// End to end through the binary, which is where the `-o <dir>` contract and
+/// the `--frames` plumbing live.
+#[test]
+fn the_cli_writes_a_frame_directory() {
+    let dir = TempDir::new("cli");
+    let doc = dir.0.join("assembly.vcad");
+    std::fs::write(&doc, JOINTED_ASSEMBLY).expect("write doc");
+    let spec = dir.0.join("sweep.json");
+    std::fs::write(&spec, SWEEP).expect("write spec");
+    let out = dir.0.join("frames");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vcad-render"))
+        .arg(&doc)
+        .arg("--photoreal")
+        .arg("--animate")
+        .arg(&spec)
+        .arg("--spp")
+        .arg("2")
+        .arg("--size")
+        .arg("48")
+        .arg("--no-mp4")
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("run vcad-render");
+    assert!(
+        output.status.success(),
+        "render failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for name in ["frame_0000.png", "frame_0001.png", "frame_0002.png"] {
+        assert!(out.join(name).is_file(), "missing {name}");
+    }
+}


### PR DESCRIPTION
Two photoreal-renderer features, driven by rendering purl (the pond's stator winder) natively in vcad.

## 1. Built-in material library (7a4ed11c)

Loon documents that name materials without declaring `[material ...]` defs (`[root x "copper"]`) rendered as default clay in `--photoreal` — the loon→IR conversion records the name but creates no MaterialDef, and `Pbr::from_material_def(None, _)` falls back to grey. The web viewport was unaffected (it has its own TS table); the Rust path was the gap.

- New `crates/vcad-render/src/materials.rs`: ~40 built-in PBR defs (metals, ABS colors, PLA/PETG/delrin, FR4, glass, woods…), resolved at both scene-assembly sites via `materials::resolve(&doc.materials, name)`. Authored defs win by construction; lookup is case/separator-insensitive; the caller's spelling is preserved so the `brushed_*`/`turned_*` anisotropy heuristic still fires.
- Draft raster fills read the same resolved color, so line-art and photoreal agree on hue.
- 5 unit tests + 3 JSON-document photoreal tests; fmt/clippy clean.

## 2. `--photoreal --animate` (9091cd30)

Animating an assembly previously meant baking one document per frame and re-paying the serial BRep evaluation + BLAS build every frame (~55 s/frame at 16 spp/640 px for a 35-part machine — evaluation-dominated, not tracing).

- `evaluate_vcad` split so assembly instances come back in part-definition space; the animation path evaluates geometry **once**, then per frame samples the timeline (`Timeline::sample_sequence`), runs the same `solve_forward_kinematics` the app/MCP use, bumps per-part `Arc` transforms, and rebuilds only the TLAS.
- CLI: `--animate [keys.json]` (bare form reads the document's embedded timeline; shorthand `{"joint":"A","keys":[…]}` accepted, joints resolve by id or name, misses fail with the available list), `--frames/--fps/--mp4`. `-o` becomes a frame directory; ffmpeg muxing is best-effort, never load-bearing.
- Parameter tracks are refused rather than silently ignored (they'd reintroduce per-frame evaluation).
- Camera frames the union of all poses so nothing swims; shared seed keeps grain stable across frames.
- Measured on the winder assembly: evaluation paid once (340 s) for a 49-frame clip vs 49× under the old bake-per-frame path. Integration test renders 3 tiny frames and asserts single evaluation + differing frames.

Known limitations (documented in-code): timeline `CameraShot` intents parse but don't compile to the render camera yet; only joint tracks animate.

Changelog entries included for both. Verified end-to-end on `hardware` loons and the purl repo (materials swatch, hero still, full-cycle photoreal mp4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)