### PR TITLE
feat(mcp): joint-sweep clearance — measure/check_clearance min distance across FK poses

### DIFF
--- a/changelog/entries/2026-08-25-measure-joint-sweep.json
+++ b/changelog/entries/2026-08-25-measure-joint-sweep.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-25-measure-joint-sweep",
+  "version": "0.9.4",
+  "date": "2026-08-25",
+  "category": "feat",
+  "title": "measure sweeps a mechanism's range of motion",
+  "summary": "measure now takes joint_state and sweep: the worst distance across a joint's travel plus the full per-pose margin curve; check_clearance gains include_samples and out-of-limits warnings.",
+  "features": ["measure", "clearance", "assembly", "joints", "kinematics"],
+  "mcpTools": ["measure", "check_clearance"]
+}

--- a/packages/mcp/src/__tests__/clearance.test.ts
+++ b/packages/mcp/src/__tests__/clearance.test.ts
@@ -311,7 +311,7 @@ describe("clearance receipts (build_receipt / verify_receipt)", () => {
  * and clears by a wide margin; at 0° it swings straight through it. Modelling
  * one pose is exactly the trap — the authored pose is the pose that works.
  */
-function swingArmDocument(): Document {
+function swingArmDocument(opts?: { limits?: [number, number] }): Document {
   const nodes: Record<string, unknown> = {};
   let id = 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -353,7 +353,11 @@ function swingArmDocument(): Document {
         childInstanceId: "arm-1",
         parentAnchor: { x: 0, y: 0, z: 0 },
         childAnchor: { x: 0, y: 0, z: 0 },
-        kind: { type: "Revolute", axis: { x: 0, y: 0, z: 1 } },
+        kind: {
+          type: "Revolute",
+          axis: { x: 0, y: 0, z: 1 },
+          ...(opts?.limits ? { limits: opts.limits } : {}),
+        },
         state: 90, // authored at the one angle that clears
       },
     ],
@@ -477,6 +481,95 @@ describe("check_clearance sweep", () => {
     const res = out(await verifyReceipt({ document_id: docId, receipt: rebuilt }, engine));
     expect(res.status).toBe("Violated");
     expect(res.clearance.checks[0].poses_checked).toBe(10);
+  });
+
+  it("returns the per-pose margin curve on request, and never persists it", async () => {
+    const docId = openSwingArm();
+    const plain = out(
+      await checkClearance(
+        {
+          document_id: docId,
+          group_a: ["arm-1"],
+          group_b: ["post-1"],
+          min_mm: 1,
+          sweep: [{ joint: "shoulder", from: 30, to: 90, steps: 6 }],
+        },
+        engine,
+      ),
+    );
+    expect(plain.samples).toBeUndefined();
+
+    const withSamples = out(
+      await checkClearance(
+        {
+          document_id: docId,
+          group_a: ["arm-1"],
+          group_b: ["post-1"],
+          min_mm: 1,
+          label: "knee-swing",
+          include_samples: true,
+          sweep: [{ joint: "shoulder", from: 30, to: 90, steps: 6 }],
+        },
+        engine,
+      ),
+    );
+    expect(withSamples.samples).toHaveLength(7);
+    expect(withSamples.samples[0].pose).toEqual([{ joint: "shoulder", state: 30 }]);
+    expect(withSamples.measured_mm).toBeCloseTo(withSamples.samples[0].distance_mm, 6);
+    // The spec is the assertion, not the curve.
+    const spec = getSession(docId).clearance_specs![0];
+    expect(spec.label).toBe("knee-swing");
+    expect((spec as unknown as Record<string, unknown>).samples).toBeUndefined();
+
+    const built = out(await buildReceipt({ document_id: docId }, engine));
+    const claim = built.unified.claims.find(
+      (c: { id: string }) => c.id === "mech.clearance.knee-swing",
+    );
+    expect(JSON.parse(claim.details).samples).toBeUndefined();
+  });
+
+  it("omits samples above the 256-pose cap and says so", async () => {
+    const docId = openSwingArm();
+    const res = out(
+      await checkClearance(
+        {
+          document_id: docId,
+          group_a: ["arm-1"],
+          group_b: ["post-1"],
+          min_mm: 1,
+          include_samples: true,
+          sweep: [{ joint: "shoulder", from: 30, to: 90, steps: 300 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.poses_checked).toBe(301);
+    expect(res.samples).toBeUndefined();
+    expect(res.samples_omitted).toBe(true);
+    expect(res.samples_note).toContain("256");
+  });
+
+  it("warns instead of failing when the sweep exceeds a joint's declared limits", async () => {
+    const docId = out(
+      openDocument({ initial: swingArmDocument({ limits: [30, 90] }) }),
+    ).document_id as string;
+    const res = out(
+      await checkClearance(
+        {
+          document_id: docId,
+          group_a: ["arm-1"],
+          group_b: ["post-1"],
+          min_mm: 1,
+          sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 9 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.sweep_warnings).toHaveLength(1);
+    expect(res.sweep_warnings[0]).toContain("[30, 90]");
+    // Reported, not clamped: the unreachable pose still drives the verdict.
+    expect(res.pass).toBe(false);
+    expect(res.worst_pose).toEqual([{ joint: "shoulder", state: 0 }]);
   });
 });
 

--- a/packages/mcp/src/__tests__/measure.test.ts
+++ b/packages/mcp/src/__tests__/measure.test.ts
@@ -214,3 +214,261 @@ describe("inspect_part / describe_scene (dispatched over the registry surface)",
     ).not.toThrow(/not dispatchable/);
   });
 });
+
+/**
+ * A crank arm swinging about the origin past a fixed post — the four-bar-knee
+ * trap, minimized. Authored at 90° the arm points away from the post and
+ * clears by a wide margin; at 0° it swings straight through it. Measuring the
+ * authored pose is exactly the mistake: the authored pose is the pose that
+ * works.
+ */
+function swingArmDocument(limits?: [number, number]): Document {
+  const nodes: Record<string, unknown> = {};
+  let id = 0;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const add = (name: string, op: any): number => {
+    id += 1;
+    nodes[String(id)] = { id, name, op };
+    return id;
+  };
+
+  const arm = add("arm-solid", { type: "Cube", size: { x: 30, y: 4, z: 4 } });
+  const postSolid = add("post-solid", { type: "Cube", size: { x: 6, y: 6, z: 10 } });
+  const post = add("post", {
+    type: "Translate",
+    child: postSolid,
+    offset: { x: 20, y: -3, z: -3 },
+  });
+
+  return {
+    version: "0.1",
+    nodes,
+    materials: {},
+    part_materials: {},
+    roots: [],
+    partDefs: {
+      arm: { id: "arm", name: "arm", root: arm },
+      post: { id: "post", name: "post", root: post },
+    },
+    instances: [
+      { id: "post-1", partDefId: "post", name: "post" },
+      { id: "arm-1", partDefId: "arm", name: "arm" },
+    ],
+    joints: [
+      {
+        id: "shoulder",
+        name: "shoulder",
+        parentInstanceId: null,
+        childInstanceId: "arm-1",
+        parentAnchor: { x: 0, y: 0, z: 0 },
+        childAnchor: { x: 0, y: 0, z: 0 },
+        kind: {
+          type: "Revolute",
+          axis: { x: 0, y: 0, z: 1 },
+          ...(limits ? { limits } : {}),
+        },
+        state: 90, // authored at the one angle that clears
+      },
+    ],
+  } as unknown as Document;
+}
+
+function openSwingArm(limits?: [number, number]): string {
+  return out(openDocument({ initial: swingArmDocument(limits) })).document_id as string;
+}
+
+describe("measure joint sweep", () => {
+  it("measures the authored pose when unswept", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure({ document_id: docId, part_ids: ["arm-1", "post-1"] }, engine),
+    );
+    expect(res.mode).toBe("pair");
+    expect(res.intersecting).toBe(false);
+    expect(res.poses_checked).toBeUndefined();
+    expect(res.samples).toBeUndefined();
+  });
+
+  it("finds the collision the authored pose hides, and names the pose", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 9 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.mode).toBe("sweep");
+    expect(res.intersecting).toBe(true);
+    expect(res.distance_mm).toBeLessThanOrEqual(0);
+    expect(res.poses_checked).toBe(10);
+    expect(res.worst_pose).toEqual([{ joint: "shoulder", state: 0 }]);
+    expect(res.sweep).toEqual([{ joint: "shoulder", from: 0, to: 90, steps: 9 }]);
+  });
+
+  it("returns the margin curve, minimal at the known worst angle", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          // 30°–90°: the arm never reaches the post, and the gap grows
+          // monotonically with the angle, so the minimum is the 30° endpoint.
+          sweep: [{ joint: "shoulder", from: 30, to: 90, steps: 6 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.intersecting).toBe(false);
+    expect(res.samples).toHaveLength(7);
+    expect(res.samples[0].pose).toEqual([{ joint: "shoulder", state: 30 }]);
+    expect(res.samples[6].pose).toEqual([{ joint: "shoulder", state: 90 }]);
+    expect(res.worst_pose).toEqual([{ joint: "shoulder", state: 30 }]);
+    expect(res.distance_mm).toBeCloseTo(res.samples[0].distance_mm, 6);
+    const gaps = res.samples.map((s: { distance_mm: number }) => s.distance_mm);
+    expect(Math.min(...gaps)).toBeCloseTo(res.distance_mm, 6);
+    for (let i = 1; i < gaps.length; i++) expect(gaps[i]).toBeGreaterThan(gaps[i - 1]);
+  });
+
+  it("omits samples above the 256-pose cap but still reports the worst pose", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          sweep: [{ joint: "shoulder", from: 30, to: 90, steps: 300 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.poses_checked).toBe(301);
+    expect(res.samples).toBeUndefined();
+    expect(res.samples_omitted).toBe(true);
+    expect(res.samples_note).toContain("256");
+    expect(res.worst_pose).toEqual([{ joint: "shoulder", state: 30 }]);
+  });
+
+  it("restores joint states — a sweep asks a question, it does not pose the model", () => {
+    const docId = openSwingArm();
+    measure(
+      {
+        document_id: docId,
+        part_ids: ["arm-1", "post-1"],
+        sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 4 }],
+      },
+      engine,
+    );
+    expect(getSession(docId).joints?.[0].state).toBe(90);
+  });
+
+  it("refuses a sweep with one part id instead of guessing what to measure", () => {
+    const docId = openSwingArm();
+    const res = measure(
+      {
+        document_id: docId,
+        part_ids: ["arm-1"],
+        sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 4 }],
+      },
+      engine,
+    );
+    expect(res.isError).toBe(true);
+    expect(res.content[0].text).toContain("TWO parts");
+  });
+
+  it("rejects an unknown joint and an oversized grid", () => {
+    const docId = openSwingArm();
+    const unknown = measure(
+      {
+        document_id: docId,
+        part_ids: ["arm-1", "post-1"],
+        sweep: [{ joint: "elbow", from: 0, to: 90, steps: 4 }],
+      },
+      engine,
+    );
+    expect(unknown.isError).toBe(true);
+
+    const huge = measure(
+      {
+        document_id: docId,
+        part_ids: ["arm-1", "post-1"],
+        sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 9999 }],
+      },
+      engine,
+    );
+    expect(huge.isError).toBe(true);
+  });
+
+  it("warns — without clamping — when the sweep exceeds the joint's limits", () => {
+    const docId = openSwingArm([30, 90]);
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          sweep: [{ joint: "shoulder", from: 0, to: 90, steps: 9 }],
+        },
+        engine,
+      ),
+    );
+    expect(res.sweep_warnings).toHaveLength(1);
+    expect(res.sweep_warnings[0]).toContain("[30, 90]");
+    // Not clamped: the out-of-limits pose was still measured and still won.
+    expect(res.worst_pose).toEqual([{ joint: "shoulder", state: 0 }]);
+    expect(res.intersecting).toBe(true);
+  });
+});
+
+describe("measure joint_state", () => {
+  it("measures at the requested pose without touching the session", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          joint_state: { shoulder: 0 },
+        },
+        engine,
+      ),
+    );
+    expect(res.mode).toBe("pair");
+    expect(res.intersecting).toBe(true);
+    expect(res.pose.applied.shoulder).toBe(0);
+    expect(getSession(docId).joints?.[0].state).toBe(90);
+  });
+
+  it("lets a sweep override the base pose on the joints it drives", () => {
+    const docId = openSwingArm();
+    const res = out(
+      measure(
+        {
+          document_id: docId,
+          part_ids: ["arm-1", "post-1"],
+          joint_state: { shoulder: 0 },
+          sweep: [{ joint: "shoulder", from: 60, to: 90, steps: 3 }],
+        },
+        engine,
+      ),
+    );
+    // The base pose collides; the swept 60°–90° arc does not, and the sweep
+    // wins on the joint it drives.
+    expect(res.intersecting).toBe(false);
+    expect(res.poses_checked).toBe(4);
+    expect(res.pose.applied.shoulder).toBe(0);
+    expect(getSession(docId).joints?.[0].state).toBe(90);
+  });
+
+  it("errors on an unknown joint key", () => {
+    const docId = openSwingArm();
+    const res = measure(
+      { document_id: docId, part_ids: ["arm-1", "post-1"], joint_state: { elbow: 10 } },
+      engine,
+    );
+    expect(res.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -1588,7 +1588,7 @@
   {
     "name": "measure",
     "title": "Measure",
-    "description": "Measure geometry in an open session. Pass `part_ids` with two ids to get the minimum distance between those parts (0/negative = contact/overlap) plus each part's world-space bounding box; pass one id to get that part's bbox, volume, and center of mass. Complements `inspect_cad` (whole-document aggregate) and `check_clearance` (named, persisted air-gap assertions). Distances are measured from evaluated tessellations, so accuracy is tessellation-bound.",
+    "description": "Measure geometry in an open session. Pass `part_ids` with two ids to get the minimum distance between those parts (0/negative = contact/overlap) plus each part's world-space bounding box; pass one id to get that part's bbox, volume, and center of mass. Pass `joint_state` (joint id or name → degrees, mm for sliders) to measure a jointed assembly at one real pose instead of the stored one. Pass `sweep` — [{joint, from, to, steps}] — with TWO part ids to drive the mechanism through its range of motion and get the WORST (minimum) distance over the whole travel, the pose that realizes it (`worst_pose`), and `samples`: the full per-pose margin curve, so you can see where the clearance collapses rather than only that it does (omitted above 256 poses). Sweep endpoints outside a joint's declared limits are reported in `sweep_warnings`, not clamped; joint states are always restored, so a sweep never edits the document. Complements `inspect_cad` (whole-document aggregate) and `check_clearance` (named, persisted air-gap assertions with pass/fail and whole-document audits). Distances are measured from evaluated tessellations — swept poses re-place those same meshes — so accuracy is tessellation-bound.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -1602,6 +1602,44 @@
             "type": "string"
           },
           "description": "One or two part ids (or part names). One id → that part's bbox, volume, and center of mass. Two ids → the minimum distance between them (0/negative = contact/overlap) plus each part's bbox."
+        },
+        "joint_state": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Pose the assembly before evaluating: map of joint id (or joint name) → state — degrees for revolute/ball joints, mm for sliders. Joints not listed keep their stored state, so omitting this renders the document exactly as stored. States outside a joint's declared limits are clamped and reported in `pose.warnings`; an unknown joint key is an error."
+        },
+        "sweep": {
+          "type": "array",
+          "description": "Range-of-motion sweep: drive these joints across their travel and report the WORST pose, not the authored one. Each axis is {joint, from, to, steps}; multiple axes form a Cartesian grid (capped at 4096 poses). Endpoints outside a joint's declared limits are reported as warnings, not clamped. Joint states are restored afterwards — the sweep never edits the document.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "joint": {
+                "type": "string",
+                "description": "Joint id or name to drive."
+              },
+              "from": {
+                "type": "number",
+                "description": "Start of travel (degrees for revolute, mm for prismatic)."
+              },
+              "to": {
+                "type": "number",
+                "description": "End of travel."
+              },
+              "steps": {
+                "type": "number",
+                "description": "Number of intervals; steps + 1 poses are sampled."
+              }
+            },
+            "required": [
+              "joint",
+              "from",
+              "to",
+              "steps"
+            ]
+          }
         }
       },
       "required": [
@@ -8781,7 +8819,7 @@
   {
     "name": "check_clearance",
     "title": "Check Clearance",
-    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at one real pose (joint id or name → degrees, or mm for sliders) instead of the stored one. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes. Two modes beyond the single-pair snapshot: (1) `sweep` — pass [{joint, from, to, steps}] to drive the mechanism through its range of motion and report the WORST pose, not the one it was authored in (a linkage modelled at mid-travel routinely clears there and collides at both ends); persisted with the label, so the assertion re-verifies over the same range. (2) audit — omit `group_a`/`group_b` entirely to broadphase EVERY part pair in the document and list everything that interpenetrates, with penetration depth; whitelist intended contact with `ignore_pairs` (Fixed-joint pairs are skipped by default). Combine both for 'does this machine ever hit itself anywhere in its workspace'.",
+    "description": "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` — air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at one real pose (joint id or name → degrees, or mm for sliders) instead of the stored one. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes. Two modes beyond the single-pair snapshot: (1) `sweep` — pass [{joint, from, to, steps}] to drive the mechanism through its range of motion and report the WORST pose, not the one it was authored in (a linkage modelled at mid-travel routinely clears there and collides at both ends); persisted with the label, so the assertion re-verifies over the same range. Sweep endpoints beyond a joint's declared limits are reported in `sweep_warnings` rather than clamped, and `include_samples: true` returns the per-pose margin curve as `samples` (one {pose, distance_mm, intersecting} per pose, omitted above 256 poses and never persisted). Swept distances come from the same tessellated meshes, re-placed per pose, so accuracy stays tessellation-bound. (2) audit — omit `group_a`/`group_b` entirely to broadphase EVERY part pair in the document and list everything that interpenetrates, with penetration depth; whitelist intended contact with `ignore_pairs` (Fixed-joint pairs are skipped by default). Combine both for 'does this machine ever hit itself anywhere in its workspace'.",
     "inputSchema": {
       "type": "object",
       "properties": {
@@ -8824,7 +8862,7 @@
         },
         "sweep": {
           "type": "array",
-          "description": "Range-of-motion sweep: drive these joints across their travel and report the WORST pose, not the authored one. Each axis is {joint, from, to, steps}; multiple axes form a Cartesian grid (capped at 4096 poses). Joint states are restored afterwards — the sweep never edits the document.",
+          "description": "Range-of-motion sweep: drive these joints across their travel and report the WORST pose, not the authored one. Each axis is {joint, from, to, steps}; multiple axes form a Cartesian grid (capped at 4096 poses). Endpoints outside a joint's declared limits are reported as warnings, not clamped. Joint states are restored afterwards — the sweep never edits the document.",
           "items": {
             "type": "object",
             "properties": {
@@ -8852,6 +8890,10 @@
               "steps"
             ]
           }
+        },
+        "include_samples": {
+          "type": "boolean",
+          "description": "Swept queries only: return the per-pose margin curve as `samples` — one {pose, distance_mm, intersecting} entry per pose, in grid order. Omitted (with a note) when the grid exceeds 256 poses. Never persisted with a labelled spec."
         },
         "ignore_pairs": {
           "type": "array",

--- a/packages/mcp/src/tools/clearance.ts
+++ b/packages/mcp/src/tools/clearance.ts
@@ -26,11 +26,35 @@ import type {
   Transform3D,
 } from "@vcad/ir";
 import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
-import { solveForwardKinematics, transformMesh } from "@vcad/engine";
 import { unverifiableClaim } from "../receipt-unified.js";
 import { applyJointState, jointStateSchemaProp, type PoseInfo } from "./pose.js";
 import { getSession } from "./session-core.js";
 import { asBool } from "./arg-coerce.js";
+import {
+  MAX_SWEEP_POSES,
+  MAX_SWEEP_SAMPLES,
+  parseSweep,
+  placeParts,
+  poseGrid,
+  poseableParts,
+  poseTransforms,
+  resolveSweepAxes,
+  round6,
+  roundPose,
+  sweepSchemaProp,
+  worseThan,
+  type Pose,
+  type PlacedPart,
+  type PoseablePart,
+  type SweepSample,
+} from "./sweep.js";
+
+export {
+  MAX_SWEEP_POSES,
+  poseGrid,
+  type Pose,
+  type SweepSample,
+} from "./sweep.js";
 
 /** Claim-id prefix shared with the Rust mech adapter (`vcad-receipt`). */
 export const CLEARANCE_CLAIM_PREFIX = "mech.clearance.";
@@ -83,18 +107,6 @@ export function clearanceHolds(
   );
 }
 
-/** Is measurement `a` worse than `b`? Interpenetration beats any distance. */
-function worseThan(
-  a: { distance: number; intersecting: boolean },
-  b: { distance: number; intersecting: boolean },
-): boolean {
-  if (a.intersecting !== b.intersecting) return a.intersecting;
-  return a.distance < b.distance;
-}
-
-/** Round distances so payloads don't carry float noise. */
-const round6 = (v: number) => Math.round(v * 1e6) / 1e6;
-
 export const checkClearanceSchema = {
   type: "object" as const,
   properties: {
@@ -127,20 +139,11 @@ export const checkClearanceSchema = {
         "Treat exact surface contact (measured distance within 0.001 mm of zero) as passing even though it is below `min_mm` — for parts designed to touch, e.g. a stage bolted flush to the chamber floor. Penetration beyond the tolerance still fails. Persisted with the spec when `label` is given.",
     },
     joint_state: jointStateSchemaProp,
-    sweep: {
-      type: "array" as const,
+    sweep: sweepSchemaProp,
+    include_samples: {
+      type: "boolean" as const,
       description:
-        "Range-of-motion sweep: drive these joints across their travel and report the WORST pose, not the authored one. Each axis is {joint, from, to, steps}; multiple axes form a Cartesian grid (capped at 4096 poses). Joint states are restored afterwards — the sweep never edits the document.",
-      items: {
-        type: "object" as const,
-        properties: {
-          joint: { type: "string" as const, description: "Joint id or name to drive." },
-          from: { type: "number" as const, description: "Start of travel (degrees for revolute, mm for prismatic)." },
-          to: { type: "number" as const, description: "End of travel." },
-          steps: { type: "number" as const, description: "Number of intervals; steps + 1 poses are sampled." },
-        },
-        required: ["joint", "from", "to", "steps"],
-      },
+        "Swept queries only: return the per-pose margin curve as `samples` — one {pose, distance_mm, intersecting} entry per pose, in grid order. Omitted (with a note) when the grid exceeds 256 poses. Never persisted with a labelled spec.",
     },
     ignore_pairs: {
       type: "array" as const,
@@ -166,86 +169,7 @@ export const checkClearanceSchema = {
 } as const;
 
 /** A part resolved to its evaluated (already-placed) mesh. */
-interface ResolvedPart {
-  id: string;
-  name?: string;
-  mesh: TriangleMesh;
-}
-
-/**
- * A part as evaluated once, kept re-poseable: static roots carry their world
- * mesh directly, assembly instances carry the *part-local* mesh plus the
- * world transform of the pose they were evaluated in. Sweeping then costs one
- * mesh transform per pose instead of one full BRep evaluation.
- */
-interface PoseablePart {
-  id: string;
-  name?: string;
-  /** Part-local mesh for instances; already-world mesh for static roots. */
-  localMesh: TriangleMesh;
-  /** World transform for instances; absent for static roots. */
-  transform?: Transform3D;
-  /** Instance id, when this part is an assembly instance (drives re-posing). */
-  instanceId?: string;
-}
-
-/** Bake a world transform into a part-local mesh. */
-function placeMesh(mesh: TriangleMesh, transform?: Transform3D): TriangleMesh {
-  if (!transform) return mesh;
-  return transformMesh(mesh, {
-    translate: transform.translation,
-    rotate: transform.rotation,
-    scale: transform.scale,
-  });
-}
-
-/** Evaluate a CAD session once into re-poseable parts. */
-function poseableParts(doc: Document, engine: Engine): PoseablePart[] {
-  const scene = engine.evaluate(doc);
-  const visibleRoots = doc.roots.filter((e) => e.visible !== false);
-  const out: PoseablePart[] = [];
-  for (let i = 0; i < scene.parts.length && i < visibleRoots.length; i++) {
-    const rootId = visibleRoots[i].root;
-    const node = doc.nodes[String(rootId)];
-    const mesh = scene.parts[i].mesh;
-    if (!mesh || mesh.positions.length === 0) continue;
-    out.push({ id: String(rootId), name: node?.name ?? undefined, localMesh: mesh });
-  }
-  // Assembly instances: bake the FK world transform into the part-local mesh
-  // so clearances measure poses, not part-local geometry. Without this,
-  // assembly-only documents had no clearance candidates at all.
-  for (const inst of scene.instances ?? []) {
-    if (!inst.mesh || inst.mesh.positions.length === 0) continue;
-    out.push({
-      id: inst.instanceId,
-      name: inst.name ?? undefined,
-      localMesh: inst.mesh,
-      transform: inst.transform ?? undefined,
-      instanceId: inst.instanceId,
-    });
-  }
-  return out;
-}
-
-/**
- * Place every part for one pose. `worldTransforms` (from a re-solved FK pass)
- * overrides the evaluated transform for instances it names; static roots are
- * pose-independent and pass through.
- */
-function placeParts(
-  parts: PoseablePart[],
-  worldTransforms?: Map<string, Transform3D>,
-): ResolvedPart[] {
-  const out: ResolvedPart[] = [];
-  for (const p of parts) {
-    const transform =
-      (p.instanceId ? worldTransforms?.get(p.instanceId) : undefined) ?? p.transform;
-    const mesh = placeMesh(p.localMesh, transform);
-    if (!mesh || mesh.positions.length === 0) continue;
-    out.push({ id: p.id, ...(p.name ? { name: p.name } : {}), mesh });
-  }
-  return out;
-}
+type ResolvedPart = PlacedPart;
 
 /** Evaluate a CAD session into measurable parts (id, name, placed mesh). */
 function partCandidates(doc: Document, engine: Engine): ResolvedPart[] {
@@ -291,91 +215,10 @@ export interface GroupClearance {
   worst_pose?: Pose;
   /** Number of poses evaluated (absent when unswept). */
   poses_checked?: number;
-}
-
-/** One sampled configuration of the mechanism: joint id → state. */
-export type Pose = Array<{ joint: string; state: number }>;
-
-/**
- * Ceiling on the pose grid a single query may span. A sweep is O(poses ×
- * pairs × BVH query); silently truncating would report a clearance the
- * machine never proved, so an oversized grid is an error, not a sample.
- */
-export const MAX_SWEEP_POSES = 4096;
-
-/** Resolve sweep axes against the document's joints (by id, then by name). */
-function resolveSweepAxes(
-  doc: Document,
-  axes: JointSweep[],
-): { axes?: JointSweep[]; error?: string } {
-  const joints = doc.joints ?? [];
-  const resolved: JointSweep[] = [];
-  for (const axis of axes) {
-    const wanted = String(axis.joint);
-    const found =
-      joints.find((j) => j.id === wanted) ?? joints.find((j) => j.name === wanted);
-    if (!found) {
-      const available = joints.map((j) => `${j.id}${j.name ? ` (${j.name})` : ""}`).join(", ");
-      return { error: `No joint with id or name "${wanted}". Available: ${available || "none"}` };
-    }
-    if (!Number.isFinite(axis.from) || !Number.isFinite(axis.to)) {
-      return { error: `Sweep axis "${wanted}" needs finite \`from\` and \`to\`.` };
-    }
-    const steps = Math.trunc(axis.steps);
-    if (!Number.isFinite(steps) || steps < 1) {
-      return { error: `Sweep axis "${wanted}" needs \`steps\` >= 1.` };
-    }
-    resolved.push({ joint: found.id, from: axis.from, to: axis.to, steps });
-  }
-  if (resolved.length === 0) return { error: "`sweep` needs at least one joint axis." };
-  const total = resolved.reduce((n, a) => n * (a.steps + 1), 1);
-  if (total > MAX_SWEEP_POSES) {
-    return {
-      error: `Sweep grid is ${total} poses (limit ${MAX_SWEEP_POSES}). Lower \`steps\` or sweep fewer joints at once.`,
-    };
-  }
-  return { axes: resolved };
-}
-
-/** Cartesian product of the axes: `steps + 1` samples each, endpoints included. */
-export function poseGrid(axes: JointSweep[]): Pose[] {
-  let poses: Pose[] = [[]];
-  for (const axis of axes) {
-    const n = Math.trunc(axis.steps);
-    const next: Pose[] = [];
-    for (const pose of poses) {
-      for (let i = 0; i <= n; i++) {
-        const state = axis.from + ((axis.to - axis.from) * i) / n;
-        next.push([...pose, { joint: axis.joint, state }]);
-      }
-    }
-    poses = next;
-  }
-  return poses;
-}
-
-/**
- * Solve forward kinematics once per pose. Joint states are driven on the
- * document and restored afterwards, so the session is left exactly as the
- * author posed it — a sweep is a question, not an edit.
- */
-function poseTransforms(doc: Document, poses: Pose[]): Array<Map<string, Transform3D>> {
-  const joints = doc.joints ?? [];
-  const byId = new Map(joints.map((j) => [j.id, j] as const));
-  const saved = joints.map((j) => j.state);
-  try {
-    return poses.map((pose) => {
-      for (const { joint, state } of pose) {
-        const j = byId.get(joint);
-        if (j) j.state = state;
-      }
-      return solveForwardKinematics(doc);
-    });
-  } finally {
-    joints.forEach((j, i) => {
-      j.state = saved[i];
-    });
-  }
+  /** Per-pose margin curve (swept queries only; capped, never persisted). */
+  samples?: SweepSample[];
+  /** Sweep endpoints beyond a joint's declared limits, etc. */
+  sweep_warnings?: string[];
 }
 
 /**
@@ -404,7 +247,7 @@ export function computeGroupClearance(
     return measureGroups(engine, placeParts(base), groupA, groupB);
   }
 
-  const { axes, error: sweepError } = resolveSweepAxes(doc, sweep);
+  const { axes, warnings, error: sweepError } = resolveSweepAxes(doc, sweep);
   if (sweepError || !axes) return { error: sweepError ?? "sweep could not be resolved" };
   const poses = poseGrid(axes);
   let transforms: Array<Map<string, Transform3D>>;
@@ -415,6 +258,8 @@ export function computeGroupClearance(
   }
 
   let worst: { result: GroupClearance; pose: Pose } | undefined;
+  const samples: SweepSample[] = [];
+  const keepSamples = poses.length <= MAX_SWEEP_SAMPLES;
   for (let i = 0; i < poses.length; i++) {
     const { result, error } = measureGroups(
       engine,
@@ -423,6 +268,13 @@ export function computeGroupClearance(
       groupB,
     );
     if (error || !result) return { error };
+    if (keepSamples) {
+      samples.push({
+        pose: roundPose(poses[i]),
+        distance_mm: result.distance_mm,
+        intersecting: result.intersecting,
+      });
+    }
     if (
       !worst ||
       worseThan(
@@ -437,8 +289,10 @@ export function computeGroupClearance(
   return {
     result: {
       ...worst.result,
-      worst_pose: worst.pose.map((p) => ({ joint: p.joint, state: round6(p.state) })),
+      worst_pose: roundPose(worst.pose),
       poses_checked: poses.length,
+      ...(keepSamples ? { samples } : {}),
+      ...(warnings && warnings.length > 0 ? { sweep_warnings: warnings } : {}),
     },
   };
 }
@@ -540,6 +394,8 @@ export interface InterferenceAudit {
   findings: InterferenceFinding[];
   /** Ignore-list entries that matched no part — reported, never silently dropped. */
   unresolved_ignores: string[];
+  /** Sweep endpoints beyond a joint's declared limits, etc. */
+  sweep_warnings?: string[];
 }
 
 /** Axis-aligned bounds of a placed mesh. */
@@ -606,10 +462,12 @@ export function computeInterferenceAudit(
   }
 
   let poses: Pose[] = [];
+  let sweepWarnings: string[] | undefined;
   let transforms: Array<Map<string, Transform3D> | undefined> = [undefined];
   if (opts.sweep && opts.sweep.length > 0) {
-    const { axes, error } = resolveSweepAxes(doc, opts.sweep);
+    const { axes, warnings, error } = resolveSweepAxes(doc, opts.sweep);
     if (error || !axes) return { error: error ?? "sweep could not be resolved" };
+    sweepWarnings = warnings;
     poses = poseGrid(axes);
     try {
       transforms = poseTransforms(doc, poses);
@@ -720,6 +578,7 @@ export function computeInterferenceAudit(
       ...(poses.length > 0 ? { poses_checked: poses.length } : {}),
       findings,
       unresolved_ignores: [...new Set(unresolved)],
+      ...(sweepWarnings && sweepWarnings.length > 0 ? { sweep_warnings: sweepWarnings } : {}),
     },
   };
 }
@@ -741,6 +600,7 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
   const groupB = stringArray(args.group_b);
   const label = typeof args.label === "string" && args.label.trim() ? args.label.trim() : undefined;
   const allowContact = asBool(args.allow_contact);
+  const includeSamples = asBool(args.include_samples);
 
   const { sweep, error: sweepParseError } = parseSweep(args.sweep);
   if (sweepParseError) return err(sweepParseError);
@@ -819,6 +679,15 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
     worst_pair: result.worst_pair,
     ...(result.worst_pose ? { worst_pose: result.worst_pose } : {}),
     ...(result.poses_checked !== undefined ? { poses_checked: result.poses_checked } : {}),
+    ...(result.sweep_warnings ? { sweep_warnings: result.sweep_warnings } : {}),
+    ...(includeSamples && result.poses_checked !== undefined
+      ? result.samples
+        ? { samples: result.samples }
+        : {
+            samples_omitted: true,
+            samples_note: `Sweep grid is ${result.poses_checked} poses (over the ${MAX_SWEEP_SAMPLES}-pose sample cap) — per-pose samples were omitted. Lower \`steps\` to get the margin curve.`,
+          }
+      : {}),
     pairs_checked: result.pairs_checked,
     group_a: result.group_a,
     group_b: result.group_b,
@@ -836,32 +705,6 @@ export async function checkClearance(args: Record<string, unknown>, engine: Engi
       document_id: documentId,
     },
   };
-}
-
-/** Parse the `sweep` argument into typed axes (undefined when absent). */
-function parseSweep(raw: unknown): { sweep?: JointSweep[]; error?: string } {
-  if (raw === undefined || raw === null) return {};
-  if (!Array.isArray(raw)) {
-    return { error: "`sweep` must be an array of {joint, from, to, steps} axes." };
-  }
-  const sweep: JointSweep[] = [];
-  for (const entry of raw) {
-    if (!entry || typeof entry !== "object") {
-      return { error: "Each `sweep` axis must be an object {joint, from, to, steps}." };
-    }
-    const e = entry as Record<string, unknown>;
-    const joint = typeof e.joint === "string" ? e.joint.trim() : "";
-    const from = Number(e.from);
-    const to = Number(e.to);
-    const steps = Number(e.steps);
-    if (!joint || !Number.isFinite(from) || !Number.isFinite(to) || !Number.isFinite(steps)) {
-      return {
-        error: "Each `sweep` axis needs a `joint` id/name plus numeric `from`, `to`, and `steps`.",
-      };
-    }
-    sweep.push({ joint, from, to, steps });
-  }
-  return sweep.length > 0 ? { sweep } : {};
 }
 
 /** Parse `ignore_pairs` into id/name couples, tolerating loose shapes. */
@@ -920,6 +763,7 @@ function auditClearance(
     pairs_broadphase: result.pairs_broadphase,
     queries: result.queries,
     ...(result.poses_checked !== undefined ? { poses_checked: result.poses_checked } : {}),
+    ...(result.sweep_warnings ? { sweep_warnings: result.sweep_warnings } : {}),
     ...(result.unresolved_ignores.length > 0
       ? {
           unresolved_ignores: result.unresolved_ignores,
@@ -1159,7 +1003,7 @@ export const toolDefs: ToolDef[] = [
     name: "check_clearance",
     pack: null,
     description:
-      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at one real pose (joint id or name \u2192 degrees, or mm for sliders) instead of the stored one. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes. Two modes beyond the single-pair snapshot: (1) `sweep` \u2014 pass [{joint, from, to, steps}] to drive the mechanism through its range of motion and report the WORST pose, not the one it was authored in (a linkage modelled at mid-travel routinely clears there and collides at both ends); persisted with the label, so the assertion re-verifies over the same range. (2) audit \u2014 omit `group_a`/`group_b` entirely to broadphase EVERY part pair in the document and list everything that interpenetrates, with penetration depth; whitelist intended contact with `ignore_pairs` (Fixed-joint pairs are skipped by default). Combine both for 'does this machine ever hit itself anywhere in its workspace'.",
+      "Measure the minimum distance between two groups of parts in a CAD session and assert it stays above `min_mm` \u2014 air gaps, press fits, screw-head clearances. Reports the measured minimum (negative = penetration depth), a clear/touching/intersecting verdict, the worst part pair, and pass/fail. Pass `allow_contact: true` for parts designed to touch (e.g. bolted flush) so exact contact passes instead of reading as an intersection. Pass `joint_state` to measure at one real pose (joint id or name \u2192 degrees, or mm for sliders) instead of the stored one. Give it a `label` to persist the assertion on the document: build_receipt then emits it as a mech.clearance claim and verify_receipt re-verifies it as Holds / Stale / Violated when geometry changes. Two modes beyond the single-pair snapshot: (1) `sweep` \u2014 pass [{joint, from, to, steps}] to drive the mechanism through its range of motion and report the WORST pose, not the one it was authored in (a linkage modelled at mid-travel routinely clears there and collides at both ends); persisted with the label, so the assertion re-verifies over the same range. Sweep endpoints beyond a joint's declared limits are reported in `sweep_warnings` rather than clamped, and `include_samples: true` returns the per-pose margin curve as `samples` (one {pose, distance_mm, intersecting} per pose, omitted above 256 poses and never persisted). Swept distances come from the same tessellated meshes, re-placed per pose, so accuracy stays tessellation-bound. (2) audit \u2014 omit `group_a`/`group_b` entirely to broadphase EVERY part pair in the document and list everything that interpenetrates, with penetration depth; whitelist intended contact with `ignore_pairs` (Fixed-joint pairs are skipped by default). Combine both for 'does this machine ever hit itself anywhere in its workspace'.",
     inputSchema: checkClearanceSchema,
     handler: (a, c) => checkClearance(a, c.engine),
     behavior: behavior({ writesDoc: true }),

--- a/packages/mcp/src/tools/measure.ts
+++ b/packages/mcp/src/tools/measure.ts
@@ -28,11 +28,26 @@
  */
 
 import type { ClearanceResult, Engine, TriangleMesh } from "@vcad/engine";
-import { transformMesh } from "@vcad/engine";
-import type { Document } from "@vcad/ir";
+import type { Document, JointSweep, Transform3D } from "@vcad/ir";
 import { computeMeshProperties, type BoundingBox } from "./inspect.js";
 import { getSession } from "./session-core.js";
 import { behavior, type ToolDef } from "./tool-def.js";
+import { applyJointState, jointStateSchemaProp, type PoseInfo } from "./pose.js";
+import {
+  MAX_SWEEP_SAMPLES,
+  parseSweep,
+  placeParts,
+  poseGrid,
+  poseableParts,
+  poseTransforms,
+  resolveSweepAxes,
+  roundPose,
+  sweepSchemaProp,
+  worseThan,
+  type Pose,
+  type PoseablePart,
+  type SweepSample,
+} from "./sweep.js";
 
 /** Round to micron precision so payloads don't carry float noise. */
 const r6 = (v: number) => Math.round(v * 1e6) / 1e6;
@@ -55,44 +70,7 @@ interface ResolvedPart {
  *  placed mesh), skipping hidden roots and empty meshes — mirrors the
  *  clearance tool's part resolution. */
 function evaluateParts(doc: Document, engine: Engine): ResolvedPart[] {
-  const scene = engine.evaluate(doc);
-  const visibleRoots = doc.roots.filter((e) => e.visible !== false);
-  const partMaterials = (doc as { part_materials?: Record<string, string> })
-    .part_materials;
-  const out: ResolvedPart[] = [];
-  for (let i = 0; i < scene.parts.length && i < visibleRoots.length; i++) {
-    const root = visibleRoots[i];
-    const rootId = String(root.root);
-    const mesh = scene.parts[i].mesh;
-    if (!mesh || mesh.positions.length === 0) continue;
-    const node = doc.nodes[rootId];
-    out.push({
-      id: rootId,
-      name: node?.name ?? undefined,
-      material: root.material ?? partMaterials?.[rootId] ?? undefined,
-      mesh,
-    });
-  }
-  // Assembly instances: bake the FK world transform into the part-local mesh
-  // so measurements report poses, not part-local geometry — the same
-  // candidate population check_clearance uses. Without this, assembly-only
-  // documents answered every measure/inspect_part query with "Available: none".
-  for (const inst of scene.instances ?? []) {
-    const mesh = inst.transform
-      ? transformMesh(inst.mesh, {
-          translate: inst.transform.translation,
-          rotate: inst.transform.rotation,
-          scale: inst.transform.scale,
-        })
-      : inst.mesh;
-    if (!mesh || mesh.positions.length === 0) continue;
-    out.push({
-      id: inst.instanceId,
-      name: inst.name ?? undefined,
-      mesh,
-    });
-  }
-  return out;
+  return placeParts(poseableParts(doc, engine));
 }
 
 /** Resolve a part by id first, then by exact name. */
@@ -306,6 +284,125 @@ export function measureResult(
   };
 }
 
+/**
+ * `measure` in sweep mode: the two parts' minimum distance across a whole
+ * range of motion, not the one pose the assembly happens to be stored in.
+ *
+ * The document is evaluated ONCE into re-poseable parts; each pose then costs
+ * one FK solve plus two mesh transforms. The reported `distance_mm` is the
+ * worst case over the grid (interpenetration beats any distance, mirroring
+ * `check_clearance`), and `samples` carries the full margin curve so an agent
+ * can see *where* in the travel the margin collapses rather than only how far.
+ */
+export function measureSweepResult(
+  doc: Document,
+  engine: Engine,
+  partIds: string[],
+  sweep: JointSweep[],
+): Record<string, unknown> {
+  if (partIds.length !== 2) {
+    throw new MeasureError(
+      "`sweep` measures the distance between TWO parts across a range of motion — " +
+        `${partIds.length} part id was given. Pass two \`part_ids\`, or drop \`sweep\` ` +
+        "(a single part's bbox/volume/center of mass is a per-pose property; use " +
+        "`joint_state` to read it at one pose).",
+    );
+  }
+  let base: PoseablePart[];
+  try {
+    base = poseableParts(doc, engine);
+  } catch (e) {
+    throw new MeasureError(e instanceof Error ? e.message : String(e));
+  }
+
+  const pick = (wanted: string): PoseablePart => {
+    const found =
+      base.find((p) => p.id === wanted) ?? base.find((p) => p.name === wanted);
+    if (!found) {
+      const available =
+        base.map((p) => `${p.id}${p.name ? ` (${p.name})` : ""}`).join(", ") || "none";
+      throw new MeasureError(
+        `No part with id or name "${wanted}". Available: ${available}`,
+      );
+    }
+    return found;
+  };
+  const [pa, pb] = partIds.map((id) => pick(String(id)));
+  if (pa.id === pb.id) {
+    throw new MeasureError(
+      `measure needs two distinct parts — "${pa.id}" was given twice.`,
+    );
+  }
+
+  const { axes, warnings, error } = resolveSweepAxes(doc, sweep);
+  if (error || !axes) throw new MeasureError(error ?? "sweep could not be resolved");
+  const poses = poseGrid(axes);
+  let transforms: Array<Map<string, Transform3D>>;
+  try {
+    transforms = poseTransforms(doc, poses);
+  } catch (e) {
+    throw new MeasureError(e instanceof Error ? e.message : String(e));
+  }
+
+  const keepSamples = poses.length <= MAX_SWEEP_SAMPLES;
+  const samples: SweepSample[] = [];
+  let worst:
+    | { r: ClearanceResult; pose: Pose; a: ResolvedPart; b: ResolvedPart }
+    | undefined;
+  for (let i = 0; i < poses.length; i++) {
+    const placed = placeParts([pa, pb], transforms[i]);
+    if (placed.length < 2) {
+      throw new MeasureError(
+        "One of the parts has an empty mesh at some pose — nothing to measure.",
+      );
+    }
+    let r: ClearanceResult;
+    try {
+      r = engine.meshClearance(placed[0].mesh, placed[1].mesh);
+    } catch (e) {
+      throw new MeasureError(e instanceof Error ? e.message : String(e));
+    }
+    if (keepSamples) {
+      samples.push({
+        pose: roundPose(poses[i]),
+        distance_mm: r6(r.distance),
+        intersecting: r.intersecting,
+      });
+    }
+    if (!worst || worseThan(r, worst.r)) {
+      worst = { r, pose: poses[i], a: placed[0], b: placed[1] };
+    }
+  }
+  if (!worst) throw new MeasureError("Sweep produced no poses to measure.");
+
+  const distance = r6(worst.r.distance);
+  return {
+    mode: "sweep",
+    distance_mm: distance,
+    contact: distance <= 0,
+    intersecting: worst.r.intersecting,
+    worst_pose: roundPose(worst.pose),
+    poses_checked: poses.length,
+    sweep: axes,
+    closest_points: {
+      a: worst.r.pointA.map(r6) as [number, number, number],
+      b: worst.r.pointB.map(r6) as [number, number, number],
+    },
+    parts: {
+      a: partSnapshot(worst.a),
+      b: partSnapshot(worst.b),
+    },
+    ...(keepSamples
+      ? { samples }
+      : {
+          samples_omitted: true,
+          samples_note: `Sweep grid is ${poses.length} poses (over the ${MAX_SWEEP_SAMPLES}-pose sample cap) — the per-pose margin curve was omitted. Lower \`steps\` to get it.`,
+        }),
+    ...(warnings && warnings.length > 0 ? { sweep_warnings: warnings } : {}),
+    note: "`distance_mm` is the WORST (minimum) distance over the swept range, not the authored pose; negative means the parts overlap there (penetration depth). `parts` bboxes are those of the worst pose. Measured from evaluated tessellations — accuracy is tessellation-bound. Joint states are restored: a sweep never edits the document.",
+  };
+}
+
 export const measureSchema = {
   type: "object" as const,
   properties: {
@@ -319,6 +416,8 @@ export const measureSchema = {
       description:
         "One or two part ids (or part names). One id → that part's bbox, volume, and center of mass. Two ids → the minimum distance between them (0/negative = contact/overlap) plus each part's bbox.",
     },
+    joint_state: jointStateSchemaProp,
+    sweep: sweepSchemaProp,
   },
   required: ["document_id", "part_ids"],
 } as const;
@@ -340,20 +439,41 @@ export function measure(
       "Pass `part_ids` as an array of one or two part ids (or part names).",
     );
   }
-  let doc: Document;
+  const { sweep, error: sweepParseError } = parseSweep(args.sweep);
+  if (sweepParseError) return err(sweepParseError);
+
+  let stored: Document;
   try {
-    doc = getSession(documentId);
+    stored = getSession(documentId);
   } catch (e) {
     return err(e instanceof Error ? e.message : String(e));
   }
+  // `joint_state` is the base pose, applied to a clone — the session document
+  // is never mutated. A `sweep` then drives its own axes on top of that pose
+  // (overriding the base state for the joints it names) and restores them.
+  let doc: Document;
+  let pose: PoseInfo | undefined;
+  try {
+    ({ doc, pose } = applyJointState(stored, args.joint_state));
+  } catch (e) {
+    return err(e instanceof Error ? e.message : String(e));
+  }
+
   let payload: Record<string, unknown>;
   try {
-    payload = measureResult(doc, engine, partIds);
+    payload =
+      sweep && sweep.length > 0
+        ? measureSweepResult(doc, engine, partIds, sweep)
+        : measureResult(doc, engine, partIds);
   } catch (e) {
     if (e instanceof MeasureError) return err(e.message);
     throw e;
   }
-  const body = { document_id: documentId, ...payload };
+  const body = {
+    document_id: documentId,
+    ...(pose ? { pose } : {}),
+    ...payload,
+  };
   return {
     content: [{ type: "text" as const, text: JSON.stringify(body) }],
     structuredContent: { measure: body, document_id: documentId },
@@ -372,7 +492,7 @@ export const toolDefs: ToolDef[] = [
     name: "measure",
     pack: null,
     description:
-      "Measure geometry in an open session. Pass `part_ids` with two ids to get the minimum distance between those parts (0/negative = contact/overlap) plus each part's world-space bounding box; pass one id to get that part's bbox, volume, and center of mass. Complements `inspect_cad` (whole-document aggregate) and `check_clearance` (named, persisted air-gap assertions). Distances are measured from evaluated tessellations, so accuracy is tessellation-bound.",
+      "Measure geometry in an open session. Pass `part_ids` with two ids to get the minimum distance between those parts (0/negative = contact/overlap) plus each part's world-space bounding box; pass one id to get that part's bbox, volume, and center of mass. Pass `joint_state` (joint id or name → degrees, mm for sliders) to measure a jointed assembly at one real pose instead of the stored one. Pass `sweep` — [{joint, from, to, steps}] — with TWO part ids to drive the mechanism through its range of motion and get the WORST (minimum) distance over the whole travel, the pose that realizes it (`worst_pose`), and `samples`: the full per-pose margin curve, so you can see where the clearance collapses rather than only that it does (omitted above 256 poses). Sweep endpoints outside a joint's declared limits are reported in `sweep_warnings`, not clamped; joint states are always restored, so a sweep never edits the document. Complements `inspect_cad` (whole-document aggregate) and `check_clearance` (named, persisted air-gap assertions with pass/fail and whole-document audits). Distances are measured from evaluated tessellations — swept poses re-place those same meshes — so accuracy is tessellation-bound.",
     inputSchema: measureSchema,
     handler: (a, c) => measure(a, c.engine),
     behavior: behavior({}),

--- a/packages/mcp/src/tools/sweep.ts
+++ b/packages/mcp/src/tools/sweep.ts
@@ -1,0 +1,315 @@
+/**
+ * Joint-sweep machinery shared by `check_clearance` and `measure`.
+ *
+ * A sweep drives one or more joints across their travel, re-solves forward
+ * kinematics per pose, and re-places the already-evaluated part meshes — so a
+ * range-of-motion question costs one BRep evaluation plus one mesh transform
+ * per part per pose, not a full re-evaluation. Joint states are restored
+ * afterwards: a sweep is a question, never an edit.
+ *
+ * This module owns the pieces both tools need (pose grid, FK per pose,
+ * re-poseable parts, argument parsing and the shared JSON-schema fragment);
+ * `clearance.ts` re-exports the ones its callers already imported.
+ */
+
+import type { Document, JointSweep, Transform3D } from "@vcad/ir";
+import type { Engine, TriangleMesh } from "@vcad/engine";
+import { solveForwardKinematics, transformMesh } from "@vcad/engine";
+
+/** One sampled configuration of the mechanism: joint id → state. */
+export type Pose = Array<{ joint: string; state: number }>;
+
+/**
+ * Ceiling on the pose grid a single query may span. A sweep is O(poses ×
+ * pairs × BVH query); silently truncating would report a clearance the
+ * machine never proved, so an oversized grid is an error, not a sample.
+ */
+export const MAX_SWEEP_POSES = 4096;
+
+/**
+ * Per-pose sample payloads above this size are omitted — the margin curve is
+ * a debugging aid, not a reason to ship a megabyte of JSON to a model.
+ */
+export const MAX_SWEEP_SAMPLES = 256;
+
+/** Round values so payloads don't carry float noise. */
+export const round6 = (v: number) => Math.round(v * 1e6) / 1e6;
+
+/** Is measurement `a` worse than `b`? Interpenetration beats any distance. */
+export function worseThan(
+  a: { distance: number; intersecting: boolean },
+  b: { distance: number; intersecting: boolean },
+): boolean {
+  if (a.intersecting !== b.intersecting) return a.intersecting;
+  return a.distance < b.distance;
+}
+
+/** One pose of a swept query, with the distance measured there. */
+export interface SweepSample {
+  pose: Pose;
+  distance_mm: number;
+  intersecting: boolean;
+}
+
+/** JSON-schema fragment for the `sweep` argument, shared by every tool that
+ *  accepts a range-of-motion query so the wording stays identical. */
+export const sweepSchemaProp = {
+  type: "array" as const,
+  description:
+    "Range-of-motion sweep: drive these joints across their travel and report the WORST pose, not the authored one. Each axis is {joint, from, to, steps}; multiple axes form a Cartesian grid (capped at 4096 poses). Endpoints outside a joint's declared limits are reported as warnings, not clamped. Joint states are restored afterwards — the sweep never edits the document.",
+  items: {
+    type: "object" as const,
+    properties: {
+      joint: { type: "string" as const, description: "Joint id or name to drive." },
+      from: {
+        type: "number" as const,
+        description: "Start of travel (degrees for revolute, mm for prismatic).",
+      },
+      to: { type: "number" as const, description: "End of travel." },
+      steps: {
+        type: "number" as const,
+        description: "Number of intervals; steps + 1 poses are sampled.",
+      },
+    },
+    required: ["joint", "from", "to", "steps"],
+  },
+};
+
+/** Parse the `sweep` argument into typed axes (undefined when absent). */
+export function parseSweep(raw: unknown): { sweep?: JointSweep[]; error?: string } {
+  if (raw === undefined || raw === null) return {};
+  if (!Array.isArray(raw)) {
+    return { error: "`sweep` must be an array of {joint, from, to, steps} axes." };
+  }
+  const sweep: JointSweep[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object") {
+      return { error: "Each `sweep` axis must be an object {joint, from, to, steps}." };
+    }
+    const e = entry as Record<string, unknown>;
+    const joint = typeof e.joint === "string" ? e.joint.trim() : "";
+    const from = Number(e.from);
+    const to = Number(e.to);
+    const steps = Number(e.steps);
+    if (!joint || !Number.isFinite(from) || !Number.isFinite(to) || !Number.isFinite(steps)) {
+      return {
+        error: "Each `sweep` axis needs a `joint` id/name plus numeric `from`, `to`, and `steps`.",
+      };
+    }
+    sweep.push({ joint, from, to, steps });
+  }
+  return sweep.length > 0 ? { sweep } : {};
+}
+
+/** Declared travel limits of a joint, when it has any. */
+function jointLimits(kind: unknown): [number, number] | undefined {
+  const k = kind as { type?: string; limits?: [number, number] } | undefined;
+  if (!k) return undefined;
+  if (k.type === "Revolute" || k.type === "Slider") return k.limits;
+  return undefined;
+}
+
+/** Unit label for a joint's state, for readable warnings. */
+function jointUnit(kind: unknown): string {
+  return (kind as { type?: string } | undefined)?.type === "Slider" ? "mm" : "deg";
+}
+
+/**
+ * Resolve sweep axes against the document's joints (by id, then by name).
+ *
+ * Endpoints beyond a joint's declared limits are a **warning**, not an error
+ * and not a clamp: an agent exploring travel it hasn't finalized still wants
+ * the numbers, but must be told the machine cannot actually reach them.
+ */
+export function resolveSweepAxes(
+  doc: Document,
+  axes: JointSweep[],
+): { axes?: JointSweep[]; warnings?: string[]; error?: string } {
+  const joints = doc.joints ?? [];
+  const resolved: JointSweep[] = [];
+  const warnings: string[] = [];
+  for (const axis of axes) {
+    const wanted = String(axis.joint);
+    const found =
+      joints.find((j) => j.id === wanted) ?? joints.find((j) => j.name === wanted);
+    if (!found) {
+      const available = joints.map((j) => `${j.id}${j.name ? ` (${j.name})` : ""}`).join(", ");
+      return { error: `No joint with id or name "${wanted}". Available: ${available || "none"}` };
+    }
+    if (!Number.isFinite(axis.from) || !Number.isFinite(axis.to)) {
+      return { error: `Sweep axis "${wanted}" needs finite \`from\` and \`to\`.` };
+    }
+    const steps = Math.trunc(axis.steps);
+    if (!Number.isFinite(steps) || steps < 1) {
+      return { error: `Sweep axis "${wanted}" needs \`steps\` >= 1.` };
+    }
+    const limits = jointLimits(found.kind);
+    if (limits) {
+      const [lo, hi] = limits;
+      const lowest = Math.min(axis.from, axis.to);
+      const highest = Math.max(axis.from, axis.to);
+      if (lowest < lo || highest > hi) {
+        warnings.push(
+          `sweep axis "${found.id}"${found.name ? ` ("${found.name}")` : ""} spans ` +
+            `[${lowest}, ${highest}] ${jointUnit(found.kind)}, outside its declared limits ` +
+            `[${lo}, ${hi}] — the swept range includes poses the joint cannot reach, so the ` +
+            `reported worst case may not be physically attainable.`,
+        );
+      }
+    }
+    resolved.push({ joint: found.id, from: axis.from, to: axis.to, steps });
+  }
+  if (resolved.length === 0) return { error: "`sweep` needs at least one joint axis." };
+  const total = resolved.reduce((n, a) => n * (a.steps + 1), 1);
+  if (total > MAX_SWEEP_POSES) {
+    return {
+      error: `Sweep grid is ${total} poses (limit ${MAX_SWEEP_POSES}). Lower \`steps\` or sweep fewer joints at once.`,
+    };
+  }
+  return { axes: resolved, ...(warnings.length > 0 ? { warnings } : {}) };
+}
+
+/** Cartesian product of the axes: `steps + 1` samples each, endpoints included. */
+export function poseGrid(axes: JointSweep[]): Pose[] {
+  let poses: Pose[] = [[]];
+  for (const axis of axes) {
+    const n = Math.trunc(axis.steps);
+    const next: Pose[] = [];
+    for (const pose of poses) {
+      for (let i = 0; i <= n; i++) {
+        const state = axis.from + ((axis.to - axis.from) * i) / n;
+        next.push([...pose, { joint: axis.joint, state }]);
+      }
+    }
+    poses = next;
+  }
+  return poses;
+}
+
+/** Round a pose's states for the payload. */
+export function roundPose(pose: Pose): Pose {
+  return pose.map((p) => ({ joint: p.joint, state: round6(p.state) }));
+}
+
+/**
+ * Solve forward kinematics once per pose. Joint states are driven on the
+ * document and restored afterwards, so the session is left exactly as the
+ * author posed it — a sweep is a question, not an edit.
+ */
+export function poseTransforms(
+  doc: Document,
+  poses: Pose[],
+): Array<Map<string, Transform3D>> {
+  const joints = doc.joints ?? [];
+  const byId = new Map(joints.map((j) => [j.id, j] as const));
+  const saved = joints.map((j) => j.state);
+  try {
+    return poses.map((pose) => {
+      for (const { joint, state } of pose) {
+        const j = byId.get(joint);
+        if (j) j.state = state;
+      }
+      return solveForwardKinematics(doc);
+    });
+  } finally {
+    joints.forEach((j, i) => {
+      j.state = saved[i];
+    });
+  }
+}
+
+/**
+ * A part as evaluated once, kept re-poseable: static roots carry their world
+ * mesh directly, assembly instances carry the *part-local* mesh plus the
+ * world transform of the pose they were evaluated in. Sweeping then costs one
+ * mesh transform per pose instead of one full BRep evaluation.
+ */
+export interface PoseablePart {
+  id: string;
+  name?: string;
+  material?: string;
+  /** Part-local mesh for instances; already-world mesh for static roots. */
+  localMesh: TriangleMesh;
+  /** World transform for instances; absent for static roots. */
+  transform?: Transform3D;
+  /** Instance id, when this part is an assembly instance (drives re-posing). */
+  instanceId?: string;
+}
+
+/** A part resolved to its evaluated (already-placed) mesh. */
+export interface PlacedPart {
+  id: string;
+  name?: string;
+  material?: string;
+  mesh: TriangleMesh;
+}
+
+/** Bake a world transform into a part-local mesh. */
+export function placeMesh(mesh: TriangleMesh, transform?: Transform3D): TriangleMesh {
+  if (!transform) return mesh;
+  return transformMesh(mesh, {
+    translate: transform.translation,
+    rotate: transform.rotation,
+    scale: transform.scale,
+  });
+}
+
+/** Evaluate a CAD session once into re-poseable parts. */
+export function poseableParts(doc: Document, engine: Engine): PoseablePart[] {
+  const scene = engine.evaluate(doc);
+  const visibleRoots = doc.roots.filter((e) => e.visible !== false);
+  const partMaterials = (doc as { part_materials?: Record<string, string> }).part_materials;
+  const out: PoseablePart[] = [];
+  for (let i = 0; i < scene.parts.length && i < visibleRoots.length; i++) {
+    const root = visibleRoots[i];
+    const rootId = String(root.root);
+    const node = doc.nodes[rootId];
+    const mesh = scene.parts[i].mesh;
+    if (!mesh || mesh.positions.length === 0) continue;
+    out.push({
+      id: rootId,
+      name: node?.name ?? undefined,
+      material: root.material ?? partMaterials?.[rootId] ?? undefined,
+      localMesh: mesh,
+    });
+  }
+  // Assembly instances: bake the FK world transform into the part-local mesh
+  // so measurements report poses, not part-local geometry. Without this,
+  // assembly-only documents had no candidates at all.
+  for (const inst of scene.instances ?? []) {
+    if (!inst.mesh || inst.mesh.positions.length === 0) continue;
+    out.push({
+      id: inst.instanceId,
+      name: inst.name ?? undefined,
+      localMesh: inst.mesh,
+      transform: inst.transform ?? undefined,
+      instanceId: inst.instanceId,
+    });
+  }
+  return out;
+}
+
+/**
+ * Place every part for one pose. `worldTransforms` (from a re-solved FK pass)
+ * overrides the evaluated transform for instances it names; static roots are
+ * pose-independent and pass through.
+ */
+export function placeParts(
+  parts: PoseablePart[],
+  worldTransforms?: Map<string, Transform3D>,
+): PlacedPart[] {
+  const out: PlacedPart[] = [];
+  for (const p of parts) {
+    const transform =
+      (p.instanceId ? worldTransforms?.get(p.instanceId) : undefined) ?? p.transform;
+    const mesh = placeMesh(p.localMesh, transform);
+    if (!mesh || mesh.positions.length === 0) continue;
+    out.push({
+      id: p.id,
+      ...(p.name ? { name: p.name } : {}),
+      ...(p.material ? { material: p.material } : {}),
+      mesh,
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Adds a joint-sweep mode to the MCP `measure` tool and margin-curve output to `check_clearance`, so "does the nozzle clear the flanges at EVERY spindle angle" is one call instead of manual re-pose + re-measure per pose.

- **`measure`**: new optional `joint_state` (base pose, id-or-name keyed, clamped with warnings) and `sweep` (`[{joint, from, to, steps}]`, 1–2 axes → Cartesian grid, 4096-pose cap). Two-part mode only; returns minimum `distance_mm`, argmin `worst_pose`, `poses_checked`, closest points, and a per-pose `samples` margin curve (omitted with a note above 256 poses). Accuracy remains tessellation-bound and is documented as such.
- **`check_clearance`**: new `include_samples` flag returns the same per-pose margin curve on swept checks; samples are never persisted into the spec or receipt. Persisted sweep specs already re-verify across the stored grid on `verify_receipt` (existing behavior, unchanged).
- **Shared machinery**: sweep helpers (`resolveSweepAxes`, `poseGrid`, `poseTransforms`, poseable-part model) extracted from `clearance.ts` into `packages/mcp/src/tools/sweep.ts`; `resolveSweepAxes` now warns (no clamp, no error) when sweep endpoints exceed a joint's declared limits.

## Why

Motivating case: a coil winder where a nozzle tip must clear rotating cheek flanges by ~2 mm across the full spindle × traverse envelope. Static measures at the modeled pose can't guarantee non-modeled poses, and trusting "it's a surface of revolution" is exactly the assumption this replaces with a measurement.

## Validation

End-to-end on the real fixture (purl `stack-anim.loon`, `stack-trav-nozzle` vs `stack-cheeks`, A=0..360×15° × Y=-5..+5×2.5 mm, 125 poses): minimum **1.900 mm at A=90°, Y=-5** vs 2.000 mm at the authored pose; a 6× finer grid (803 poses) reproduces the minimum to 1e-6. Cost ~6 ms/pose after one-time evaluation (poses re-place meshes, no BRep re-eval).

## Tests

`npm test -w @vcad/mcp`: 1144 passed, 0 failed (+13 new: known-argmin revolute fixture, sample cap, joint-state restoration, sweep-with-one-part refusal, limit warnings, include_samples not persisted). Full workspace build + tsc clean. Tool-surface fixture regenerated; changelog entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)