### PR TITLE
render: --animate without --photoreal (drafting + raytrace tiers, fixed union framing)

### DIFF
--- a/changelog/entries/2026-08-25-animate-drafting-style.json
+++ b/changelog/entries/2026-08-25-animate-drafting-style.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-25-animate-drafting-style",
+  "version": "0.9.4",
+  "date": "2026-08-25",
+  "category": "feat",
+  "title": "Animate in any style, not just photoreal",
+  "summary": "vcad-render --animate now works without --photoreal: drafting line art by default, --raytrace as a middle tier, with one camera pinned across the whole sequence.",
+  "details": "--animate used to require --photoreal, so the cheapest and most legible style — the default drafting line art — could not be animated at all, and a sequence meant tens of seconds a frame. It is now a style-agnostic path: the front half (resolve the timeline, evaluate the document exactly once, sample the sequence, bake one pose vector per frame) is shared, and three back ends turn a pose into pixels — drafting (default), --raytrace, and --photoreal. The drafting tier tessellates each part once and only re-poses the cached meshes per frame, which puts a 37-part machine at ~0.35 s a frame instead of minutes. Every tier now frames its camera once, on the union of all posed bounds, and hands that same framing to every frame, so all PNGs share one canvas size and scale and the assembly no longer swims about; --auto-aspect resolves once against that union. --trim is refused with --animate (a per-frame crop is per-frame sizing, the drift the shared camera prevents) and names the flag to drop.",
+  "features": ["rendering", "animation", "assemblies", "joints", "cli"]
+}

--- a/crates/termview/src/terminal.rs
+++ b/crates/termview/src/terminal.rs
@@ -160,11 +160,7 @@ impl TerminalCaps {
         }
 
         // Check for explicit SIXEL environment hint
-        if env::var("TERM_SIXEL").is_ok() {
-            return true;
-        }
-
-        false
+        env::var("TERM_SIXEL").is_ok()
     }
 
     fn kitty_with_tmux(in_tmux: bool) -> Self {

--- a/crates/vcad-ecad-pcb/src/router/grid.rs
+++ b/crates/vcad-ecad-pcb/src/router/grid.rs
@@ -64,10 +64,8 @@ impl GridRouter {
         let x1 = ((max.x / self.resolution).ceil() as usize).min(self.width);
         let y1 = ((max.y / self.resolution).ceil() as usize).min(self.height);
 
-        for x in x0..x1 {
-            for y in y0..y1 {
-                self.grid[x][y] = CellState::Blocked;
-            }
+        for col in &mut self.grid[x0..x1] {
+            col[y0..y1].fill(CellState::Blocked);
         }
     }
 
@@ -81,10 +79,10 @@ impl GridRouter {
         let x1 = ((max.x / self.resolution).ceil() as usize).min(self.width);
         let y1 = ((max.y / self.resolution).ceil() as usize).min(self.height);
 
-        for x in x0..x1 {
-            for y in y0..y1 {
-                if self.grid[x][y] == CellState::Empty {
-                    self.grid[x][y] = CellState::Occupied(net_id);
+        for col in &mut self.grid[x0..x1] {
+            for cell in &mut col[y0..y1] {
+                if *cell == CellState::Empty {
+                    *cell = CellState::Occupied(net_id);
                 }
             }
         }

--- a/crates/vcad-kernel-acoustics/src/linalg.rs
+++ b/crates/vcad-kernel-acoustics/src/linalg.rs
@@ -86,8 +86,8 @@ impl Lu {
         assert_eq!(b.len(), n);
         let mut x = b.to_vec();
         // Apply the row permutation.
-        for k in 0..n {
-            x.swap(k, self.piv[k]);
+        for (k, &pk) in self.piv.iter().enumerate() {
+            x.swap(k, pk);
         }
         // Forward substitution (unit lower L).
         for i in 0..n {

--- a/crates/vcad-kernel-nurbs/src/lib.rs
+++ b/crates/vcad-kernel-nurbs/src/lib.rs
@@ -223,9 +223,7 @@ impl BSplineCurve {
         let mut new_pts = Vec::with_capacity(self.control_points.len() + 1);
 
         // Points before the affected range
-        for i in 0..=(span.saturating_sub(p)) {
-            new_pts.push(self.control_points[i]);
-        }
+        new_pts.extend_from_slice(&self.control_points[..=span.saturating_sub(p)]);
 
         // Affected points
         for i in (span - p + 1)..=span {
@@ -239,9 +237,7 @@ impl BSplineCurve {
         }
 
         // Points after the affected range
-        for i in span..=n {
-            new_pts.push(self.control_points[i]);
-        }
+        new_pts.extend_from_slice(&self.control_points[span..=n]);
 
         Self::new(new_pts, new_knots, p)
     }
@@ -682,9 +678,7 @@ impl NurbsCurve {
         // New control points — interpolate in homogeneous space
         let mut new_pts = Vec::with_capacity(self.control_points.len() + 1);
 
-        for i in 0..=(span.saturating_sub(p)) {
-            new_pts.push(self.control_points[i]);
-        }
+        new_pts.extend_from_slice(&self.control_points[..=span.saturating_sub(p)]);
 
         for i in (span - p + 1)..=span {
             let alpha = (t - self.knots[i]) / (self.knots[i + p] - self.knots[i]);
@@ -699,9 +693,7 @@ impl NurbsCurve {
             new_pts.push(WeightedPoint::from_homogeneous(h_new));
         }
 
-        for i in span..=n {
-            new_pts.push(self.control_points[i]);
-        }
+        new_pts.extend_from_slice(&self.control_points[span..=n]);
 
         Self::new(new_pts, new_knots, p)
     }

--- a/crates/vcad-kernel-qcd/src/su3.rs
+++ b/crates/vcad-kernel-qcd/src/su3.rs
@@ -207,9 +207,9 @@ impl GaugeGroup for Su3 {
 
     fn scale(&self, s: f64) -> Self {
         let mut r = *self;
-        for i in 0..3 {
-            for j in 0..3 {
-                r.m[i][j] = r.m[i][j].scale(s);
+        for row in r.m.iter_mut() {
+            for c in row.iter_mut() {
+                *c = c.scale(s);
             }
         }
         r
@@ -232,8 +232,8 @@ impl GaugeGroup for Su3 {
         if n0 <= 0.0 {
             return Su3::identity_();
         }
-        for j in 0..3 {
-            r.m[0][j] = r.m[0][j].scale(1.0 / n0);
+        for c in r.m[0].iter_mut() {
+            *c = c.scale(1.0 / n0);
         }
         // Orthogonalize row 1 against row 0, then normalize.
         let mut dot = C::ZERO; // <row0, row1> = Σ conj(r0)·r1
@@ -247,8 +247,8 @@ impl GaugeGroup for Su3 {
         if n1 <= 0.0 {
             return Su3::identity_();
         }
-        for j in 0..3 {
-            r.m[1][j] = r.m[1][j].scale(1.0 / n1);
+        for c in r.m[1].iter_mut() {
+            *c = c.scale(1.0 / n1);
         }
         // Row 2 = conj(row0 × row1).
         for j in 0..3 {

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -6039,9 +6039,7 @@ pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
         while mesh.face_kinds.len() < post_face_tris {
             mesh.face_kinds.push(FaceKindTag::Unknown as u8);
         }
-        for t in pre_face_tris..post_face_tris {
-            mesh.face_kinds[t] = face_kind_tag;
-        }
+        mesh.face_kinds[pre_face_tris..post_face_tris].fill(face_kind_tag);
     }
 
     weld_coincident_vertices(&mut mesh);

--- a/crates/vcad-render/src/animate.rs
+++ b/crates/vcad-render/src/animate.rs
@@ -486,7 +486,7 @@ fn freeze(solid: &Solid, segments: u32) -> Solid {
 #[cfg(feature = "raster")]
 fn accumulate_verts(fb: &mut crate::FramingBuilder, solid: &Solid, t: &KTransform) {
     let mesh = solid.to_mesh(0); // mesh-backed: a clone, not a tessellation
-    for c in mesh.vertices.chunks_exact(3) {
+    for c in mesh.vertices.as_chunks::<3>().0 {
         let p = t.apply_point(&vcad_kernel::vcad_kernel_math::Point3::new(
             c[0] as f64,
             c[1] as f64,
@@ -509,7 +509,7 @@ fn solid_bbox_corners(solid: &Solid) -> [[f64; 3]; 8] {
     let mesh = solid.to_mesh(crate::TESSELLATION_SEGMENTS);
     let mut lo = [f64::INFINITY; 3];
     let mut hi = [f64::NEG_INFINITY; 3];
-    for c in mesh.vertices.chunks_exact(3) {
+    for c in mesh.vertices.as_chunks::<3>().0 {
         for i in 0..3 {
             lo[i] = lo[i].min(c[i] as f64);
             hi[i] = hi[i].max(c[i] as f64);

--- a/crates/vcad-render/src/animate.rs
+++ b/crates/vcad-render/src/animate.rs
@@ -1,4 +1,4 @@
-//! Batch (animation) rendering for the photoreal path.
+//! Batch (animation) rendering: photoreal, ray-traced, and drafting.
 //!
 //! A jointed assembly posed over time is, geometrically, the *same* parts in
 //! different places. The expensive half of a photoreal render — evaluating
@@ -12,6 +12,21 @@
 //! and shell out to the renderer N times, paying the full evaluation cost
 //! every frame. On a 35-part machine at 640px/16spp that was ~55 s a frame
 //! against ~10 s of actual tracing.
+//!
+//! That argument is about *geometry*, not about shading, so the same
+//! front half serves all three styles: the drafting line-art raster
+//! ([`render_drafting_animation`], the default), direct BRep ray tracing
+//! ([`render_raytrace_animation`]), and the path tracer
+//! ([`render_photoreal_animation`]). [`plan_animation`] is that front half —
+//! resolve the timeline, evaluate once, sample the sequence, bake one pose
+//! vector per frame — and each back end differs only in how it turns a pose
+//! into pixels.
+//!
+//! Every back end frames its camera on the union of all posed bounds, once,
+//! and hands that same framing to every frame (see
+//! [`crate::FixedFraming`]). Framing per frame would resize the canvas as
+//! the subject's projected extent changed — frames that no muxer will accept
+//! and, even at a fixed size, a machine that swims about in the canvas.
 //!
 //! The pose source is the document's own [`Timeline`] when it has one, or a
 //! keyframe file passed to `--animate`. Both are sampled by
@@ -30,6 +45,7 @@ use crate::photoreal::{
 };
 use crate::raster::encode_png;
 use crate::RasterOptions;
+use vcad_kernel::Solid;
 
 /// What to render, and where to put it.
 #[derive(Debug, Clone)]
@@ -173,23 +189,26 @@ fn resolve_joint<'a>(
     ))
 }
 
-/// Render a jointed assembly over a timeline, evaluating geometry once.
-///
-/// Writes `frame_0000.png` … into `an.out_dir` and reports what each stage
-/// cost. `progress` is called after every frame with `(index, total,
-/// elapsed)` so a CLI can stream timings.
-pub fn render_photoreal_animation(
-    raw_vcad: &str,
-    opts: &RasterOptions,
-    pr: &PhotorealOptions,
-    an: &AnimateOptions,
-    progress: &mut dyn FnMut(usize, usize, Duration),
-) -> Result<AnimateReport, String> {
-    check_raster_opts(opts)?;
+/// A document evaluated once and posed for every frame — everything the
+/// three back ends share, and the reason none of them re-evaluates geometry.
+struct AnimationPlan {
+    /// Static scene roots, already world-placed. Never move.
+    statics: Vec<crate::SceneSolid>,
+    /// Assembly instances in their *local* frame, in pose-vector order.
+    parts: Vec<crate::SceneSolid>,
+    /// `poses[frame][part]` — the object→world transform for `parts[part]`.
+    poses: Vec<Vec<vcad_kernel::vcad_kernel_math::Transform>>,
+    /// Effective frame rate (the timeline's, or the `--fps` override).
+    fps: f64,
+    /// What the single evaluation cost.
+    eval: Duration,
+}
 
+/// Resolve the timeline, evaluate the document **once**, and bake one pose
+/// vector per frame. The style-agnostic half of every animation render.
+fn plan_animation(raw_vcad: &str, an: &AnimateOptions) -> Result<AnimationPlan, String> {
     // ── evaluate, exactly once ───────────────────────────────────────────
     let t_eval = Instant::now();
-    let evals_before = crate::document_eval_count();
     let mut ev = crate::evaluate_vcad_document(raw_vcad)?;
     let eval = t_eval.elapsed();
 
@@ -231,29 +250,11 @@ pub fn render_photoreal_animation(
             .to_string());
     }
 
-    let t_setup = Instant::now();
-
-    // ── one BLAS per part, built once ────────────────────────────────────
-    // Static scene roots first (their transforms never change), then the
-    // assembly instances, whose object→world transform is rewritten per
-    // frame.
-    let mut objects = build_objects(&ev.statics, pr.mesh_segments()).unwrap_or_default();
-    let static_count = objects.len();
-
     let part_solids: Vec<crate::SceneSolid> = std::mem::take(&mut ev.parts)
         .into_iter()
         .map(crate::part_as_local_scene_solid)
         .collect();
     let instance_ids: Vec<String> = part_solids.iter().map(|s| s.id.clone()).collect();
-    objects.extend(build_objects(&part_solids, pr.mesh_segments())?);
-    let articulated = objects.len() - static_count;
-    // build_objects fails closed on untraceable parts, so counts can only
-    // agree here; keep the invariant visible without implying a live branch.
-    debug_assert_eq!(
-        articulated,
-        instance_ids.len(),
-        "build_objects returned fewer objects than instances without erroring"
-    );
 
     // ── sample the timeline, and pose every frame up front ───────────────
     let mut sequence = timeline.sample_sequence();
@@ -306,6 +307,56 @@ pub fn render_photoreal_animation(
         );
     }
 
+    Ok(AnimationPlan {
+        statics: std::mem::take(&mut ev.statics),
+        parts: part_solids,
+        poses,
+        fps: timeline.fps,
+        eval,
+    })
+}
+
+/// Render a jointed assembly over a timeline, evaluating geometry once.
+///
+/// Writes `frame_0000.png` … into `an.out_dir` and reports what each stage
+/// cost. `progress` is called after every frame with `(index, total,
+/// elapsed)` so a CLI can stream timings.
+pub fn render_photoreal_animation(
+    raw_vcad: &str,
+    opts: &RasterOptions,
+    pr: &PhotorealOptions,
+    an: &AnimateOptions,
+    progress: &mut dyn FnMut(usize, usize, Duration),
+) -> Result<AnimateReport, String> {
+    check_raster_opts(opts)?;
+    let evals_before = crate::document_eval_count();
+    let plan = plan_animation(raw_vcad, an)?;
+    let AnimationPlan {
+        statics,
+        parts: part_solids,
+        poses,
+        fps,
+        eval,
+    } = plan;
+
+    let t_setup = Instant::now();
+
+    // ── one BLAS per part, built once ────────────────────────────────────
+    // Static scene roots first (their transforms never change), then the
+    // assembly instances, whose object→world transform is rewritten per
+    // frame.
+    let mut objects = build_objects(&statics, pr.mesh_segments()).unwrap_or_default();
+    let static_count = objects.len();
+    objects.extend(build_objects(&part_solids, pr.mesh_segments())?);
+    let articulated = objects.len() - static_count;
+    // build_objects fails closed on untraceable parts, so counts can only
+    // agree here; keep the invariant visible without implying a live branch.
+    debug_assert_eq!(
+        articulated,
+        part_solids.len(),
+        "build_objects returned fewer objects than instances without erroring"
+    );
+
     // ── frame the camera on the union of every pose ──────────────────────
     // A per-frame fit would make the machine swim about in the canvas; the
     // union keeps the camera locked and nothing ever leaves the frame.
@@ -328,16 +379,16 @@ pub fn render_photoreal_animation(
 
     // ── trace ────────────────────────────────────────────────────────────
     let mut report = AnimateReport {
-        frames: Vec::with_capacity(sequence.len()),
-        fps: timeline.fps,
+        frames: Vec::with_capacity(poses.len()),
+        fps,
         eval,
         setup,
-        per_frame: Vec::with_capacity(sequence.len()),
+        per_frame: Vec::with_capacity(poses.len()),
         parts: objects.len(),
         articulated,
     };
 
-    let total = sequence.len();
+    let total = poses.len();
     // `Scene` owns its objects, so hand it a fresh vector each frame built
     // from the same `Arc<Bvh>` handles — an Arc bump per part, not a rebuild.
     let blueprint: Vec<(std::sync::Arc<vcad_kernel_raytrace::Bvh>, _)> = objects
@@ -384,6 +435,301 @@ pub fn render_photoreal_animation(
     Ok(report)
 }
 
+/// Options the raster animation tiers cannot honour, refused up front with
+/// the flag to drop.
+///
+/// `--trim` is the interesting one: it crops each frame to the drawn
+/// content, which for a moving subject is a *different* crop every frame —
+/// exactly the size drift a fixed camera exists to prevent. There is no
+/// silently-correct interpretation, so it is refused rather than quietly
+/// ignored.
+fn check_animation_raster_opts(opts: &RasterOptions, tier: &str) -> Result<(), String> {
+    if opts.size_px < 16 {
+        return Err("size_px too small".to_string());
+    }
+    if !(opts.fill_frac > 0.0 && opts.fill_frac <= 1.0) {
+        return Err("fill_frac must be in (0, 1]".to_string());
+    }
+    if opts.trim_margin_px.is_some() {
+        return Err(format!(
+            "--trim does not compose with --animate: it crops each frame to \
+             its own content, so a moving subject would give every frame a \
+             different size. Drop --trim (use --auto-aspect, which the {tier} \
+             animation resolves once against the whole sequence)."
+        ));
+    }
+    if opts.focus.is_some() {
+        return Err(
+            "--focus does not compose with --animate: the camera is framed \
+             once on the whole posed sequence, so a per-part frame would be \
+             overwritten. Drop --focus."
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+/// Freeze a solid at `segments` into a mesh-backed solid.
+///
+/// The animation draws the same geometry in a new place every frame, so
+/// tessellating inside the frame loop would pay the BRep→triangles cost N
+/// times over for an identical result. A mesh-backed solid renders
+/// identically to the BRep it came from *at the same segment count* (the
+/// invariant the root-mesh cache already relies on), and its
+/// `apply_transform` is a vertex walk rather than a surface rebuild.
+#[cfg(feature = "raster")]
+fn freeze(solid: &Solid, segments: u32) -> Solid {
+    Solid::from_mesh(solid.to_mesh(segments))
+}
+
+/// Fold every vertex of `solid`, transformed by `t`, into `fb`.
+#[cfg(feature = "raster")]
+fn accumulate_verts(fb: &mut crate::FramingBuilder, solid: &Solid, t: &KTransform) {
+    let mesh = solid.to_mesh(0); // mesh-backed: a clone, not a tessellation
+    for c in mesh.vertices.chunks_exact(3) {
+        let p = t.apply_point(&vcad_kernel::vcad_kernel_math::Point3::new(
+            c[0] as f64,
+            c[1] as f64,
+            c[2] as f64,
+        ));
+        fb.add([p.x, p.y, p.z]);
+    }
+}
+
+/// Kernel rigid transform — the pose type the FK solver hands back.
+type KTransform = vcad_kernel::vcad_kernel_math::Transform;
+
+/// The eight corners of a solid's axis-aligned bounds, in its own frame.
+///
+/// A degenerate (empty) solid yields eight copies of the origin, which the
+/// framing builder folds in harmlessly; `FramingBuilder::finish` is what
+/// fails closed when *nothing* has extent.
+#[cfg(feature = "raytrace")]
+fn solid_bbox_corners(solid: &Solid) -> [[f64; 3]; 8] {
+    let mesh = solid.to_mesh(crate::TESSELLATION_SEGMENTS);
+    let mut lo = [f64::INFINITY; 3];
+    let mut hi = [f64::NEG_INFINITY; 3];
+    for c in mesh.vertices.chunks_exact(3) {
+        for i in 0..3 {
+            lo[i] = lo[i].min(c[i] as f64);
+            hi[i] = hi[i].max(c[i] as f64);
+        }
+    }
+    if !lo.iter().all(|v| v.is_finite()) {
+        return [[0.0; 3]; 8];
+    }
+    std::array::from_fn(|k| {
+        [
+            if k & 1 == 0 { lo[0] } else { hi[0] },
+            if k & 2 == 0 { lo[1] } else { hi[1] },
+            if k & 4 == 0 { lo[2] } else { hi[2] },
+        ]
+    })
+}
+
+/// Render a jointed assembly over a timeline in the **default drafting
+/// line-art style** — the same projection, shading ramp, and hidden-line
+/// overlay a single `-o frame.png` render produces, one PNG per frame.
+///
+/// Geometry is evaluated once and tessellated once; a frame costs only a
+/// vertex transform per part plus the projection/rasterization, which is why
+/// this tier runs in tens of milliseconds a frame where the path tracer
+/// takes seconds. The camera is pinned across the sequence (see
+/// [`crate::FixedFraming`]), so every PNG has identical dimensions and the
+/// machine stays put while its joints move.
+#[cfg(feature = "raster")]
+pub fn render_drafting_animation(
+    raw_vcad: &str,
+    opts: &RasterOptions,
+    an: &AnimateOptions,
+    progress: &mut dyn FnMut(usize, usize, Duration),
+) -> Result<AnimateReport, String> {
+    check_animation_raster_opts(opts, "drafting")?;
+    if opts.section.is_some() {
+        return Err(
+            "--section does not compose with --animate: the cut is a boolean \
+             against tessellated geometry, which the animation path freezes \
+             once and only re-poses. Drop --section."
+                .to_string(),
+        );
+    }
+
+    let evals_before = crate::document_eval_count();
+    let AnimationPlan {
+        statics,
+        parts,
+        poses,
+        fps,
+        eval,
+    } = plan_animation(raw_vcad, an)?;
+
+    let t_setup = Instant::now();
+    // Tessellate at exactly the segment count the raster path would have
+    // chosen for this canvas, so a frame is what a single still would have
+    // drawn.
+    let segments = crate::tessellation_segments(Some(opts.size_px));
+    let static_solids: Vec<Solid> = statics.iter().map(|s| freeze(&s.solid, segments)).collect();
+    let part_solids: Vec<Solid> = parts.iter().map(|s| freeze(&s.solid, segments)).collect();
+
+    // Columns the raster path wants, statics first then instances — the same
+    // order `evaluate_vcad` produces for a still.
+    let tints: Vec<Option<[f64; 3]>> = statics.iter().chain(parts.iter()).map(|s| s.tint).collect();
+    let names: Vec<Option<String>> = statics
+        .iter()
+        .chain(parts.iter())
+        .map(|s| s.name.clone())
+        .collect();
+
+    // ── frame the camera on the union of every pose ──────────────────────
+    let mut fb = crate::FramingBuilder::new(opts.view);
+    let identity = KTransform::identity();
+    for s in &static_solids {
+        accumulate_verts(&mut fb, s, &identity);
+    }
+    for pose in &poses {
+        for (s, t) in part_solids.iter().zip(pose) {
+            accumulate_verts(&mut fb, s, t);
+        }
+    }
+    let framing = fb.finish()?;
+    let setup = t_setup.elapsed();
+
+    std::fs::create_dir_all(&an.out_dir)
+        .map_err(|e| format!("create {}: {e}", an.out_dir.display()))?;
+
+    let mut report = AnimateReport {
+        frames: Vec::with_capacity(poses.len()),
+        fps,
+        eval,
+        setup,
+        per_frame: Vec::with_capacity(poses.len()),
+        parts: static_solids.len() + part_solids.len(),
+        articulated: part_solids.len(),
+    };
+    let total = poses.len();
+    for (i, pose) in poses.iter().enumerate() {
+        let t_frame = Instant::now();
+        let mut frame_solids: Vec<Solid> = static_solids.clone();
+        frame_solids.extend(
+            part_solids
+                .iter()
+                .zip(pose)
+                .map(|(s, t)| s.apply_transform(t)),
+        );
+        let png =
+            crate::raster::render_png_solids_framed(&frame_solids, &tints, &names, opts, &framing)?;
+        let path = an.out_dir.join(format!("frame_{i:04}.png"));
+        std::fs::write(&path, png).map_err(|e| format!("write {}: {e}", path.display()))?;
+        let elapsed = t_frame.elapsed();
+        report.frames.push(path);
+        report.per_frame.push(elapsed);
+        progress(i + 1, total, elapsed);
+    }
+
+    let evals = crate::document_eval_count() - evals_before;
+    debug_assert_eq!(evals, 1, "geometry was evaluated {evals} times, not once");
+    Ok(report)
+}
+
+/// Render a jointed assembly over a timeline with direct BRep ray tracing —
+/// the `--raytrace` middle tier between drafting line art and the path
+/// tracer.
+///
+/// Analytic surfaces mean the geometry cannot be frozen to triangles (that
+/// is the whole point of the tier), so each frame re-places the BReps and
+/// rebuilds their BVHs; evaluation still happens exactly once. Framing is
+/// pinned the same way as the drafting tier — from the union of every posed
+/// part's *bounds*, which is what the ray-traced still frames on too — so
+/// frames come out uniformly sized.
+#[cfg(feature = "raytrace")]
+pub fn render_raytrace_animation(
+    raw_vcad: &str,
+    opts: &RasterOptions,
+    an: &AnimateOptions,
+    progress: &mut dyn FnMut(usize, usize, Duration),
+) -> Result<AnimateReport, String> {
+    check_animation_raster_opts(opts, "ray-traced")?;
+    if opts.section.is_some() {
+        return Err(
+            "--section does not compose with --raytrace --animate; render the \
+             drafting tier for a sectioned sequence"
+                .to_string(),
+        );
+    }
+
+    let evals_before = crate::document_eval_count();
+    let AnimationPlan {
+        statics,
+        parts,
+        poses,
+        fps,
+        eval,
+    } = plan_animation(raw_vcad, an)?;
+
+    let t_setup = Instant::now();
+    // Framing from posed bounding boxes: the ray-traced still frames on BVH
+    // root AABBs, so matching it here keeps the two paths reading alike.
+    // Each part's *local* bbox corners are computed once (a tessellation
+    // each, not one per frame) and then merely transformed per pose.
+    let mut fb = crate::FramingBuilder::new(opts.view);
+    for s in &statics {
+        for c in solid_bbox_corners(&s.solid) {
+            fb.add(c);
+        }
+    }
+    let local_corners: Vec<[[f64; 3]; 8]> =
+        parts.iter().map(|s| solid_bbox_corners(&s.solid)).collect();
+    for pose in &poses {
+        for (corners, t) in local_corners.iter().zip(pose) {
+            for c in corners {
+                let p = t.apply_point(&vcad_kernel::vcad_kernel_math::Point3::new(
+                    c[0], c[1], c[2],
+                ));
+                fb.add([p.x, p.y, p.z]);
+            }
+        }
+    }
+    let framing = fb.finish()?;
+    let setup = t_setup.elapsed();
+
+    std::fs::create_dir_all(&an.out_dir)
+        .map_err(|e| format!("create {}: {e}", an.out_dir.display()))?;
+
+    let mut report = AnimateReport {
+        frames: Vec::with_capacity(poses.len()),
+        fps,
+        eval,
+        setup,
+        per_frame: Vec::with_capacity(poses.len()),
+        parts: statics.len() + parts.len(),
+        articulated: parts.len(),
+    };
+    let total = poses.len();
+    for (i, pose) in poses.iter().enumerate() {
+        let t_frame = Instant::now();
+        let mut scene: Vec<crate::SceneSolid> = statics.clone();
+        scene.extend(parts.iter().zip(pose).map(|(s, t)| crate::SceneSolid {
+            solid: s.solid.apply_transform(t),
+            tint: s.tint,
+            material: s.material.clone(),
+            name: s.name.clone(),
+            labels: s.labels.clone(),
+            id: s.id.clone(),
+        }));
+        let png = crate::render_raytrace_png_solids_framed(&scene, opts, &framing)?;
+        let path = an.out_dir.join(format!("frame_{i:04}.png"));
+        std::fs::write(&path, png).map_err(|e| format!("write {}: {e}", path.display()))?;
+        let elapsed = t_frame.elapsed();
+        report.frames.push(path);
+        report.per_frame.push(elapsed);
+        progress(i + 1, total, elapsed);
+    }
+
+    let evals = crate::document_eval_count() - evals_before;
+    debug_assert_eq!(evals, 1, "geometry was evaluated {evals} times, not once");
+    Ok(report)
+}
+
 /// Assemble `report`'s frames into an H.264 mp4 with ffmpeg.
 ///
 /// Returns the ffmpeg command line when ffmpeg is not on `PATH` (or fails),
@@ -423,6 +769,23 @@ pub fn assemble_mp4(frame_dir: &Path, fps: f64, out: &Path) -> Result<(), String
 mod tests {
     use super::*;
     use vcad_ir::animation::{AnimKey, AnimTrack};
+
+    /// A private, per-test output directory under the system temp dir.
+    fn scratch_dir(tag: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("vcad-render-anim-{}-{tag}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        dir
+    }
+
+    /// Decoded pixel dimensions of a written frame.
+    fn png_size(path: &PathBuf) -> (u32, u32) {
+        let img = image::open(path).expect("decode frame");
+        (
+            image::GenericImageView::width(&img),
+            image::GenericImageView::height(&img),
+        )
+    }
 
     /// Two cubes, one bolted to the other by `kind`, driven from a timeline.
     fn jointed_doc(kind: &str, axis: [f64; 3]) -> String {
@@ -561,6 +924,101 @@ mod tests {
             serde_json::from_str(&jointed_doc("Revolute", [0.0, 0.0, 1.0])).expect("parse");
         assert_eq!(resolve_joint(&doc, "swing").unwrap().id, "joint_0");
         assert_eq!(resolve_joint(&doc, "joint_0").unwrap().id, "joint_0");
+    }
+
+    /// The drafting tier renders the whole sequence, and every frame comes
+    /// out the same size — the property a per-frame fit (or `--trim`) would
+    /// break, and the one an mp4 muxer refuses to work without.
+    #[test]
+    fn drafting_animation_frames_share_one_size() {
+        let dir = scratch_dir("size");
+        let an = AnimateOptions {
+            out_dir: dir.clone(),
+            timeline: Some(joint_timeline("swing", 0.0, 90.0)),
+            frames: None,
+            fps: None,
+        };
+        // Small canvas, no supersampling: this is about framing and frame
+        // count, not image quality, and it runs on every build.
+        let opts = RasterOptions {
+            size_px: 128,
+            auto_aspect: true,
+            aa: Some(1),
+            ..Default::default()
+        };
+        let report = render_drafting_animation(
+            &jointed_doc("Revolute", [0.0, 0.0, 1.0]),
+            &opts,
+            &an,
+            &mut |_, _, _| {},
+        )
+        .expect("drafting animation");
+
+        assert_eq!(report.frames.len(), 3, "1 s at 2 fps is three samples");
+        let sizes: Vec<(u32, u32)> = report.frames.iter().map(png_size).collect();
+        assert!(
+            sizes.windows(2).all(|w| w[0] == w[1]),
+            "frames differ in size: {sizes:?}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// …and the arm actually moves: identical frames would satisfy the size
+    /// check above while rendering a still life.
+    #[test]
+    fn drafting_animation_frames_differ() {
+        let dir = scratch_dir("motion");
+        let an = AnimateOptions {
+            out_dir: dir.clone(),
+            timeline: Some(joint_timeline("swing", 0.0, 90.0)),
+            frames: None,
+            fps: None,
+        };
+        let opts = RasterOptions {
+            size_px: 128,
+            aa: Some(1),
+            ..Default::default()
+        };
+        let report = render_drafting_animation(
+            &jointed_doc("Revolute", [0.0, 0.0, 1.0]),
+            &opts,
+            &an,
+            &mut |_, _, _| {},
+        )
+        .expect("drafting animation");
+        let bytes: Vec<Vec<u8>> = report
+            .frames
+            .iter()
+            .map(|p| std::fs::read(p).expect("read frame"))
+            .collect();
+        assert_ne!(bytes[0], bytes[1], "frames 0 and 1 are identical");
+        assert_ne!(bytes[1], bytes[2], "frames 1 and 2 are identical");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `--trim` and animation are mutually exclusive by construction, and
+    /// the refusal has to name the flag to drop.
+    #[test]
+    fn trim_is_refused_with_animation() {
+        let an = AnimateOptions {
+            out_dir: scratch_dir("never"),
+            timeline: Some(joint_timeline("swing", 0.0, 90.0)),
+            frames: None,
+            fps: None,
+        };
+        let opts = RasterOptions {
+            size_px: 128,
+            trim_margin_px: Some(0),
+            ..Default::default()
+        };
+        let err = render_drafting_animation(
+            &jointed_doc("Revolute", [0.0, 0.0, 1.0]),
+            &opts,
+            &an,
+            &mut |_, _, _| {},
+        )
+        .expect_err("should refuse");
+        assert!(err.contains("--trim"), "unhelpful error: {err}");
     }
 
     /// The timeline sampler is shared with the app; check the animation

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -571,6 +571,7 @@ fn xml_escape(s: &str) -> String {
 /// The colour tints the shading ramp; `name` feeds the optional part-label
 /// annotation; `labels` (node name, instance id/name, part-def id) drive
 /// `--focus`.
+#[derive(Clone)]
 struct SceneSolid {
     solid: Solid,
     tint: Option<[f64; 3]>,
@@ -3002,7 +3003,8 @@ fn emit_svg_axes(out: &mut String, view: View, h: f64) {
 
 #[cfg(feature = "raster")]
 pub use raster::{
-    render_jpeg_solids, render_jpeg_str, render_png_solids, render_png_str, RasterOptions,
+    render_jpeg_solids, render_jpeg_str, render_png_solids, render_png_str, FixedFraming,
+    FramingBuilder, RasterOptions,
 };
 
 #[cfg(feature = "raster")]
@@ -3122,6 +3124,99 @@ mod raster {
                 mask,
                 canvas: out,
             }
+        }
+    }
+
+    /// A camera framing computed once and reused for every frame of a
+    /// sequence.
+    ///
+    /// A single still frames itself: the projected bounds of what it draws
+    /// pick the canvas, the scale, and the depth-cue range. An *animation*
+    /// cannot do that per frame — the subject's projected bounds change as
+    /// the machine moves, so each frame would get its own canvas size and
+    /// its own scale, and the assembly would swim about (and, with
+    /// `auto_aspect`, the PNGs would not even agree on their dimensions,
+    /// which no muxer will accept). Computing this once over the union of
+    /// every posed frame and handing the same value to all of them pins the
+    /// camera: identical canvas, identical scale, identical shading ladder.
+    #[derive(Debug, Clone, Copy)]
+    pub struct FixedFraming {
+        /// Screen-plane (mm) lower bound, in the view's right/down basis.
+        pub screen_min: [f64; 2],
+        /// Screen-plane (mm) upper bound.
+        pub screen_max: [f64; 2],
+        /// 3D bounding-box diagonal (mm) — drives the hidden-line depth bias.
+        pub diag: f64,
+        /// Depth (toward the camera, mm) range for the depth cue.
+        pub depth: (f64, f64),
+    }
+
+    /// Accumulates world points into a [`FixedFraming`]. Callers feed it
+    /// every vertex of every pose; the projection math here is the same the
+    /// raster path uses, so a fixed framing frames exactly as a still would
+    /// have framed that union.
+    #[derive(Debug, Clone)]
+    pub struct FramingBuilder {
+        right: [f64; 3],
+        down: [f64; 3],
+        cam: [f64; 3],
+        min: [f64; 2],
+        max: [f64; 2],
+        lo3: [f64; 3],
+        hi3: [f64; 3],
+        dmin: f64,
+        dmax: f64,
+    }
+
+    impl FramingBuilder {
+        /// Start an empty framing for `view`.
+        pub fn new(view: View) -> Self {
+            FramingBuilder {
+                right: normalize(view.right()),
+                down: normalize(view.down()),
+                cam: view.cam(),
+                min: [f64::INFINITY; 2],
+                max: [f64::NEG_INFINITY; 2],
+                lo3: [f64::INFINITY; 3],
+                hi3: [f64::NEG_INFINITY; 3],
+                dmin: f64::INFINITY,
+                dmax: f64::NEG_INFINITY,
+            }
+        }
+
+        /// Fold one world-space point into the framing.
+        pub fn add(&mut self, v: [f64; 3]) {
+            let s = [dot(v, self.right), dot(v, self.down)];
+            for (i, si) in s.iter().enumerate() {
+                self.min[i] = self.min[i].min(*si);
+                self.max[i] = self.max[i].max(*si);
+            }
+            for (i, vi) in v.iter().enumerate() {
+                self.lo3[i] = self.lo3[i].min(*vi);
+                self.hi3[i] = self.hi3[i].max(*vi);
+            }
+            let d = dot(v, self.cam);
+            self.dmin = self.dmin.min(d);
+            self.dmax = self.dmax.max(d);
+        }
+
+        /// Finish, failing closed on an empty or degenerate accumulation
+        /// rather than handing the renderer an infinite canvas.
+        pub fn finish(self) -> Result<FixedFraming, String> {
+            let extent = (self.max[0] - self.min[0]).max(self.max[1] - self.min[1]);
+            if !extent.is_finite() || extent < 1e-9 {
+                return Err("degenerate projection (no extent) across the sequence".to_string());
+            }
+            let d = (0..3)
+                .map(|i| (self.hi3[i] - self.lo3[i]).powi(2))
+                .sum::<f64>()
+                .sqrt();
+            Ok(FixedFraming {
+                screen_min: self.min,
+                screen_max: self.max,
+                diag: d,
+                depth: (self.dmin, self.dmax),
+            })
         }
     }
 
@@ -3284,7 +3379,7 @@ mod raster {
             .map(|f| focus_mask(&scene, f))
             .transpose()?;
         encode_jpeg(
-            rasterize(&solids, &tints, &names, opts, mask.as_deref(), false)?,
+            rasterize(&solids, &tints, &names, opts, mask.as_deref(), false, None)?,
             opts,
         )
     }
@@ -3296,7 +3391,7 @@ mod raster {
         let no_tints: Vec<Option<[f64; 3]>> = vec![None; solids.len()];
         let no_names: Vec<Option<String>> = vec![None; solids.len()];
         encode_jpeg(
-            rasterize(solids, &no_tints, &no_names, opts, None, false)?,
+            rasterize(solids, &no_tints, &no_names, opts, None, false, None)?,
             opts,
         )
     }
@@ -3316,7 +3411,28 @@ mod raster {
             .map(|f| focus_mask(&scene, f))
             .transpose()?;
         encode_png(
-            rasterize(&solids, &tints, &names, opts, mask.as_deref(), true)?,
+            rasterize(&solids, &tints, &names, opts, mask.as_deref(), true, None)?,
+            opts,
+        )
+    }
+
+    /// Render pre-evaluated, already-placed solids to RGBA PNG bytes using a
+    /// framing computed elsewhere — the animation path's per-frame entry
+    /// point.
+    ///
+    /// Everything else matches [`render_png_str`]; only the camera framing
+    /// (canvas, scale, depth-cue range) comes from `framing` instead of from
+    /// this frame's own bounds, which is what keeps every frame of a
+    /// sequence the same size with the subject nailed in place.
+    pub(crate) fn render_png_solids_framed(
+        solids: &[Solid],
+        tints: &[Option<[f64; 3]>],
+        names: &[Option<String>],
+        opts: &RasterOptions,
+        framing: &FixedFraming,
+    ) -> Result<Vec<u8>, String> {
+        encode_png(
+            rasterize(solids, tints, names, opts, None, true, Some(framing))?,
             opts,
         )
     }
@@ -3327,7 +3443,7 @@ mod raster {
         let no_tints: Vec<Option<[f64; 3]>> = vec![None; solids.len()];
         let no_names: Vec<Option<String>> = vec![None; solids.len()];
         encode_png(
-            rasterize(solids, &no_tints, &no_names, opts, None, true)?,
+            rasterize(solids, &no_tints, &no_names, opts, None, true, None)?,
             opts,
         )
     }
@@ -3379,6 +3495,13 @@ mod raster {
     /// labels solid `i` when the `labels` annotation is on. Returns the RGB
     /// frame plus a per-pixel coverage mask (255 where geometry, an edge
     /// stroke, or an annotation was drawn, 0 over untouched background).
+    ///
+    /// `framing`, when given, replaces this frame's own projected bounds
+    /// (and the 3D diagonal and depth range derived from them) with a
+    /// pre-computed camera — see [`FixedFraming`]. `None` frames the frame
+    /// on itself, which is what every single-image caller does and what
+    /// makes their output byte-identical to before this parameter existed.
+    #[allow(clippy::too_many_arguments)]
     fn rasterize(
         solids: &[Solid],
         tints: &[Option<[f64; 3]>],
@@ -3386,6 +3509,7 @@ mod raster {
         opts: &RasterOptions,
         focus: Option<&[bool]>,
         png: bool,
+        framing: Option<&FixedFraming>,
     ) -> Result<Frame, String> {
         if solids.is_empty() {
             return Err("no solids produced".to_string());
@@ -3480,6 +3604,11 @@ mod raster {
                 }
             }
         }
+        // A pinned camera (animation) overrides the self-framing above.
+        if let Some(f) = framing {
+            min = f.screen_min;
+            max = f.screen_max;
+        }
         let extent = (max[0] - min[0]).max(max[1] - min[1]);
         if !extent.is_finite() || extent < 1e-9 {
             return Err(if focus.is_some() {
@@ -3488,9 +3617,13 @@ mod raster {
                 "degenerate projection (no extent)".to_string()
             });
         }
-        let diag =
-            ((hi3[0] - lo3[0]).powi(2) + (hi3[1] - lo3[1]).powi(2) + (hi3[2] - lo3[2]).powi(2))
-                .sqrt();
+        let diag = match framing {
+            Some(f) => f.diag,
+            None => {
+                ((hi3[0] - lo3[0]).powi(2) + (hi3[1] - lo3[1]).powi(2) + (hi3[2] - lo3[2]).powi(2))
+                    .sqrt()
+            }
+        };
 
         let canvas = canvas_for(opts, max[0] - min[0], max[1] - min[1]);
         // The subject fills `fill_frac` of whichever canvas axis binds
@@ -3539,7 +3672,8 @@ mod raster {
         let mut zbuf: Vec<f64> = vec![f64::NEG_INFINITY; sc.len()];
         let mut mask: Vec<u8> = vec![0; sc.len()];
 
-        // Depth range for depth cueing (below).
+        // Depth range for depth cueing (below). Pinned across an animation
+        // so a part doesn't change shade merely because another part moved.
         let mut dmin = f64::INFINITY;
         let mut dmax = f64::NEG_INFINITY;
         for art in &arts {
@@ -3548,6 +3682,9 @@ mod raster {
                 dmin = dmin.min(d);
                 dmax = dmax.max(d);
             }
+        }
+        if let Some(f) = framing {
+            (dmin, dmax) = f.depth;
         }
         let dspan = (dmax - dmin).max(1e-9);
 
@@ -4294,6 +4431,8 @@ mod raster {
 // ─── raytrace path (feature-gated) ────────────────────────────────────────
 
 #[cfg(feature = "raytrace")]
+pub(crate) use raytrace::render_raytrace_png_solids_framed;
+#[cfg(feature = "raytrace")]
 pub use raytrace::{render_raytrace_jpeg_str, render_raytrace_png_str};
 
 /// Direct BRep ray tracing (`--raytrace`): pixel-perfect raster output with
@@ -4349,6 +4488,29 @@ mod raytrace {
     /// tessellated path's `encode_jpeg` / `encode_png`.
     fn rasterize_rt(raw_vcad: &str, opts: &RasterOptions, png: bool) -> Result<Frame, String> {
         let tinted = evaluate_vcad(raw_vcad)?;
+        rasterize_rt_scene(&tinted, opts, png, None)
+    }
+
+    /// Ray-trace already-placed scene solids to RGBA PNG bytes with a
+    /// camera pinned by `framing` — the `--raytrace --animate` per-frame
+    /// entry point. See [`FixedFraming`](super::FixedFraming).
+    pub(crate) fn render_raytrace_png_solids_framed(
+        scene: &[SceneSolid],
+        opts: &RasterOptions,
+        framing: &FixedFraming,
+    ) -> Result<Vec<u8>, String> {
+        encode_png(rasterize_rt_scene(scene, opts, true, Some(framing))?, opts)
+    }
+
+    /// The body of [`rasterize_rt`], over an already-evaluated scene so an
+    /// animation can re-pose the same document without re-evaluating it,
+    /// and with an optional pinned camera.
+    fn rasterize_rt_scene(
+        tinted: &[SceneSolid],
+        opts: &RasterOptions,
+        png: bool,
+        framing: Option<&FixedFraming>,
+    ) -> Result<Frame, String> {
         if tinted.is_empty() {
             return Err("no solids produced".to_string());
         }
@@ -4370,7 +4532,7 @@ mod raytrace {
         let mut ramps: Vec<Option<[[u8; 3]; 4]>> = Vec::new();
         let mut instances = Vec::new();
         let mut untraceable: Vec<String> = Vec::new();
-        for s in &tinted {
+        for s in tinted {
             let bvh = match s.solid.as_brep() {
                 Some(brep) => Bvh::build(brep),
                 None => {
@@ -4439,6 +4601,13 @@ mod raytrace {
                 dmin = dmin.min(d);
                 dmax = dmax.max(d);
             }
+        }
+        // A pinned camera (animation) overrides the self-framing above, so
+        // every frame of a sequence shares one canvas, scale, and depth cue.
+        if let Some(f) = framing {
+            min = f.screen_min;
+            max = f.screen_max;
+            (dmin, dmax) = f.depth;
         }
         let extent = (max[0] - min[0]).max(max[1] - min[1]);
         if !extent.is_finite() || extent < 1e-9 {

--- a/crates/vcad-render/src/main.rs
+++ b/crates/vcad-render/src/main.rs
@@ -13,7 +13,8 @@
 //!   vcad-render <path.vcad> -o out.jpg [--view ...] [--size <N|WxH>] [--fill <frac>] [--quality <1-100>]
 //!   vcad-render <path.vcad> -o out.png [--auto-aspect] [--trim [--trim-margin <px>]]
 //!   vcad-render <path.vcad> -o out.png [--raytrace]   # RGBA raster, transparent background
-//!   vcad-render <path.vcad> --photoreal --animate [keys.json] -o <dir> [--frames N] [--fps F] [--mp4 out.mp4]
+//!   vcad-render <path.vcad> --animate [keys.json] -o <dir> [--frames N] [--fps F] [--mp4 out.mp4]
+//!                              [--raytrace | --photoreal]   # drafting line art by default
 //!   vcad-render <path.vcad> --sheet [--size <sheet-width-px>] [-o out.svg|out.jpg]
 //!   vcad-render <dir-or-paths...> [--out-dir <dir>] [--format svg|jpeg|png]
 //!
@@ -43,13 +44,18 @@
 //! `--animate` renders a jointed assembly over time instead of a single
 //! image: one `frame_NNNN.png` per timeline sample into the directory named
 //! by `-o`, then an H.264 mp4 if ffmpeg is on PATH. The document is
-//! evaluated — and its per-part BVHs built — exactly *once* for the whole
-//! sequence; each frame only re-solves forward kinematics, re-places the
-//! parts, and re-traces. Poses come from the document's own timeline, or
+//! evaluated — and its per-part geometry prepared — exactly *once* for the
+//! whole sequence; each frame only re-solves forward kinematics, re-places
+//! the parts, and re-draws. Poses come from the document's own timeline, or
 //! from the keyframe file given as `--animate <keys.json>`. The camera is
 //! framed on the union of every pose, so the subject neither swims nor
-//! clips. Photoreal only — the tessellated paths are already cheap enough
-//! that per-frame evaluation is not the bottleneck.
+//! clips, and every frame comes out the same size.
+//!
+//! Any style animates: bare `--animate` draws the default drafting line art
+//! (tens of milliseconds a frame), `--raytrace --animate` traces analytic
+//! BRep surfaces, and `--photoreal --animate` path-traces. `--trim` is
+//! refused with `--animate` — a per-frame crop is per-frame sizing, which
+//! is the drift the shared camera exists to prevent.
 //!
 //! Raster framing: `--size` takes `N` (square) or `WxH`, `--auto-aspect`
 //! fits the canvas to the subject's projected aspect ratio, and `--trim`
@@ -415,16 +421,17 @@ struct Cli {
     #[arg(long, requires = "photoreal")]
     no_adaptive: bool,
 
-    /// Render a jointed assembly over time (`--photoreal`): one PNG per
-    /// timeline sample into the directory given by `-o`, evaluating the
-    /// document's geometry exactly once for the whole sequence.
+    /// Render a jointed assembly over time: one PNG per timeline sample
+    /// into the directory given by `-o`, evaluating the document's geometry
+    /// exactly once for the whole sequence. Drawn in the default drafting
+    /// style unless `--raytrace` or `--photoreal` picks another tier.
     ///
     /// Takes an optional keyframe file; bare `--animate` uses the timeline
     /// stored on the document. The file is a timeline — `durationS`, `fps`,
     /// `tracks` — with a shorthand for joint tracks:
     /// `{"joint":"A","keys":[{"t":0,"value":0},{"t":6,"value":1440}]}`.
     /// A joint may be named by id (`joint_0`) or by its authored name.
-    #[arg(long, value_name = "KEYFRAMES.json", num_args = 0..=1, requires = "photoreal")]
+    #[arg(long, value_name = "KEYFRAMES.json", num_args = 0..=1)]
     animate: Option<Option<PathBuf>>,
 
     /// Render only the first N frames of the animation (`--animate`).
@@ -631,7 +638,8 @@ fn render_photoreal_gpu(
 #[cfg(feature = "raytrace")]
 fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
     use vcad_render::animate::{
-        assemble_mp4, parse_timeline_spec, render_photoreal_animation, AnimateOptions,
+        assemble_mp4, parse_timeline_spec, render_drafting_animation, render_photoreal_animation,
+        render_raytrace_animation, AnimateOptions,
     };
 
     // `--gpu` bakes each part's transform into the uploaded vertices — the
@@ -645,6 +653,16 @@ fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
                     each part's pose into its uploaded vertices, so every frame \
                     would repack and re-upload the whole assembly — which is the \
                     one cost --animate exists to avoid. Drop --gpu."
+                .to_string(),
+        );
+    }
+    // The overlays and the section cut are drawn by the projected 2D path,
+    // which the photoreal tier has no counterpart for — the same refusal the
+    // single-image path makes, made here before anything is evaluated.
+    if cli.photoreal && (cli.section.is_some() || cli.annotations().any()) {
+        return Err(
+            "--photoreal does not compose with --section/--axes/--labels/--dims; \
+             drop --photoreal to animate in the drafting style"
                 .to_string(),
         );
     }
@@ -672,7 +690,6 @@ fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
 
     let raw = read_document(input)?;
     let opts = raster_opts(cli, true);
-    let pr = photoreal_options(cli);
     let an = AnimateOptions {
         out_dir: out_dir.clone(),
         timeline,
@@ -680,9 +697,20 @@ fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
         fps: cli.fps,
     };
 
-    let report = render_photoreal_animation(&raw, &opts, &pr, &an, &mut |i, n, dt| {
-        eprintln!("frame {i}/{n}  {:.1}s", dt.as_secs_f64());
-    })?;
+    // Style tiers, cheapest first. Each one evaluates the document once and
+    // pins one camera across the sequence; they differ only in how a pose
+    // becomes pixels.
+    let progress = &mut |i: usize, n: usize, dt: std::time::Duration| {
+        eprintln!("frame {i}/{n}  {:.2}s", dt.as_secs_f64());
+    };
+    let report = if cli.photoreal {
+        let pr = photoreal_options(cli);
+        render_photoreal_animation(&raw, &opts, &pr, &an, progress)?
+    } else if cli.raytrace {
+        render_raytrace_animation(&raw, &opts, &an, progress)?
+    } else {
+        render_drafting_animation(&raw, &opts, &an, progress)?
+    };
 
     eprintln!(
         "evaluated {} part(s) once in {:.1}s ({} articulated), setup {:.1}s",
@@ -693,7 +721,7 @@ fn run_animation(input: &Path, cli: &Cli) -> Result<(), String> {
     );
     if let (Some(first), median) = (report.per_frame.first(), report.median_frame()) {
         eprintln!(
-            "frame 1 {:.1}s, steady state {:.1}s, {} frames in {:.1}s total",
+            "frame 1 {:.2}s, steady state {:.2}s, {} frames in {:.1}s total",
             first.as_secs_f64(),
             median.as_secs_f64(),
             report.frames.len(),


### PR DESCRIPTION
## What

`--animate [KEYFRAMES.json]` now works in all three render styles instead of requiring `--photoreal`:

- **default (drafting line-art)** — new `render_drafting_animation`: every part is evaluated and frozen to a mesh **once**, then only re-transformed per frame through the existing raster pipeline. ~0.36 s/frame vs 25+ s/frame photoreal.
- **`--raytrace`** — new middle tier on the BRep tracer (~0.07 s/frame on small scenes).
- **`--photoreal`** — unchanged behavior.

All tiers share a new style-agnostic `plan_animation()` (timeline resolution, evaluate-once, `--fps`/`--frames` sampling, FK pose baking) and the existing `assemble_mp4` muxing; `--mp4`/`--no-mp4` semantics are identical.

## The frame-size fix

Previously the drafting camera refit each render's bbox (and `--auto-aspect` refit the canvas), so animating by shelling out per frame produced drifting sizes that needed external imagemagick padding. Now a `FixedFraming` is computed once from the **union of all posed bboxes across the timeline** (via `FramingBuilder`) and threaded into `rasterize()` as an optional override — screen bbox, hidden-line diagonal, and depth-cue range. Every frame is identical size, the machine never swims, and `--auto-aspect` resolves once against the union. All pre-existing callers pass `None`, and a before/after still render is **byte-identical**.

`--trim` and `--focus` are refused with `--animate` (per-frame crop would reintroduce size drift), with errors naming the fix.

## Why

Kinematic review reads far better in edge-line drafting style; the photoreal-only gate forced users (e.g. purl's winder cycle) to hand-roll per-frame pose baking + frame normalization + ffmpeg.

## Verification

- `cargo test -p vcad-render` (117 pass, incl. new tests: uniform frame dimensions, frames actually differ, `--trim` refusal), `clippy --all-targets -- -D warnings` clean, `fmt --check` clean.
- Real-world: purl's 35-part winder (`stack-anim.loon` + `stack-keys.json`, `--fps 6 --size 1100 --auto-aspect`, drafting): 37 frames, all 1100×871, all distinct, mp4 muxed — **47 s wall total** (32 s one-time eval, 0.36 s/frame steady state).
- Single-image regression: pre/post-change still renders byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)