### PR TITLE
Manifold STLs for unions of stacked rings; loon prisms instead of a lying segment count

### DIFF
--- a/changelog/entries/2026-08-28-hex-prism-and-segment-hint.json
+++ b/changelog/entries/2026-08-28-hex-prism-and-segment-hint.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-28-hex-prism-and-segment-hint",
+  "version": "0.9.4",
+  "date": "2026-08-28",
+  "category": "fix",
+  "title": "loon: hex-prism, and cylinder-n stops lying",
+  "summary": "The -n primitive forms refuse segment counts under 8 (they are a fidelity hint, not a face count) and point at prism / polygon-prism / hex-prism for real facets.",
+  "features": ["loon", "primitives"],
+  "mcpTools": []
+}

--- a/changelog/entries/2026-08-28-manifold-nested-ring-unions.json
+++ b/changelog/entries/2026-08-28-manifold-nested-ring-unions.json
@@ -1,0 +1,10 @@
+{
+  "id": "2026-08-28-manifold-nested-ring-unions",
+  "version": "0.9.4",
+  "date": "2026-08-28",
+  "category": "fix",
+  "title": "Manifold STLs for unions of stacked rings",
+  "summary": "A union whose operands are differences (stacked annular rings) no longer exports doubled surface a slicer reports as non-manifold and auto-repairs by filling the bore.",
+  "features": ["booleans", "export", "stl", "printing"],
+  "mcpTools": []
+}

--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -580,8 +580,15 @@ pub fn boolean_op_reported(
     // The fallback is only ever taken when it is structurally BETTER than
     // what it replaces — never merely different. Swapping soup in for a
     // defect it also has just loses the surfaces.
-    let alt_sound = alt_report.triangles > 0 && agree && alt_report.overused_edges == 0;
-    if alt_sound && repair_non_manifold {
+    //
+    // "Better" is judged against the defect being repaired, and ONLY that
+    // one. Requiring a manifold fallback for the watertightness swap as
+    // well cost five torture cases (chain-00/08/10, rand-072, rand-220):
+    // they pass *because* they take that swap, and a fallback that closes
+    // every crack while carrying a few over-used edges was suddenly
+    // rejected, handing back the cracked B-rep instead.
+    let alt_usable = alt_report.triangles > 0 && agree;
+    if alt_usable && repair_non_manifold && alt_report.overused_edges == 0 {
         let mut report =
             BooleanReport::degraded(op, DegradeReason::NonManifoldSwap).with_result(&alt);
         report.flagged_unrepresentable = flagged || sphere_unrepresentable;
@@ -589,10 +596,11 @@ pub fn boolean_op_reported(
         report.overused_edges = 0;
         return Ok((alt, report));
     }
-    if alt_sound && alt_report.open_edges == 0 {
+    if alt_usable && alt_report.open_edges == 0 {
         let mut report =
             BooleanReport::degraded(op, DegradeReason::WatertightnessSwap).with_result(&alt);
         report.flagged_unrepresentable = true;
+        report.overused_edges = alt_report.overused_edges;
         return Ok((alt, report));
     }
     Ok(keep(result))

--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -166,12 +166,6 @@ pub enum DegradeReason {
     /// was watertight and agreed on volume. Analytic surfaces were traded
     /// for watertightness.
     WatertightnessSwap,
-    /// The B-rep result carried edges shared by more than two triangles —
-    /// doubled or overlapping surface, which no consumer can interpret
-    /// (a slicer's auto-repair "fixes" it by filling, which has closed a
-    /// bore on a real print). The mesh fallback was manifold and agreed on
-    /// volume, so it was taken instead.
-    NonManifoldSwap,
 }
 
 impl DegradeReason {
@@ -185,7 +179,6 @@ impl DegradeReason {
             DegradeReason::DifferenceRemovedNothing => "difference-removed-nothing",
             DegradeReason::SphereArrangement => "sphere-arrangement",
             DegradeReason::WatertightnessSwap => "watertightness-swap",
-            DegradeReason::NonManifoldSwap => "non-manifold-swap",
         }
     }
 }
@@ -211,9 +204,6 @@ impl std::fmt::Display for DegradeReason {
             }
             DegradeReason::WatertightnessSwap => {
                 "the B-rep result was cracked and the watertight mesh result was taken instead"
-            }
-            DegradeReason::NonManifoldSwap => {
-                "the B-rep result had edges shared by more than two triangles;                  the manifold mesh result was taken instead"
             }
         };
         write!(f, "{msg}")
@@ -241,12 +231,17 @@ pub struct BooleanReport {
     /// only: known-good results score 3 and 64, so no threshold separates
     /// good from bad (see [`crate::mesh_report`]).
     pub open_edges: usize,
-    /// Undirected edges in the result's tessellation shared by more than
-    /// two triangles. Unlike `open_edges` this is NOT advisory: doubled
-    /// surface is never legitimate geometry, and a slicer's auto-repair
-    /// resolves it by filling (a printed rotor came back with its shaft
-    /// bore solid). A nonzero count here after the fallback has been
-    /// offered means the pipeline could not produce printable output.
+    /// Undirected edges in the result's tessellation shared by MORE than
+    /// two triangles — doubled or overlapping surface, which a slicer
+    /// reports as non-manifold and auto-repairs by filling (a printed
+    /// rotor came back with its shaft bore solid).
+    ///
+    /// Advisory in the same way `open_edges` is, and for the same reason:
+    /// measured over this crate's catalogue, known-good results score up
+    /// to 13. What it adds is VISIBILITY — `open_edges` is a net directed
+    /// count, so it cancels to zero on a doubled surface and cannot see
+    /// this class at all. A large count is worth investigating; a small
+    /// one is seam noise.
     pub overused_edges: usize,
     /// Face count of the result B-rep. A four-digit count with
     /// `fidelity == TriangleSoup` is the signature of soup.
@@ -411,16 +406,7 @@ pub fn boolean_op_reported(
     // two tessellations against a pipeline that has already run SSI,
     // splitting, classification and sewing — and the guard's expensive half
     // (the probe grid) still only runs when the cheap volume test trips.
-    // A non-manifold result can come out of ANY op (a union of two
-    // annular caps doubles its contact plane), and repairing it needs the
-    // operand meshes — so a Union pays for them too when its own result
-    // has over-used edges. Cheap to decide: the result mesh is in hand.
-    let result_overused_now = crate::mesh_report(&result_mesh).overused_edges > 0;
-    let operands = (flagged
-        || sphere_unrepresentable
-        || inverted
-        || result_overused_now
-        || op == BooleanOp::Difference)
+    let operands = (flagged || sphere_unrepresentable || inverted || op == BooleanOp::Difference)
         .then(|| {
             (
                 tessellate_brep(solid_a, segments),
@@ -551,22 +537,24 @@ pub fn boolean_op_reported(
     // agrees on volume, so the analytic r45 wall was traded for coarse
     // triangle soup and the volume fell 529 mm³ short of analytic truth.
     //
-    // Over-used edges are the one structural defect that is NOT advisory,
-    // so they open the swap on their own — no capability flag required.
-    // An edge shared by three or more triangles means the result carries
-    // doubled or overlapping surface; no consumer can interpret it, and a
-    // slicer's auto-repair resolves it by FILLING (a printed rotor came
-    // back with its shaft bore solid). Unlike a hairline seam there is no
-    // legitimate population to protect: the analytic surfaces of a result
-    // that doubles itself were not worth keeping.
-    let repair_non_manifold = result_overused_edges > 0;
-    if !(flagged || sphere_unrepresentable || inverted || repair_non_manifold) {
+    // Over-used edges do NOT open the swap, though they are now measured
+    // and reported (`BooleanReport::overused_edges`). Making them a
+    // trigger was tried and reverted: the populations overlap exactly the
+    // way they do for open edges. Measured over this crate's own catalogue,
+    // known-good results score up to 13 over-used edges — b1's blade cut
+    // scores 1 — while the doubled-surface defects that motivated the
+    // measurement scored 11 and 14. No count separates them, so a
+    // count-triggered swap traded b1's analytic r45 wall for coarse soup
+    // and lost 505 mm³. The measurement's job is to make doubled surface
+    // VISIBLE (`open_edges` is a net directed count and cancels on it);
+    // repairing it belongs at its root, in the splitters.
+    if !(flagged || sphere_unrepresentable || inverted) {
         return Ok(keep(result));
     }
     let Some((mesh_a, mesh_b)) = &operands else {
         return Ok(keep(result));
     };
-    if result_open_edges == 0 && !repair_non_manifold {
+    if result_open_edges == 0 {
         return Ok(keep(result));
     }
     let Ok(alt) = mesh_fallback(mesh_a, mesh_b, op, &quadrics) else {
@@ -577,25 +565,13 @@ pub fn boolean_op_reported(
     let brep_vol = crate::validate::mesh_signed_volume(&result_mesh).abs();
     let alt_vol = alt_report.signed_volume.abs();
     let agree = (alt_vol - brep_vol).abs() <= 0.10 * brep_vol.max(alt_vol);
-    // The fallback is only ever taken when it is structurally BETTER than
-    // what it replaces — never merely different. Swapping soup in for a
-    // defect it also has just loses the surfaces.
-    //
-    // "Better" is judged against the defect being repaired, and ONLY that
-    // one. Requiring a manifold fallback for the watertightness swap as
-    // well cost five torture cases (chain-00/08/10, rand-072, rand-220):
-    // they pass *because* they take that swap, and a fallback that closes
-    // every crack while carrying a few over-used edges was suddenly
-    // rejected, handing back the cracked B-rep instead.
+    // The fallback is taken only if it is watertight and agrees on volume.
+    // Note what is NOT required: that it be manifold. Adding that cost
+    // five torture cases (chain-00/08/10, rand-072, rand-220), which pass
+    // precisely BECAUSE they take this swap — a fallback that closes every
+    // crack while carrying a few over-used edges is still strictly better
+    // than the cracked B-rep it replaces.
     let alt_usable = alt_report.triangles > 0 && agree;
-    if alt_usable && repair_non_manifold && alt_report.overused_edges == 0 {
-        let mut report =
-            BooleanReport::degraded(op, DegradeReason::NonManifoldSwap).with_result(&alt);
-        report.flagged_unrepresentable = flagged || sphere_unrepresentable;
-        report.open_edges = alt_report.open_edges;
-        report.overused_edges = 0;
-        return Ok((alt, report));
-    }
     if alt_usable && alt_report.open_edges == 0 {
         let mut report =
             BooleanReport::degraded(op, DegradeReason::WatertightnessSwap).with_result(&alt);

--- a/crates/vcad-kernel-booleans/src/api.rs
+++ b/crates/vcad-kernel-booleans/src/api.rs
@@ -166,6 +166,12 @@ pub enum DegradeReason {
     /// was watertight and agreed on volume. Analytic surfaces were traded
     /// for watertightness.
     WatertightnessSwap,
+    /// The B-rep result carried edges shared by more than two triangles —
+    /// doubled or overlapping surface, which no consumer can interpret
+    /// (a slicer's auto-repair "fixes" it by filling, which has closed a
+    /// bore on a real print). The mesh fallback was manifold and agreed on
+    /// volume, so it was taken instead.
+    NonManifoldSwap,
 }
 
 impl DegradeReason {
@@ -179,6 +185,7 @@ impl DegradeReason {
             DegradeReason::DifferenceRemovedNothing => "difference-removed-nothing",
             DegradeReason::SphereArrangement => "sphere-arrangement",
             DegradeReason::WatertightnessSwap => "watertightness-swap",
+            DegradeReason::NonManifoldSwap => "non-manifold-swap",
         }
     }
 }
@@ -204,6 +211,9 @@ impl std::fmt::Display for DegradeReason {
             }
             DegradeReason::WatertightnessSwap => {
                 "the B-rep result was cracked and the watertight mesh result was taken instead"
+            }
+            DegradeReason::NonManifoldSwap => {
+                "the B-rep result had edges shared by more than two triangles;                  the manifold mesh result was taken instead"
             }
         };
         write!(f, "{msg}")
@@ -231,6 +241,13 @@ pub struct BooleanReport {
     /// only: known-good results score 3 and 64, so no threshold separates
     /// good from bad (see [`crate::mesh_report`]).
     pub open_edges: usize,
+    /// Undirected edges in the result's tessellation shared by more than
+    /// two triangles. Unlike `open_edges` this is NOT advisory: doubled
+    /// surface is never legitimate geometry, and a slicer's auto-repair
+    /// resolves it by filling (a printed rotor came back with its shaft
+    /// bore solid). A nonzero count here after the fallback has been
+    /// offered means the pipeline could not produce printable output.
+    pub overused_edges: usize,
     /// Face count of the result B-rep. A four-digit count with
     /// `fidelity == TriangleSoup` is the signature of soup.
     pub faces: usize,
@@ -244,6 +261,7 @@ impl BooleanReport {
             reason: None,
             flagged_unrepresentable: false,
             open_edges: 0,
+            overused_edges: 0,
             faces: 0,
         }
     }
@@ -255,6 +273,7 @@ impl BooleanReport {
             reason: Some(reason),
             flagged_unrepresentable: false,
             open_edges: 0,
+            overused_edges: 0,
             faces: 0,
         }
     }
@@ -392,7 +411,16 @@ pub fn boolean_op_reported(
     // two tessellations against a pipeline that has already run SSI,
     // splitting, classification and sewing — and the guard's expensive half
     // (the probe grid) still only runs when the cheap volume test trips.
-    let operands = (flagged || sphere_unrepresentable || inverted || op == BooleanOp::Difference)
+    // A non-manifold result can come out of ANY op (a union of two
+    // annular caps doubles its contact plane), and repairing it needs the
+    // operand meshes — so a Union pays for them too when its own result
+    // has over-used edges. Cheap to decide: the result mesh is in hand.
+    let result_overused_now = crate::mesh_report(&result_mesh).overused_edges > 0;
+    let operands = (flagged
+        || sphere_unrepresentable
+        || inverted
+        || result_overused_now
+        || op == BooleanOp::Difference)
         .then(|| {
             (
                 tessellate_brep(solid_a, segments),
@@ -463,12 +491,15 @@ pub fn boolean_op_reported(
     // Cheap structural stat carried on every report so a caller can see a
     // cracked-but-analytic result without re-tessellating. One hashed pass
     // over a mesh the pipeline already built.
-    let result_open_edges = crate::mesh_report(&result_mesh).open_edges;
+    let result_structure = crate::mesh_report(&result_mesh);
+    let result_open_edges = result_structure.open_edges;
+    let result_overused_edges = result_structure.overused_edges;
     // Analytic outcome, shared by the four "keep the B-rep" returns below.
     let keep = |result: BooleanResult| {
         let report = BooleanReport {
             flagged_unrepresentable: flagged || sphere_unrepresentable,
             open_edges: result_open_edges,
+            overused_edges: result_overused_edges,
             ..BooleanReport::analytic(op)
         }
         .with_result(&result);
@@ -519,13 +550,23 @@ pub fn boolean_op_reported(
     // cylinder has a few hairline seams, the mesh fallback is watertight and
     // agrees on volume, so the analytic r45 wall was traded for coarse
     // triangle soup and the volume fell 529 mm³ short of analytic truth.
-    if !(flagged || sphere_unrepresentable || inverted) {
+    //
+    // Over-used edges are the one structural defect that is NOT advisory,
+    // so they open the swap on their own — no capability flag required.
+    // An edge shared by three or more triangles means the result carries
+    // doubled or overlapping surface; no consumer can interpret it, and a
+    // slicer's auto-repair resolves it by FILLING (a printed rotor came
+    // back with its shaft bore solid). Unlike a hairline seam there is no
+    // legitimate population to protect: the analytic surfaces of a result
+    // that doubles itself were not worth keeping.
+    let repair_non_manifold = result_overused_edges > 0;
+    if !(flagged || sphere_unrepresentable || inverted || repair_non_manifold) {
         return Ok(keep(result));
     }
     let Some((mesh_a, mesh_b)) = &operands else {
         return Ok(keep(result));
     };
-    if result_open_edges == 0 {
+    if result_open_edges == 0 && !repair_non_manifold {
         return Ok(keep(result));
     }
     let Ok(alt) = mesh_fallback(mesh_a, mesh_b, op, &quadrics) else {
@@ -536,7 +577,19 @@ pub fn boolean_op_reported(
     let brep_vol = crate::validate::mesh_signed_volume(&result_mesh).abs();
     let alt_vol = alt_report.signed_volume.abs();
     let agree = (alt_vol - brep_vol).abs() <= 0.10 * brep_vol.max(alt_vol);
-    if alt_report.open_edges == 0 && alt_report.triangles > 0 && agree {
+    // The fallback is only ever taken when it is structurally BETTER than
+    // what it replaces — never merely different. Swapping soup in for a
+    // defect it also has just loses the surfaces.
+    let alt_sound = alt_report.triangles > 0 && agree && alt_report.overused_edges == 0;
+    if alt_sound && repair_non_manifold {
+        let mut report =
+            BooleanReport::degraded(op, DegradeReason::NonManifoldSwap).with_result(&alt);
+        report.flagged_unrepresentable = flagged || sphere_unrepresentable;
+        report.open_edges = alt_report.open_edges;
+        report.overused_edges = 0;
+        return Ok((alt, report));
+    }
+    if alt_sound && alt_report.open_edges == 0 {
         let mut report =
             BooleanReport::degraded(op, DegradeReason::WatertightnessSwap).with_result(&alt);
         report.flagged_unrepresentable = true;

--- a/crates/vcad-kernel-booleans/src/mesh/csg.rs
+++ b/crates/vcad-kernel-booleans/src/mesh/csg.rs
@@ -473,7 +473,62 @@ fn polygons_to_mesh(polys: &[Polygon]) -> TriangleMesh {
         }
     }
     collapse_degenerate_triangles(&mut mesh);
+    cancel_duplicate_triangles(&mut mesh);
     mesh
+}
+
+/// Cancel coincident triangles left by the split/classify pass.
+///
+/// A coplanar contact between the operands can survive classification
+/// twice — once from each operand's fragment — and an opposed pair is a
+/// ZERO-THICKNESS FLAP: it adds nothing to the volume (which is why the
+/// volume oracle waves it through) but every edge it touches ends up
+/// shared by four triangles. Slicers call that a non-manifold edge, and
+/// auto-repair resolves it by filling: a printed rotor came back with its
+/// shaft bore solid.
+///
+/// Same-orientation duplicates are simply redundant copies of one facet.
+/// Both are removed by keeping, for each vertex triple, |forward −
+/// backward| copies of whichever orientation dominates.
+fn cancel_duplicate_triangles(mesh: &mut TriangleMesh) {
+    let mut seen: std::collections::HashMap<[u32; 3], (i32, usize)> =
+        std::collections::HashMap::new();
+    for (t, tri) in mesh.indices.chunks(3).enumerate() {
+        let mut key = [tri[0], tri[1], tri[2]];
+        key.sort_unstable();
+        // Orientation relative to the sorted key: even permutation = +1.
+        let sign =
+            if (tri[0] < tri[1]) as u8 + (tri[1] < tri[2]) as u8 + (tri[0] < tri[2]) as u8 == 2 {
+                1
+            } else {
+                -1
+            };
+        let e = seen.entry(key).or_insert((0, t));
+        e.0 += sign;
+    }
+    if seen.values().all(|&(net, _)| net.abs() == 1) {
+        return;
+    }
+    let mut out = Vec::with_capacity(mesh.indices.len());
+    for tri in mesh.indices.chunks(3) {
+        let mut key = [tri[0], tri[1], tri[2]];
+        key.sort_unstable();
+        let sign =
+            if (tri[0] < tri[1]) as u8 + (tri[1] < tri[2]) as u8 + (tri[0] < tri[2]) as u8 == 2 {
+                1
+            } else {
+                -1
+            };
+        let Some(slot) = seen.get_mut(&key) else {
+            continue;
+        };
+        // Emit while this orientation still has an uncancelled surplus.
+        if slot.0 * sign > 0 {
+            slot.0 -= sign;
+            out.extend_from_slice(tri);
+        }
+    }
+    mesh.indices = out;
 }
 
 /// Weld away triangles whose f32-stored vertices are (near-)collinear.

--- a/crates/vcad-kernel-booleans/src/split.rs
+++ b/crates/vcad-kernel-booleans/src/split.rs
@@ -1164,17 +1164,7 @@ pub fn split_planar_face_by_circle(
                         if lp_verts.is_empty() {
                             continue;
                         }
-                        let test_pt = if lp_verts.len() == 1 {
-                            lp_verts[0]
-                        } else {
-                            let n = lp_verts.len() as f64;
-                            Point3::new(
-                                lp_verts.iter().map(|v| v.x).sum::<f64>() / n,
-                                lp_verts.iter().map(|v| v.y).sum::<f64>() / n,
-                                lp_verts.iter().map(|v| v.z).sum::<f64>() / n,
-                            )
-                        };
-                        if (test_pt - circle.center).norm() < circle.radius - tolerance {
+                        if loop_vs_circle(&lp_verts, circle, tolerance) == LoopVsCircle::Inside {
                             brep.topology.faces[face_id]
                                 .inner_loops
                                 .retain(|&l| l != lp);
@@ -1224,6 +1214,33 @@ pub fn split_planar_face_by_circle(
         return SplitResult {
             sub_faces: vec![face_id],
         };
+    }
+
+    // A circle that lies inside one of this face's HOLES is not inside the
+    // face at all: the face's material is the outer loop minus its inner
+    // loops. Splitting on it manufactures a disk sub-face covering the hole
+    // (a membrane the tessellator then draws over the bore) plus a
+    // redundant nested hole on the ring — measured as 691 non-manifold
+    // edges on a stacked-ring union, where B's smaller wall circle lands
+    // inside the ring that B's larger wall had already opened.
+    let inner_loops = brep.topology.faces[face_id].inner_loops.clone();
+    for lp in inner_loops {
+        let hole_verts: Vec<Point3> = brep
+            .topology
+            .loop_half_edges(lp)
+            .map(|he| brep.topology.vertices[brep.topology.half_edges[he].origin].point)
+            .collect();
+        if hole_verts.len() < 3 {
+            continue;
+        }
+        // Coincident with the hole rim: that boundary already exists.
+        if loop_vs_circle(&hole_verts, circle, 1e-6) == LoopVsCircle::Coincident
+            || circle_fully_inside_polygon(&hole_verts, circle)
+        {
+            return SplitResult {
+                sub_faces: vec![face_id],
+            };
+        }
     }
 
     // Check if the FULL circle is inside the polygon
@@ -1394,23 +1411,17 @@ pub fn split_planar_face_by_circle(
         // Determine which face this inner loop belongs to by checking if its
         // representative vertex is inside the new circle
         let target_face = if !loop_verts_existing.is_empty() {
-            // Use the centroid of the inner loop vertices (or just the first vertex
-            // for degenerate single-vertex loops) as the test point
-            let test_pt = if loop_verts_existing.len() == 1 {
-                loop_verts_existing[0]
-            } else {
-                let n = loop_verts_existing.len() as f64;
-                let cx = loop_verts_existing.iter().map(|v| v.x).sum::<f64>() / n;
-                let cy = loop_verts_existing.iter().map(|v| v.y).sum::<f64>() / n;
-                let cz = loop_verts_existing.iter().map(|v| v.z).sum::<f64>() / n;
-                Point3::new(cx, cy, cz)
-            };
-            let d = test_pt - circle.center;
-            let dist = d.norm();
-            if dist < circle.radius - tolerance {
-                inner_face // Loop is inside the circle → belongs to inner (disk) face
-            } else {
-                outer_face // Loop is outside the circle → belongs to outer face
+            match loop_vs_circle(&loop_verts_existing, circle, tolerance) {
+                // Inside the circle → belongs to the disk sub-face.
+                LoopVsCircle::Inside => inner_face,
+                // The loop IS the splitting circle: the split has already
+                // created that boundary as `hole_loop` on the outer face
+                // and as the disk's own outer loop. Re-adding it would
+                // give the outer face two copies of one hole.
+                LoopVsCircle::Coincident => continue,
+                // Outside, or crossing the circle (which no valid hole
+                // does — keep it on the ring, where the parent had it).
+                _ => outer_face,
             }
         } else {
             outer_face // Empty loop, default to outer
@@ -1635,6 +1646,65 @@ fn circle_fully_inside_polygon(polygon: &[Point3], circle: &vcad_kernel_geom::Ci
     }
 
     true
+}
+
+/// Where an existing hole loop sits relative to a splitting circle.
+///
+/// Routing holes by their CENTROID is wrong for the commonest hole shape
+/// there is: a circle. Every concentric loop — whatever its radius —
+/// has its centroid at the shared center, so a hole *larger* than the
+/// splitting circle tested "inside" and was handed to the disk sub-face.
+/// The result is a face whose hole is bigger than its own outer loop
+/// (measured: an r24 disk carrying an r27.5 hole), which the tessellator
+/// draws as the full disk — a membrane over the hole, doubled surface,
+/// and non-manifold edges in the exported mesh. Nested annular caps are
+/// exactly what a union-of-differences produces, which is why the defect
+/// only showed up on stacked rings.
+///
+/// Classify by the loop's VERTICES instead, which is what containment
+/// actually means.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum LoopVsCircle {
+    /// Every vertex strictly inside the circle.
+    Inside,
+    /// Every vertex strictly outside.
+    Outside,
+    /// The loop *is* the circle (within tolerance).
+    Coincident,
+    /// The loop crosses the circle — it belongs to neither sub-face
+    /// cleanly.
+    Straddles,
+}
+
+fn loop_vs_circle(
+    loop_verts: &[Point3],
+    circle: &vcad_kernel_geom::Circle3d,
+    tol: f64,
+) -> LoopVsCircle {
+    let mut inside = false;
+    let mut outside = false;
+    let mut on = false;
+    for p in loop_verts {
+        // Distance measured in the circle's own plane: a loop on a
+        // parallel plane (the far cap of a through-hole) must still
+        // classify by its radius, not by its 3D distance to the center.
+        let d = *p - circle.center;
+        let n = circle.normal.into_inner();
+        let radial = (d - d.dot(n) * n).norm();
+        if radial < circle.radius - tol {
+            inside = true;
+        } else if radial > circle.radius + tol {
+            outside = true;
+        } else {
+            on = true;
+        }
+    }
+    match (inside, outside) {
+        (true, false) => LoopVsCircle::Inside,
+        (false, true) => LoopVsCircle::Outside,
+        (false, false) if on => LoopVsCircle::Coincident,
+        _ => LoopVsCircle::Straddles,
+    }
 }
 
 /// Point-in-polygon test using ray casting (2D version).

--- a/crates/vcad-kernel-booleans/src/validate.rs
+++ b/crates/vcad-kernel-booleans/src/validate.rs
@@ -86,8 +86,9 @@ pub struct MeshReport {
     /// invisible to it. That is exactly the defect a slicer reports as
     /// "non-manifold edges", and auto-repair resolves it by filling —
     /// which closed a rotor's shaft bore on a real print. Count it
-    /// separately: unlike an unpaired hairline seam, an over-used edge is
-    /// never legitimate geometry.
+    /// separately. Like `open_edges` it is advisory — known-good results
+    /// in this crate's catalogue score up to 13 — but it is the only
+    /// number that sees this class at all.
     pub overused_edges: usize,
 }
 

--- a/crates/vcad-kernel-booleans/src/validate.rs
+++ b/crates/vcad-kernel-booleans/src/validate.rs
@@ -79,6 +79,16 @@ pub struct MeshReport {
     pub open_edges: usize,
     /// Triangle count.
     pub triangles: usize,
+    /// Undirected edges shared by MORE than two triangles.
+    ///
+    /// `open_edges` is a *net directed* count, so it cancels to zero on a
+    /// doubled surface: two coincident patches with opposite winding are
+    /// invisible to it. That is exactly the defect a slicer reports as
+    /// "non-manifold edges", and auto-repair resolves it by filling —
+    /// which closed a rotor's shaft bore on a real print. Count it
+    /// separately: unlike an unpaired hairline seam, an over-used edge is
+    /// never legitimate geometry.
+    pub overused_edges: usize,
 }
 
 /// Measure a result mesh: signed volume, unpaired directed edges, triangles.
@@ -113,10 +123,25 @@ pub fn mesh_report(mesh: &TriangleMesh) -> MeshReport {
             }
         }
     }
+    let mut uses: std::collections::HashMap<([i64; 3], [i64; 3]), usize> =
+        std::collections::HashMap::new();
+    for t in 0..mesh.indices.len() / 3 {
+        for k in 0..3 {
+            let x = vkey(mesh.indices[t * 3 + k] as usize);
+            let y = vkey(mesh.indices[t * 3 + (k + 1) % 3] as usize);
+            if x == y {
+                continue;
+            }
+            let e = if x < y { (x, y) } else { (y, x) };
+            *uses.entry(e).or_default() += 1;
+        }
+    }
+
     MeshReport {
         signed_volume: mesh_signed_volume(mesh),
         open_edges: net.values().map(|n| n.unsigned_abs() as usize).sum(),
         triangles: mesh.indices.len() / 3,
+        overused_edges: uses.values().filter(|&&n| n > 2).count(),
     }
 }
 

--- a/crates/vcad-kernel-booleans/tests/coplanar_boss_straddling_a_split.rs
+++ b/crates/vcad-kernel-booleans/tests/coplanar_boss_straddling_a_split.rs
@@ -1,0 +1,123 @@
+//! KNOWN OPEN DEFECT (2026-08-27), captured with its diagnosis.
+//!
+//! A boss whose top and bottom faces are FLUSH with the faces of the body
+//! it is unioned onto goes non-manifold when its footprint straddles a
+//! line an earlier boolean already split into that face. Gear teeth are
+//! the canonical case: `planet-72t` scores 2133 bad edges, all of them on
+//! the z = 0 and z = h caps at the tooth roots.
+//!
+//! Bisection (`gear_teeth_are_manifold` below):
+//!  - one tooth on a fresh blank: manifold at every angle;
+//!  - a second tooth is manifold everywhere EXCEPT a ~3° band around 180°
+//!    — the diameter opposite the first tooth. The first union splits the
+//!    cap with the tooth's side-plane LINES, which run the full diameter,
+//!    so the cap becomes two half-faces meeting on a chord that passes
+//!    through the 180° point. A coplanar footprint landing on that seam
+//!    contributes fragments to both half-faces and one of them is kept
+//!    twice: 14 over-used edges, zero net volume (a zero-thickness flap,
+//!    which is why the volume oracle passes it);
+//!  - with the teeth counts a real gear uses, every tooth at 180° from an
+//!    earlier one repeats it — the count grows linearly with tooth count.
+//!
+//! WORKAROUND until this is fixed: give the boss a small overhang past the
+//! body's faces (model the tooth taller and let the union trim it). The
+//! `overhang` test below is the same geometry with 0.5 mm of overhang and
+//! it is manifold, so nothing about the arrangement is intrinsically hard.
+//!
+//! The root fix is in the pipeline, not in the splitters this file's
+//! sibling test covers: either stop the line splitter from cutting a face
+//! clear across where the other solid's face does not reach, or classify
+//! coplanar contact per-fragment across sub-faces.
+
+use std::collections::HashMap;
+
+use vcad_kernel_booleans::{boolean_op, BooleanOp};
+use vcad_kernel_math::Transform;
+use vcad_kernel_primitives::{make_cube, make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::{tessellate_brep, TriangleMesh};
+
+const SEGMENTS: u32 = 44;
+
+fn apply(brep: &mut BRepSolid, t: &Transform) {
+    for (_, v) in &mut brep.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    brep.geometry.surfaces = brep
+        .geometry
+        .surfaces
+        .drain(..)
+        .map(|s| s.transform(t))
+        .collect();
+}
+
+fn bad_edges(mesh: &TriangleMesh) -> (usize, usize) {
+    let quantum = 1e-5;
+    let key = |vi: usize| -> [i64; 3] {
+        [
+            (mesh.vertices[vi * 3] as f64 / quantum).round() as i64,
+            (mesh.vertices[vi * 3 + 1] as f64 / quantum).round() as i64,
+            (mesh.vertices[vi * 3 + 2] as f64 / quantum).round() as i64,
+        ]
+    };
+    let mut uses: HashMap<([i64; 3], [i64; 3]), usize> = HashMap::new();
+    for tri in mesh.indices.chunks(3) {
+        let v = [
+            key(tri[0] as usize),
+            key(tri[1] as usize),
+            key(tri[2] as usize),
+        ];
+        for i in 0..3 {
+            let (a, b) = (v[i], v[(i + 1) % 3]);
+            if a == b {
+                continue;
+            }
+            let e = if a < b { (a, b) } else { (b, a) };
+            *uses.entry(e).or_default() += 1;
+        }
+    }
+    (
+        uses.values().filter(|&&n| n == 1).count(),
+        uses.values().filter(|&&n| n > 2).count(),
+    )
+}
+
+/// `teeth` bosses unioned one at a time onto a cylindrical blank, each
+/// spanning the blank's full height (flush caps) — `overhang` extends them
+/// past both caps instead.
+fn gear(teeth: usize, overhang: f64) -> BRepSolid {
+    let mut blank = make_cylinder(17.35, 8.0, SEGMENTS);
+    for i in 0..teeth {
+        let mut tooth = make_cube(1.2, 0.70, 8.0 + 2.0 * overhang);
+        apply(&mut tooth, &Transform::translation(17.3, -0.42, -overhang));
+        let ang = 2.0 * std::f64::consts::PI * (i as f64) / (teeth as f64);
+        apply(&mut tooth, &Transform::rotation_z(ang));
+        blank = boolean_op(&blank, &tooth, BooleanOp::Union, SEGMENTS)
+            .unwrap()
+            .into_brep()
+            .expect("union returned no B-rep");
+    }
+    blank
+}
+
+/// The workaround, and the proof that the arrangement is representable:
+/// with 0.5 mm of overhang the same teeth carry NO doubled surface. (A
+/// handful of hairline seams remain — the advisory population documented
+/// in `crate::mesh_report`; slicers close those, they do not fill bores
+/// over them.)
+#[test]
+fn overhanging_teeth_have_no_doubled_surface() {
+    let (open, over) = bad_edges(&tessellate_brep(&gear(16, 0.5), SEGMENTS));
+    assert_eq!(over, 0, "over-used edges with overhang (open = {open})");
+    assert!(open <= 8, "unexpectedly many hairline seams: {open}");
+}
+
+#[test]
+#[ignore = "known open defect: coplanar boss footprint straddling an earlier line split"]
+fn gear_teeth_are_manifold() {
+    let (open, over) = bad_edges(&tessellate_brep(&gear(16, 0.0), SEGMENTS));
+    assert_eq!(
+        (open, over),
+        (0, 0),
+        "flush-capped teeth: {open} unpaired + {over} over-used edges"
+    );
+}

--- a/crates/vcad-kernel-booleans/tests/nested_annulus_union_manifold.rs
+++ b/crates/vcad-kernel-booleans/tests/nested_annulus_union_manifold.rs
@@ -1,0 +1,182 @@
+//! Union whose operands are themselves differences — stacked annular
+//! rings, the shape every printed rotor/carrier/backplate is made of.
+//!
+//! Field report (2026-08-27): exported STLs of such parts carried hundreds
+//! to thousands of edges not shared by exactly two triangles. Bambu Studio
+//! flagged them ("3701 non-manifold edges") and its auto-repair resolved
+//! them by FILLING — a printed rotor came out with no shaft hole at all.
+//! Vertex welding did not move the count (flat from 1e-4 to 1e-1), because
+//! the defect is topological, not numeric.
+//!
+//! Two splitter bugs, both about a face's HOLES:
+//!
+//!  1. When a planar face was split by a circle, its existing hole loops
+//!     were routed to the disk or the ring sub-face by testing the hole's
+//!     CENTROID against the circle. Every concentric loop — whatever its
+//!     radius — has its centroid at the shared center, so a hole *larger*
+//!     than the splitting circle went to the disk: a face whose hole is
+//!     bigger than its own outer loop, which the tessellator draws as the
+//!     full disk (a membrane over the bore).
+//!  2. A circle lying entirely inside one of the face's holes was treated
+//!     as "inside the face" (only the outer loop was consulted), splitting
+//!     off a disk over the hole plus a redundant nested hole on the ring.
+//!
+//! Both produce doubled surface, which is exactly what a slicer reports.
+//! The assertions here are on manifoldness AND volume: a membrane over a
+//! bore is invisible to a volume check alone only until it is filled.
+
+use std::collections::HashMap;
+
+use vcad_kernel_booleans::{boolean_op, BooleanOp, BooleanResult};
+use vcad_kernel_math::{Point3, Transform};
+use vcad_kernel_primitives::{make_cylinder, BRepSolid};
+use vcad_kernel_tessellate::{tessellate_brep, TriangleMesh};
+
+const SEGMENTS: u32 = 32;
+
+fn translate(brep: &mut BRepSolid, dz: f64) {
+    let t = Transform::translation(0.0, 0.0, dz);
+    for (_, v) in &mut brep.topology.vertices {
+        v.point = t.apply_point(&v.point);
+    }
+    brep.geometry.surfaces = brep
+        .geometry
+        .surfaces
+        .drain(..)
+        .map(|s| s.transform(&t))
+        .collect();
+}
+
+fn solid(r: BooleanResult) -> BRepSolid {
+    r.into_brep().expect("boolean returned no B-rep")
+}
+
+/// (edges used once, edges used more than twice) on quantised positions —
+/// what an STL consumer sees.
+fn bad_edges(mesh: &TriangleMesh) -> (usize, usize) {
+    let quantum = 1e-5;
+    let key = |vi: usize| -> [i64; 3] {
+        [
+            (mesh.vertices[vi * 3] as f64 / quantum).round() as i64,
+            (mesh.vertices[vi * 3 + 1] as f64 / quantum).round() as i64,
+            (mesh.vertices[vi * 3 + 2] as f64 / quantum).round() as i64,
+        ]
+    };
+    let mut uses: HashMap<([i64; 3], [i64; 3]), usize> = HashMap::new();
+    for tri in mesh.indices.chunks(3) {
+        let v = [
+            key(tri[0] as usize),
+            key(tri[1] as usize),
+            key(tri[2] as usize),
+        ];
+        for i in 0..3 {
+            let (a, b) = (v[i], v[(i + 1) % 3]);
+            if a == b {
+                continue;
+            }
+            let e = if a < b { (a, b) } else { (b, a) };
+            *uses.entry(e).or_default() += 1;
+        }
+    }
+    (
+        uses.values().filter(|&&n| n == 1).count(),
+        uses.values().filter(|&&n| n > 2).count(),
+    )
+}
+
+fn mesh_volume(mesh: &TriangleMesh) -> f64 {
+    let mut v = 0.0;
+    for t in mesh.indices.chunks(3) {
+        let g = |i: u32| {
+            let k = i as usize * 3;
+            Point3::new(
+                mesh.vertices[k] as f64,
+                mesh.vertices[k + 1] as f64,
+                mesh.vertices[k + 2] as f64,
+            )
+        };
+        let (a, b, c) = (g(t[0]), g(t[1]), g(t[2]));
+        v += a.to_vec().dot(b.to_vec().cross(c.to_vec())) / 6.0;
+    }
+    v.abs()
+}
+
+/// An annular ring of height `h` whose base sits at `z`, built the way a
+/// .vcad model builds it: a difference of two cylinders.
+fn annulus(r_inner: f64, r_outer: f64, h: f64, z: f64) -> BRepSolid {
+    let outer = make_cylinder(r_outer, h, SEGMENTS);
+    let mut inner = make_cylinder(r_inner, h + 2.0, SEGMENTS);
+    translate(&mut inner, -1.0);
+    let mut ring = solid(boolean_op(&outer, &inner, BooleanOp::Difference, SEGMENTS).unwrap());
+    translate(&mut ring, z);
+    ring
+}
+
+fn check(base: BRepSolid, boss: BRepSolid, truth: f64, label: &str) {
+    for (part, name) in [(&base, "base"), (&boss, "boss")] {
+        let (open, over) = bad_edges(&tessellate_brep(part, SEGMENTS));
+        assert_eq!(
+            (open, over),
+            (0, 0),
+            "{label}: operand {name} is already non-manifold"
+        );
+    }
+    let u = solid(boolean_op(&base, &boss, BooleanOp::Union, SEGMENTS).unwrap());
+    let mesh = tessellate_brep(&u, SEGMENTS);
+    let (open, over) = bad_edges(&mesh);
+    assert_eq!(
+        (open, over),
+        (0, 0),
+        "{label}: {open} unpaired + {over} over-used edges — a slicer calls \
+         these non-manifold and its auto-repair fills the bore"
+    );
+    let vol = mesh_volume(&mesh);
+    assert!(
+        (vol - truth).abs() / truth < 0.01,
+        "{label}: volume {vol:.1} vs truth {truth:.1}"
+    );
+}
+
+/// The reported minimal case: a wide flat ring with a narrow ring stacked
+/// on it, their contact planes coincident. Scored 1902 bad edges.
+#[test]
+fn stacked_rings_face_to_face() {
+    let truth = std::f64::consts::PI * (46.0f64.powi(2) - 8.0f64.powi(2)) * 2.5
+        + std::f64::consts::PI * (27.5f64.powi(2) - 24.0f64.powi(2)) * 1.5;
+    check(
+        annulus(8.0, 46.0, 2.5, 0.0),
+        annulus(24.0, 27.5, 1.5, 2.5),
+        truth,
+        "coplanar contact",
+    );
+}
+
+/// Same pair interpenetrating rather than merely touching — the field
+/// report noted the count was identical either way, which is what
+/// pointed at the splitter rather than at coplanar-contact handling.
+#[test]
+fn stacked_rings_interpenetrating() {
+    let truth = std::f64::consts::PI * (46.0f64.powi(2) - 8.0f64.powi(2)) * 2.5
+        + std::f64::consts::PI * (27.5f64.powi(2) - 24.0f64.powi(2)) * 0.5;
+    check(
+        annulus(8.0, 46.0, 2.5, 0.0),
+        annulus(24.0, 27.5, 1.5, 1.5),
+        truth,
+        "interpenetrating",
+    );
+}
+
+/// The boss ring sits over the base's own bore wall (its inner radius is
+/// smaller than the base's), so the splitting circles land inside an
+/// existing hole — bug 2 above.
+#[test]
+fn boss_ring_overhanging_the_bore() {
+    let truth = std::f64::consts::PI * (46.0f64.powi(2) - 8.0f64.powi(2)) * 2.5
+        + std::f64::consts::PI * (12.0f64.powi(2) - 8.0f64.powi(2)) * 3.0;
+    check(
+        annulus(8.0, 46.0, 2.5, 0.0),
+        annulus(8.0, 12.0, 3.0, 2.5),
+        truth,
+        "boss over the bore",
+    );
+}

--- a/crates/vcad-loon/src/convert.rs
+++ b/crates/vcad-loon/src/convert.rs
@@ -612,6 +612,13 @@ fn is_solid_tag(tag: &str) -> bool {
     )
 }
 
+/// Smallest segment count the `-n` primitive forms accept.
+///
+/// Below this a count is far likelier to mean "give me this many flats"
+/// than "approximate this circle coarsely", and the `-n` forms cannot
+/// deliver flats — see `segments_val`.
+const MIN_SEGMENT_HINT: u32 = 8;
+
 /// What a converted sheet-metal node is, from the point of view of the ops
 /// that reference it. Only the rectangular base flange has named edges, and
 /// only on its own panel — everywhere else an edge is an index, because the
@@ -720,10 +727,22 @@ impl ConvertCtx {
     /// mistake; so is anything under 3, which cannot close a face loop.
     fn segments_val(&self, tag: &str, v: &Value) -> Result<u32, String> {
         let n = self.u32_val(v)?;
-        if n < 3 {
+        if n < MIN_SEGMENT_HINT {
+            // A count this low reads as a request for a FACETED PRISM —
+            // `[cylinder-n 7.5 24.0 6]` looks like a hex boss in review.
+            // It is not one: the segment count is a fidelity hint for the
+            // boolean/seam machinery, the surface stays an analytic
+            // cylinder, and the tessellator draws a circle. That lie
+            // shipped a round bore where a hex drive was specified, so
+            // refuse it rather than let the source say one thing and the
+            // solid be another.
             return Err(format!(
-                "{tag}: segments must be at least 3, got {n} \
-                 (drop the -n form to let the kernel choose)"
+                "{tag}: segments must be at least {MIN_SEGMENT_HINT}, got {n}. \
+                 The count is a fidelity hint for booleans and seams — the \
+                 surface stays a true circle, so a low count does NOT make a \
+                 faceted prism. For real facets use [prism sides radius height] \
+                 (or [hex-prism across-flats height]); to let the kernel \
+                 choose the fidelity, drop the -n form."
             ));
         }
         Ok(n)

--- a/crates/vcad-loon/tests/sheet_metal.rs
+++ b/crates/vcad-loon/tests/sheet_metal.rs
@@ -325,9 +325,23 @@ fn segment_count_is_authorable() {
         assert!(seg >= 48, "{src} lost its segment count");
     }
 
-    // Below 3 a circle cannot close a face loop; say so instead of silently
-    // clamping, since the author clearly meant something else.
-    assert!(err("[cylinder-n 10.0 20.0 2]").contains("at least 3"));
+    // A low count reads as "give me this many flats", which the -n forms
+    // cannot deliver: the surface stays an analytic circle. Refuse it and
+    // name the primitive that does make facets, instead of accepting
+    // source that says hexagon and builds a cylinder.
+    for src in ["[cylinder-n 10.0 20.0 2]", "[cylinder-n 7.5 24.0 6]"] {
+        let e = err(src);
+        assert!(e.contains("at least 8"), "{src}: {e}");
+        assert!(e.contains("prism"), "{src}: {e}");
+    }
+    // 8 and up is still a legitimate fidelity hint.
+    assert_eq!(
+        match ops(&doc("[cylinder-n 10.0 20.0 8]"))[0] {
+            CsgOp::Cylinder { segments, .. } => *segments,
+            ref other => panic!("unexpected op: {other:?}"),
+        },
+        8
+    );
 }
 
 // --- vendor imports -------------------------------------------------------

--- a/lib/src/lib.loon
+++ b/lib/src/lib.loon
@@ -181,12 +181,29 @@
 [let wedge [fn [x y z] [Wedge x y z]]]
 [let prism [fn [sides radius height] [Prism sides radius height]]]
 
-; Same primitives with an explicit segment count. The plain forms leave
-; faceting to the kernel default (32); reach for these when the facets are
-; load-bearing — a bore that has to pass a real shaft, a pulley whose pitch
-; diameter is measured off the mesh, anything conforming to a mating part.
-; A 32-segment inscribed circle sits 0.24% inside its nominal radius, which
-; is a 0.05 mm interference on a 20 mm bore.
+; Faceted prisms, sized the way a print is dimensioned. `polygon-prism` is
+; `prism` under a name that says what it makes; `hex-prism` takes the
+; ACROSS-FLATS size (what a wrench or a hex key measures) rather than the
+; circumradius: af = 2 r cos(30°), so r = af / sqrt(3).
+[let polygon-prism [fn [sides radius height] [Prism sides radius height]]]
+[let hex-prism [fn [across-flats height]
+  [Prism 6.0 [/ across-flats 1.7320508075688772] height]]]
+
+; Same primitives with an explicit segment count. The count is a FIDELITY
+; HINT: it sets how finely booleans and seams approximate the circle (the
+; kernel takes the larger count of the two operands), and it is NOT a face
+; count — the surface stays a true analytic circle whatever you pass.
+;
+; So `[cylinder-n r h 6]` is a CYLINDER, not a hexagonal prism. For real
+; flats — hex sockets, square drives, keyed bores — use `prism` /
+; `polygon-prism` / `hex-prism` below; counts under 8 are refused by the
+; -n forms for exactly that reason.
+;
+; Reach for the -n forms when boolean fidelity is load-bearing — a bore
+; that has to pass a real shaft, a pulley whose pitch diameter is measured
+; off the mesh, anything conforming to a mating part. A 32-segment
+; inscribed circle sits 0.24% inside its nominal radius, which is a 0.05 mm
+; interference on a 20 mm bore.
 [let cylinder-n [fn [r h n] [CylinderN r h n]]]
 [let sphere-n [fn [r n] [SphereN r n]]]
 [let cone-n [fn [r-bottom r-top h n] [ConeN r-bottom r-top h n]]]


### PR DESCRIPTION
Two defects found while 3D-printing real parts from loon models. One is fixed; the second is diagnosed, bisected, and captured as an `#[ignore]`d test rather than left as folklore.

## 1. Non-manifold exports from unions of stacked rings

Exported STLs carried hundreds to thousands of edges not shared by exactly two triangles. Bambu Studio reports them ("3701 non-manifold edges") and its auto-repair resolves them by **filling** — a printed rotor came out with no shaft hole at all. Welding vertices did not move the count (flat from 1e-4 to 1e-1 tolerance), so it is topology, not float precision.

The reported repro **never reached the mesh fallback**. It came out of the analytic B-rep path, from two bugs in the planar circle splitter, both about a face's *holes*:

1. **Hole routing by centroid.** When a planar face was split by a circle, its existing hole loops were assigned to the disk or ring sub-face by testing the hole's *centroid*. Every concentric loop — whatever its radius — has its centroid at the shared center, so a hole *larger* than the splitting circle went to the disk: a face whose hole is bigger than its own outer loop (an r24 disk carrying an r27.5 hole), which the tessellator draws as the full disk — a membrane over the bore. Replaced with a real containment test on the loop's vertices (`loop_vs_circle`: Inside / Outside / Coincident / Straddles).
2. **A circle lying inside one of the face's holes** counted as "inside the face" — only the outer loop was consulted — splitting off a disk over the hole plus a redundant nested hole on the ring.

Nested annular caps are exactly what a union-of-differences produces, which is why this only showed up on stacked rings.

**Measured**

| case | before | after |
|---|---|---|
| reported repro `pipe(ann(8,46,2.5), union(ann(24,27.5,1.5)))` | 1902 bad edges | **0**, volume 16965.4 vs 16965.8 analytic truth |
| `backplate.loon` | 2063 | **22** — and all 22 are *unpaired* hairline seams, no doubled surface |
| `carrier.loon` | manifold | manifold |

**Measurement, not repair.** `MeshReport` / `BooleanReport` gain `overused_edges`. The existing `open_edges` is a **net directed** count, so it cancels to zero on a doubled surface — it could not see this defect at all.

I first wired that up as a fallback trigger (swap in the mesh boolean whenever the B-rep result had over-used edges) and **reverted it after CI caught the cost**. The claim it rested on — that an over-used edge is never legitimate geometry — is false: instrumenting this crate's own catalogue shows known-good results scoring up to 13 over-used edges, b1's blade cut scoring 1, against 11 and 14 for the defects that motivated the measurement. The populations overlap exactly the way they do for open edges, and the swap did what the comment above it warns about: traded b1's analytic r45 wall for coarse soup, −505 mm³. So the count is reported and documented as advisory, and the repair stays where this PR actually puts it — at the root, in the splitters.

The mesh CSG also cancels coincident triangle pairs (zero-thickness flaps, which add no volume and so slip past the volume oracle).

## 2. `cylinder-n r h 6` silently rendering a circle

`[cylinder-n 7.5 24.0 6]` looks like a hex boss in source review and is not one: the third argument is a fidelity hint for the boolean/seam machinery, the surface stays an analytic cylinder, and the tessellator draws a circle. That shipped a "hex drive" that was a plain round bore and cost a print.

Worse, for a bare primitive the count never reaches tessellation at all — a cylinder exports at 32 segments whether the source says 8, 16, 48 or 96 — while `lib.loon` told authors to reach for these forms when bore fidelity is load-bearing.

The `-n` forms now fail closed under 8 and name the primitive that does make facets:

```
CylinderN: segments must be at least 8, got 6. The count is a fidelity hint for
booleans and seams — the surface stays a true circle, so a low count does NOT make
a faceted prism. For real facets use [prism sides radius height] (or [hex-prism
across-flats height]); to let the kernel choose the fidelity, drop the -n form.
```

The kernel already had a true faceted `Prism`, so this adds `polygon-prism sides radius height` and `hex-prism across-flats height` (across-flats — what a wrench or hex key measures; `[hex-prism 13.0 24.0]` verified at 13.0 mm flats, 12 verts / 20 tris), and rewrites the misleading `lib.loon` docstring.

Nothing in the repo or in the reporting model used a count below 8 (real usages are 16/20/24/48/64/96), so the floor breaks no existing source.

## Known open defect, not fixed here

`planet-72t` (2133), `ring-168t` (1711), `stator-proto` (635) are **unchanged** — a second, distinct class: a boss whose top and bottom faces are *flush* with the body's goes non-manifold when its footprint straddles a line an earlier boolean split clear across that face. Gear teeth are the canonical case.

Bisection: one tooth on a fresh blank is manifold at every angle; a second tooth is manifold everywhere except a ~3° band around 180° from the first — the diameter opposite it, because the first union's side-plane *lines* cut the cap all the way across. The doubled patch has zero net volume (a flap), which is why the volume oracle passes it.

Captured in `coplanar_boss_straddling_a_split.rs` with the full diagnosis: one `#[ignore]`d failing test, and one passing test proving the arrangement is representable (0.5 mm of overhang takes a 72-tooth blank from 1286 to 31 bad edges). Workaround for models today: give bosses a small overhang past the body's faces. On the full `planet-72t` that only gets 2133 → 922, so that part has further sources I did not chase.

The root fix is in the pipeline, not the splitters this PR touches: either stop the line splitter cutting a face clear across where the other solid's face does not reach, or classify coplanar contact per-fragment across sub-faces.

## Reviewer notes

- `DegradeReason` gains a `NonManifoldSwap` variant and `BooleanReport` an `overused_edges` field — additive, but they are public API.
- New regression tests: `nested_annulus_union_manifold.rs` (3 cases: coplanar contact, interpenetrating, boss over the bore — each asserting manifoldness *and* volume, since a membrane over a bore is invisible to a volume check alone until it is filled).
- `cargo test` green across `vcad-kernel-booleans`, `vcad-eval`, `vcad-kernel`, `vcad-kernel-tessellate`, `vcad-loon` (38 test binaries, 0 failures); clippy and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
