### PR TITLE
Mac app: release-to-desktop as the only mode, with working panes and picking

### DIFF
--- a/apple/VcadApp/Sources/CVcadFFI/vcad_ffi.h
+++ b/apple/VcadApp/Sources/CVcadFFI/vcad_ffi.h
@@ -107,6 +107,16 @@ VcadEdges *vcad_mesh_edges(const VcadMesh *mesh, float angle_deg);
 VcadEdgesView vcad_edges_view(const VcadEdges *edges);
 void vcad_edges_free(VcadEdges *edges);
 
+/* Per-triangle FACE ids for a scene part: one u32 per triangle of
+ * vcad_scene_part_mesh, naming which face of the solid produced it (ordinal
+ * within the shell). UINT32_MAX marks a triangle with no face (bridging fill).
+ * Writes the count to out_len; returns NULL when the part carries no tags
+ * (e.g. a frozen or imported mesh with no B-rep), so face picking is an
+ * optional capability. Borrows the scene; valid until the scene is freed.
+ * NOT durable across edits — any change to the B-rep renumbers the ordinals. */
+const uint32_t *vcad_scene_part_face_ids(const VcadScene *scene, size_t index,
+                                         size_t *out_len);
+
 /* Direct BRep ray tracing (pixel-perfect mode): rays hit analytic surfaces,
  * no tessellation. Kernel coords (Z-up, mm); colors = 3 f32 per part
  * (linear RGB); RGBA8 row-major output. CPU renderer today, signature is

--- a/apple/VcadApp/Sources/VcadApp/AppInstance.swift
+++ b/apple/VcadApp/Sources/VcadApp/AppInstance.swift
@@ -1,0 +1,90 @@
+#if canImport(AppKit)
+import AppKit
+#endif
+import Foundation
+
+/// Opening a second document opens a second COPY OF THE APP.
+///
+/// The ask was "each tab is another icon in the Dock, and ⌘-Tab shows them
+/// separately". macOS does not offer that within one process: the Dock tile and
+/// the ⌘-Tab entry belong to the *application*, not to its windows, so a
+/// document-per-window app (Pages, Xcode) shows exactly one of each no matter
+/// how many documents are open. `NSApp.dockTile` customises that single tile; it
+/// does not mint new ones. There is no supported API for a second tile short of
+/// a second app bundle — which would mean shipping a decoy bundle pretending to
+/// be vcad, and would still be one tile per bundle rather than per document.
+///
+/// So a document is an app INSTANCE. That is a real fit rather than a
+/// workaround here: release-to-desktop has no window of its own — the app *is*
+/// the parts floating over the desktop — so "another window" was already a
+/// fiction, while another instance gives each document its own Dock tile (which
+/// already renders that document's viewport), its own ⌘-Tab entry, its own menu
+/// bar, and its own crash domain.
+///
+/// The cost is that instances share nothing but the disk: no cross-document
+/// undo, no shared selection, and anything written to `UserDefaults` is
+/// last-writer-wins (see `EditorModel.rememberRecent`).
+@MainActor
+enum AppInstance {
+    /// This instance's document, for the AppDelegate paths that have no view
+    /// to read it from (Finder open/drop). Weak: the model outlives nothing.
+    weak static var currentModel: EditorModel?
+
+    /// Launch another copy of this app, optionally opening a document.
+    ///
+    /// `createsNewApplicationInstance` is the whole trick: without it the
+    /// launch is a no-op that just activates the running copy.
+    static func open(document url: URL? = nil) {
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        config.activates = true
+        // Pass the document as an argument rather than an environment variable:
+        // env is inherited by anything the instance spawns, and a stale
+        // VCAD_OPEN two launches later would silently reopen the wrong file.
+        if let url { config.arguments = [Self.openFlag, url.path] }
+
+        let me = Bundle.main.bundleURL
+        NSWorkspace.shared.openApplication(at: me, configuration: config) { _, error in
+            guard let error else { return }
+            // Not fatal: the current instance is still usable, and saying so is
+            // better than a menu item that silently does nothing.
+            FileHandle.standardError.write(
+                Data("[vcad] could not open a new instance: \(error.localizedDescription)\n".utf8))
+        }
+    }
+
+    /// The flag this app passes to itself. Not a user-facing CLI.
+    static let openFlag = "--vcad-open"
+
+    /// The document this instance was launched to open, if any.
+    ///
+    /// Accepts the launch argument, the `VCAD_OPEN` dev hook, and a bare path
+    /// argument (so `open -a vcad --args file.vcad` and a drop onto the icon
+    /// both work).
+    static func launchDocument() -> URL? {
+        let args = CommandLine.arguments
+        if let i = args.firstIndex(of: openFlag), i + 1 < args.count {
+            return URL(fileURLWithPath: args[i + 1])
+        }
+        if let path = ProcessInfo.processInfo.environment["VCAD_OPEN"], !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+        if let bare = args.dropFirst().first(where: { $0.hasSuffix(".vcad") || $0.hasSuffix(".loon") }) {
+            return URL(fileURLWithPath: bare)
+        }
+        return nil
+    }
+
+    /// Where a document should open: in this instance, or a new one.
+    ///
+    /// An untouched sandbox is a scratch instance — reuse it, the way a Mac app
+    /// reuses its empty Untitled window. Anything else already has a document
+    /// worth keeping on screen, so the new one gets its own instance.
+    static func opening(_ url: URL, from model: EditorModel) {
+        if model.isDisposableScratch {
+            model.openDocument(url)
+        } else {
+            open(document: url)
+        }
+    }
+}

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -2006,12 +2006,42 @@ final class EditorModel {
 
     func newDocument() { source = .sandbox }
 
+    /// True when this instance holds nothing worth keeping on screen: a fresh
+    /// sandbox nobody has touched. Opening a document into one of these reuses
+    /// the instance, the way a Mac app reuses its empty Untitled window; opening
+    /// into anything else would throw away work, so that gets a new instance.
+    var isDisposableScratch: Bool {
+        source.isSandbox && !canUndo && !documentDirty
+    }
+
     func openDocument(_ url: URL) {
         source = .document(path: url.path, label: url.deletingPathExtension().lastPathComponent)
-        recents.removeAll { $0 == url }
-        recents.insert(url, at: 0)
-        if recents.count > 8 { recents = Array(recents.prefix(8)) }
-        UserDefaults.standard.set(recents.map { $0.path }, forKey: "vcad.recents")
+        rememberRecent(url)
+    }
+
+    /// Add `url` to the recents list.
+    ///
+    /// Re-reads the stored list first rather than editing this instance's copy:
+    /// several instances run at once now, and each one holds the list as it
+    /// looked when IT launched. Writing that stale copy back would drop every
+    /// document the other instances opened in the meantime. Concurrent writes
+    /// are still last-writer-wins — this narrows the window to the write itself
+    /// instead of the whole lifetime of the process.
+    private func rememberRecent(_ url: URL) {
+        let stored = (UserDefaults.standard.array(forKey: "vcad.recents") as? [String] ?? [])
+            .map { URL(fileURLWithPath: $0) }
+        var merged = stored
+        merged.removeAll { $0 == url }
+        merged.insert(url, at: 0)
+        if merged.count > 8 { merged = Array(merged.prefix(8)) }
+        recents = merged
+        UserDefaults.standard.set(merged.map { $0.path }, forKey: "vcad.recents")
+    }
+
+    /// Pick up recents opened by other instances since this one launched.
+    func refreshRecents() {
+        recents = (UserDefaults.standard.array(forKey: "vcad.recents") as? [String] ?? [])
+            .map { URL(fileURLWithPath: $0) }
     }
 
     // MARK: tool palette

--- a/apple/VcadApp/Sources/VcadApp/Editor.swift
+++ b/apple/VcadApp/Sources/VcadApp/Editor.swift
@@ -102,6 +102,15 @@ enum ToolTab: String, CaseIterable, Identifiable {
         case .combine: return "square.on.square.dashed"
         }
     }
+    /// The palette's resting hint — what this page of the palette is for, shown
+    /// when the pointer is not over a tool.
+    var paletteHint: String {
+        switch self {
+        case .create: return "Add geometry to the document"
+        case .modify: return "Edit the selected part"
+        case .combine: return "Boolean two selected parts"
+        }
+    }
 }
 
 /// A boolean combine operation (the Combine tab — acts on two selected parts).
@@ -253,6 +262,8 @@ final class EditorModel {
     var sizeMM: SIMD3<Float> = .zero
 
     // Picking.
+    /// Why the last evaluation produced nothing, when it produced nothing.
+    var loadError: String?
     var pickPoint: SIMD3<Float>?
     var pickInfo: String?
     var pickDirty = false
@@ -293,6 +304,21 @@ final class EditorModel {
     var multiSelectedParts: [Int] = []
     /// Part under the cursor (documents) — drives a subtle hover highlight.
     var hoveredPartIndex: Int?
+    /// Assembly instance under the cursor / selected, by render index.
+    ///
+    /// Assemblies draw one entity per INSTANCE, not per root part, so the
+    /// part-index selection path could never touch them: every link of a robot
+    /// was inert — no hover, no click, and an inspector that said "select a
+    /// feature in the tree" while you were pointing right at one.
+    var hoveredInstanceIndex: Int?
+    var selectedInstanceIndex: Int?
+    /// Instances currently lit. A viewport hover lights exactly one; hovering a
+    /// tree row lights every instance drawn from that row's part def, because
+    /// the row *is* the definition — one row, four elbows on a quadruped.
+    var hoveredInstances: Set<Int> = []
+    /// The tree row that is hot, whichever side the pointer is on. Hovering
+    /// geometry highlights its row; hovering a row highlights its geometry.
+    var hoveredFeatureID: String?
     var hoverDirty = false
     /// Zebra surface analysis: striped environment reflected off chromed parts,
     /// so stripe continuity reveals curvature/tangency defects.
@@ -300,8 +326,22 @@ final class EditorModel {
     var zebraDirty = false
     /// Release-to-desktop: the window goes transparent + chromeless and the
     /// parts float over the desktop (environment kept for lighting only).
-    var releaseMode = false { didSet { if releaseMode != oldValue { releaseDirty = true } } }
-    var releaseDirty = false
+    /// Release-to-desktop is the app's only mode — the parts always float over
+    /// the desktop in the borderless overlay. Kept as a constant so the scene
+    /// code that dresses the studio (floor, grid, ambient blob) keeps reading a
+    /// single source of truth instead of hard-coding the answer at each site.
+    let releaseMode = true
+    /// Panels the released overlay can close (BCB-style) and re-open from View.
+    var showsPalette = true
+    var showsTree = true
+    var showsInspector = true
+
+    /// Show or hide every floating panel at once.
+    func setPanels(shown: Bool) {
+        showsPalette = shown
+        showsTree = shown
+        showsInspector = shown
+    }
     /// Per-part kernel-space triangle meshes (+ AABB), index-aligned with the
     /// rendered parts — the basis for precise ray-triangle hover/pick. The AABB
     /// is a broadphase cull before the triangle test.
@@ -693,16 +733,131 @@ final class EditorModel {
     /// Single-select a row (clears any multi-selection).
     func selectFeature(_ id: String) {
         if !multiSelectedParts.isEmpty { multiSelectedParts = [] }
+        // A row click supersedes a click on geometry: leaving the old instance
+        // set would keep an unrelated body lit.
+        selectedInstanceIndex = nil
         selectedFeatureID = id
     }
     /// Whether anything is selected (drives Escape/empty-click deselect).
-    var hasSelection: Bool { selectedFeatureID != nil || !multiSelectedParts.isEmpty }
+    var hasSelection: Bool {
+        selectedFeatureID != nil || !multiSelectedParts.isEmpty || selectedInstanceIndex != nil
+    }
     /// Clear all selection — empty-space click or Escape (documents only).
     func deselectAll() {
         multiSelectedParts = []
+        selectedInstanceIndex = nil
         selectedFeatureID = nil
         selectionDirty = true
     }
+    // MARK: assembly instances
+
+    /// The document's instance list, as authored (index-aligned with the
+    /// rendered instances — the evaluator preserves order).
+    private var instanceDicts: [[String: Any]] {
+        (documentJSON?["instances"] as? [[String: Any]]) ?? []
+    }
+
+    /// An instance's display name, falling back to its id.
+    func instanceName(_ i: Int) -> String? {
+        guard i < instanceDicts.count else { return nil }
+        let d = instanceDicts[i]
+        return (d["name"] as? String) ?? (d["id"] as? String)
+    }
+
+    /// The part definition an instance is an instance OF.
+    func instancePartDefName(_ i: Int) -> String? {
+        guard i < instanceDicts.count,
+              let key = instanceDicts[i]["partDefId"] as? String else { return nil }
+        let defs = documentJSON?["partDefs"] as? [String: Any]
+        let def = defs?[key] as? [String: Any]
+        return (def?["name"] as? String) ?? key
+    }
+
+    /// The feature-tree row for the geometry an instance draws: its part def's
+    /// root node. Selecting an instance therefore lands you on the DAG that
+    /// produced it — edit the link's cube there and every instance follows.
+    func instanceFeatureNode(_ i: Int) -> FeatureNode? {
+        guard i < instanceDicts.count,
+              let key = instanceDicts[i]["partDefId"] as? String,
+              let defs = documentJSON?["partDefs"] as? [String: Any],
+              let def = defs[key] as? [String: Any],
+              let root = (def["root"] as? NSNumber)?.intValue else { return nil }
+        return Self.findNode(featureNodes, nodeId: root)
+    }
+
+    private static func findNode(_ nodes: [FeatureNode], nodeId: Int) -> FeatureNode? {
+        for n in nodes {
+            if n.nodeId == nodeId { return n }
+            if let f = findNode(n.children, nodeId: nodeId) { return f }
+        }
+        return nil
+    }
+
+    /// Every instance drawn from a given DAG node (a part def's root).
+    func instanceIndices(forNodeId nodeId: Int) -> [Int] {
+        guard let defs = documentJSON?["partDefs"] as? [String: Any] else { return [] }
+        let keys = defs.compactMap { key, value -> String? in
+            guard let def = value as? [String: Any],
+                  (def["root"] as? NSNumber)?.intValue == nodeId else { return nil }
+            return key
+        }
+        guard !keys.isEmpty else { return [] }
+        return instanceDicts.enumerated().compactMap { i, d in
+            (d["partDefId"] as? String).map { keys.contains($0) ? i : nil } ?? nil
+        }
+    }
+
+    /// The instances the viewport should show as selected.
+    ///
+    /// Clicking geometry selects one instance. Clicking a TREE ROW selects a
+    /// part definition, which may have been instanced many times — so the
+    /// selection is a set, derived from whichever side did the selecting.
+    /// Without this an assembly row click changed `selectedFeatureID` and
+    /// nothing else: the tree highlighted, the viewport sat there.
+    var selectedInstances: Set<Int> {
+        if let i = selectedInstanceIndex { return [i] }
+        guard assemblyInstanceCount > 0, let node = selectedFeatureNode else { return [] }
+        return Set(instanceIndices(forNodeId: node.nodeId))
+    }
+
+    /// Hover driven from the feature tree: light the row and everything it drew.
+    func hoverFeature(_ node: FeatureNode?) {
+        hoveredFeatureID = node?.id
+        hoveredPartIndex = node?.partIndex
+        hoveredInstances = node.map { Set(instanceIndices(forNodeId: $0.nodeId)) } ?? []
+    }
+
+    /// Hover driven from the viewport: light the body and its row.
+    func hoverBody(part: Int?, instance: Int?) {
+        hoveredPartIndex = part
+        hoveredInstanceIndex = instance
+        hoveredInstances = instance.map { [$0] } ?? []
+        if let part {
+            hoveredFeatureID = Self.findNode(featureNodes, partIndex: part)?.id
+        } else if let instance {
+            hoveredFeatureID = instanceFeatureNode(instance)?.id
+        } else {
+            hoveredFeatureID = nil
+        }
+    }
+
+    private static func findNode(_ nodes: [FeatureNode], partIndex: Int) -> FeatureNode? {
+        for n in nodes {
+            if n.partIndex == partIndex { return n }
+            if let f = findNode(n.children, partIndex: partIndex) { return f }
+        }
+        return nil
+    }
+
+    /// Click an instance: it becomes the selection, and the tree follows to the
+    /// part def it draws.
+    func selectInstance(_ i: Int) {
+        multiSelectedParts = []
+        selectedInstanceIndex = i
+        selectedFeatureID = instanceFeatureNode(i)?.id
+        selectionDirty = true
+    }
+
     /// ⌘-click: toggle a part in the multi-selection; the last click stays primary.
     func toggleMultiSelect(part pi: Int, featureID id: String) {
         if let idx = multiSelectedParts.firstIndex(of: pi) { multiSelectedParts.remove(at: idx) }
@@ -791,6 +946,37 @@ final class EditorModel {
         guard documentJSON != nil else { return }
         applyEdit(snapshot: true, reeval: .rebuild) { DocEdit.addPrimitiveRoot(&$0, shape: shape) }
         selectedFeatureID = featureNodes.last?.id        // focus the new part
+    }
+
+    /// Add a primitive and move it to a point in kernel space (mm) — the
+    /// palette's click-to-place. Two edits, one undo step apart: the add is the
+    /// creation, the move is where you put it.
+    func addPrimitive(_ shape: BaseShape, at p: SIMD3<Float>) {
+        addPrimitive(shape)
+        guard let pi = selectedPartIndex else { return }
+        applyEdit(snapshot: false, reeval: .rebuild) {
+            DocEdit.setRootTranslate(&$0, partIndex: pi,
+                                     Double(p.x), Double(p.y), Double(p.z))
+        }
+    }
+
+    // MARK: armed tool (the Borland palette idiom: pick a component, then place it)
+
+    /// The primitive the palette has armed, waiting for a click in the scene.
+    /// Nil means the pointer is a pointer.
+    var armedShape: BaseShape?
+
+    func arm(_ shape: BaseShape) {
+        armedShape = (armedShape == shape) ? nil : shape
+    }
+    func disarm() { armedShape = nil }
+
+    /// Replace the selection with everything a marquee caught.
+    func selectParts(_ parts: [Int]) {
+        guard !parts.isEmpty else { deselectAll(); return }
+        multiSelectedParts = parts.count == 1 ? [] : parts
+        selectedFeatureID = featureNodes.first(where: { $0.partIndex == parts[0] })?.id
+        selectionDirty = true
     }
 
     /// Combine the two ⌘-selected parts with a boolean op (first = base).
@@ -1273,7 +1459,15 @@ final class EditorModel {
         let scene: OpaquePointer? = data.withUnsafeBytes {
             vcad_scene_from_json($0.bindMemory(to: UInt8.self).baseAddress, data.count)
         }
-        guard let scene else { return nil }
+        guard let scene else {
+            // The kernel refused the document. This used to return nil and
+            // leave the app showing an empty viewport with a fully populated
+            // feature tree — the Swift-side DAG parser is lenient, the kernel is
+            // not, so a schema-stale file looked like a renderer bug. Say so.
+            loadError = SimError.pending() ?? "The kernel could not evaluate this document"
+            return nil
+        }
+        loadError = nil
         defer { vcad_scene_free(scene) }
         let count = vcad_scene_part_count(scene)
         var meshes: [MeshResource] = []
@@ -1827,11 +2021,15 @@ final class EditorModel {
         switch tab {
         case .create:
             var out = BaseShape.allCases.map { shape in
-                // Sandbox: pick the primitive. Document: add a new part.
+                // Sandbox: pick the primitive. Document: ARM the tool — the
+                // palette hands the click to the scene, where it lands where you
+                // point (Borland's pick-then-place, which is also how every CAD
+                // app places geometry).
                 Tool(id: "shape.\(shape.rawValue)",
                      label: docMode ? "Add \(shape.label)" : shape.label, symbol: shape.symbol,
-                     isActive: !docMode && baseShape == shape) { [weak self] in
-                    if docMode { self?.addPrimitive(shape) } else { self?.baseShape = shape }
+                     isActive: docMode ? armedShape == shape : baseShape == shape,
+                     hint: docMode ? "Click in the scene to place it" : "") { [weak self] in
+                    if docMode { self?.arm(shape) } else { self?.baseShape = shape }
                 }
             }
             if docMode {
@@ -2124,7 +2322,15 @@ final class EditorModel {
                                         d.baseAddress, d.count)
             }
         }
-        guard let scene else { return .empty }
+        guard let scene else {
+            // The kernel refused the document. Returning `.empty` here left the
+            // app showing a fully populated feature tree over an empty viewport:
+            // the Swift-side DAG parser is lenient, the kernel is not, so a
+            // schema-stale file read as a renderer bug. Say what happened.
+            loadError = SimError.pending() ?? "The kernel could not evaluate this document"
+            return .empty
+        }
+        loadError = nil
         if vcad_scene_instance_count(scene) > 0 {
             return assemblyScene(adopting: scene, start: start)
         }

--- a/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
+++ b/apple/VcadApp/Sources/VcadApp/ReleasedDesktop.swift
@@ -39,9 +39,22 @@ final class ReleaseWindowController {
     /// Chrome regions (tool windows, pill) in overlay view coords (top-left
     /// origin), reported by SwiftUI — the overlay owns the mouse over these.
     var chromeRects: [String: CGRect] = [:]
+    /// The document being edited, for the hover pass (which runs off an AppKit
+    /// event monitor, outside any SwiftUI view).
+    private weak var model: EditorModel?
+    /// Part under the pointer, and the gizmo handle under it. Mirrored into the
+    /// model (`hoveredPartIndex`) so panels can read it; kept here too because
+    /// the hover pass must know what to un-highlight.
+    private(set) var hoveredPart: Int?
+    private(set) var hoveredInstance: Int?
+    private var paintedInstances: Set<Int> = []
+    private var paintedPart: Int?
+    private var hoveredHandle: String?
+    private var pointerOverScene = false
 
     func show(model: EditorModel, intent: IntentEngine) {
         guard window == nil else { return }
+        self.model = model
         mainWindow = NSApp.keyWindow ?? NSApp.mainWindow
 
         let frame = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 1440, height: 900)
@@ -55,6 +68,7 @@ final class ReleaseWindowController {
         w.contentView = NSHostingView(rootView: ReleasedOverlayView(model: model, intent: intent))
         w.makeKeyAndOrderFront(nil)
         window = w
+        DockIcon.shared.follow(model: model)
         mainWindow?.orderOut(nil)
 
         let update: () -> Void = { [weak self] in self?.updatePassThrough() }
@@ -64,6 +78,21 @@ final class ReleaseWindowController {
         mouseMonitors.append(NSEvent.addLocalMonitorForEvents(matching: [.mouseMoved]) { e in
             Task { @MainActor in update() }
             return e
+        } as Any)
+        // Scroll to dolly, the way every desktop CAD app does it. Only over the
+        // scene: over a tool window the event has to reach its ScrollView, and
+        // over the desktop the window is already transparent to the mouse.
+        mouseMonitors.append(NSEvent.addLocalMonitorForEvents(matching: [.scrollWheel]) { [weak self] e in
+            guard let self else { return e }
+            // Precise (trackpad / Magic Mouse) deltas are already in points and
+            // arrive in a fine stream; a notched wheel sends few, large ticks.
+            // Scaling them the same way makes the wheel unusable. Read the event
+            // out here — NSEvent cannot cross into an isolated closure.
+            let dy = e.hasPreciseScrollingDeltas
+                ? Float(e.scrollingDeltaY) * 0.004
+                : Float(e.scrollingDeltaY) * 0.06
+            let consumed = MainActor.assumeIsolated { self.dolly(by: dy) }
+            return consumed ? nil : e
         } as Any)
         updatePassThrough()
     }
@@ -92,6 +121,27 @@ final class ReleaseWindowController {
                        y: CGFloat(0.5 - ndcY * 0.5) * size.height)
     }
 
+    /// Every collision hit under a **SwiftUI** point, nearest first.
+    ///
+    /// Two coordinate spaces meet in this file and they disagree about which
+    /// way is up:
+    ///
+    /// * SwiftUI gestures report top-left-origin points.
+    /// * `NSEvent.mouseLocation` → `convertPoint(fromScreen:)` → `ar.convert`
+    ///   gives bottom-left-origin points on an unflipped view.
+    ///
+    /// `ARView.hitTest` wants the latter. So SwiftUI points must be flipped —
+    /// and AppKit-derived points must NOT be. Getting either one backwards
+    /// mirrors picking about the horizontal midline, which is invisible on a
+    /// single centred body (you hit the same thing either way) and obvious on a
+    /// stack: point at the wrist, highlight the base.
+    func hits(atViewPoint p: CGPoint) -> [CollisionCastHit] {
+        guard let ar = arView else { return [] }
+        var vp = p
+        if !ar.isFlipped { vp.y = ar.bounds.height - vp.y }
+        return ar.hitTest(vp)
+    }
+
     /// Overlay size, for clamping floating chrome on screen.
     var overlaySize: CGSize { arView?.bounds.size ?? .zero }
 
@@ -100,20 +150,253 @@ final class ReleaseWindowController {
     private func updatePassThrough() {
         guard let w = window else { return }
         guard NSEvent.pressedMouseButtons == 0 else { return }
-        if sketchModal { w.ignoresMouseEvents = false; return }
+        if sketchModal {
+            w.ignoresMouseEvents = false
+            pointerOverScene = true
+            return
+        }
         let winPoint = w.convertPoint(fromScreen: NSEvent.mouseLocation)
         let topLeft = CGPoint(x: winPoint.x, y: w.frame.height - winPoint.y)
         if chromeRects.values.contains(where: { $0.insetBy(dx: -8, dy: -8).contains(topLeft) }) {
             w.ignoresMouseEvents = false
+            pointerOverScene = false
+            clearHover()                       // the pointer left the model
             return
         }
         guard let ar = arView else { return }
-        var viewPoint = ar.convert(winPoint, from: nil)
-        if !ar.isFlipped { viewPoint.y = ar.bounds.height - viewPoint.y }
-        w.ignoresMouseEvents = ar.hitTest(viewPoint).isEmpty
+        // `winPoint` came from AppKit, so it is ALREADY in hitTest's space once
+        // converted into the view — no flip here. The flip belongs to the
+        // SwiftUI path (see `hits(atViewPoint:)`); doing it in both places is
+        // what made hover point at the mirror image of the pointer.
+        let viewPoint = ar.convert(winPoint, from: nil)
+        // ONE raycast serves both jobs: whether we own the mouse, and what the
+        // pointer is over. Hover used to cost nothing because it did not exist;
+        // a second raycast per mouse-moved would have been the lazy way to add it.
+        // Annotated: ARView's RealityKit hitTest overload and NSView's own
+        // hitTest(_:) are both in scope, and the inferred winner is the NSView.
+        let hits: [CollisionCastHit] = ar.hitTest(viewPoint)
+        w.ignoresMouseEvents = hits.isEmpty
+        pointerOverScene = !hits.isEmpty
+        updateHover(hits)
+    }
+
+    /// Zoom by a scroll delta. Returns whether the scroll was consumed — over a
+    /// tool window it must not be, or the feature tree stops scrolling.
+    private func dolly(by dy: Float) -> Bool {
+        guard pointerOverScene, dy != 0, let m = model else { return false }
+        m.stopSpin()
+        m.distance = max(0.45, min(8.0, m.distance * (1 - dy)))
+        m.pinchBaseline = m.distance
+        return true
+    }
+
+    // MARK: hover
+
+    /// Highlight what the pointer is over, set the cursor that says what a click
+    /// will do, and publish the surface readout. Runs on every mouse-moved, so
+    /// every step is change-guarded — re-assigning an identical material or an
+    /// identical cursor is a per-frame cost for no pixels.
+    private func updateHover(_ hits: [CollisionCastHit]) {
+        guard let model else { return }
+        if model.sketching { NSCursor.crosshair.set(); return }
+        // An armed palette tool retargets the whole pointer: the next click
+        // places geometry, so it must not also read as "select this part".
+        if model.armedShape != nil {
+            setHovered(part: nil, instance: nil)
+            NSCursor.crosshair.set()
+            return
+        }
+        if model.draggingHandle { return }             // the drag owns the cursor
+
+        // Gizmo handles sit on top of the part they move, and grabbing one is a
+        // different act from selecting the part — so they win the hover.
+        let handle = model.showsGizmo
+            ? hits.compactMap({ model.gizmoHandle(for: $0.entity.name) != nil ? $0.entity.name : nil }).first
+            : nil
+        if handle != hoveredHandle {
+            hoveredHandle = handle
+            model.hoveredGizmoHandle = handle
+            model.gizmoDirty = true
+        }
+        if handle != nil {
+            setHovered(part: nil, instance: nil)
+            NSCursor.openHand.set()
+            return
+        }
+
+        // Parts and instances are the same gesture to a user — "the thing under
+        // the pointer" — and differ only in which entity the renderer built.
+        let hit = hits.first(where: { Self.partIndex($0.entity) != nil
+                                      || Self.instanceIndex($0.entity) != nil })
+        setHovered(part: hit.flatMap { Self.partIndex($0.entity) },
+                   instance: hit.flatMap { Self.instanceIndex($0.entity) })
+        publishPick(hit)
+        ((hoveredPart ?? hoveredInstance) != nil ? NSCursor.pointingHand : NSCursor.arrow).set()
+    }
+
+    private func clearHover() {
+        guard let model else { return }
+        setHovered(part: nil, instance: nil)
+        publishPick(nil)
+        if hoveredHandle != nil {
+            hoveredHandle = nil
+            model.hoveredGizmoHandle = nil
+            model.gizmoDirty = true
+        }
+        NSCursor.arrow.set()
+    }
+
+    /// Repaint every part's highlight state. Cheap: it walks the built entities
+    /// and assigns materials — no tessellation, no colliders, no new entities.
+    func repaintAll() {
+        guard let model, let centering = centeringEntity else { return }
+        let hot = model.hoveredInstances
+        for i in 0..<model.partCount where centering.findEntity(named: "part\(i)") != nil {
+            paint(entity: "part\(i)",
+                  lift: model.hoveredPartIndex == i ? .hover : liftForPart(i))
+        }
+        for i in 0..<model.assemblyInstanceCount where centering.findEntity(named: "inst\(i)") != nil {
+            paint(entity: "inst\(i)", lift: hot.contains(i) ? .hover : liftForInstance(i))
+        }
+        paintedPart = model.hoveredPartIndex
+        paintedInstances = hot
+    }
+
+    /// Re-apply the hover lift after a rebuild. Selection changes rebuild the
+    /// scene, which paints fresh materials — without this the part under the
+    /// pointer goes dull the instant you click it, until you jiggle the mouse.
+    func repaintHover() {
+        paintedPart = nil
+        paintedInstances = []
+        syncHoverPaint()
+    }
+
+    private func setHovered(part: Int?, instance: Int?) {
+        guard let model else { return }
+        if part != hoveredPart || instance != hoveredInstance {
+            hoveredPart = part
+            hoveredInstance = instance
+            model.hoverBody(part: part, instance: instance)
+        }
+        syncHoverPaint()
+    }
+
+    /// Paint the difference between what is lit and what should be lit. The
+    /// model owns "what should be" — the tree can set it too — so this diffs
+    /// rather than assuming the viewport was the last writer.
+    func syncHoverPaint() {
+        guard let model else { return }
+        let want = model.hoveredInstances
+        for i in paintedInstances.subtracting(want) {
+            paint(entity: "inst\(i)", lift: liftForInstance(i))
+        }
+        for i in want.subtracting(paintedInstances) {
+            paint(entity: "inst\(i)", lift: .hover)
+        }
+        paintedInstances = want
+        let part = model.hoveredPartIndex
+        if part != paintedPart {
+            if let previous = paintedPart { paint(entity: "part\(previous)", lift: liftForPart(previous)) }
+            if let part { paint(entity: "part\(part)", lift: .hover) }
+            paintedPart = part
+        }
+    }
+
+    /// How a part/instance should read right now, ignoring the pointer.
+    private func liftForPart(_ i: Int) -> Lift {
+        (model?.highlightedParts.contains(i) ?? false) ? .selected : .none
+    }
+    private func liftForInstance(_ i: Int) -> Lift {
+        (model?.selectedInstances.contains(i) ?? false) ? .selected : .none
+    }
+
+    /// The three states a body can be in. Selection is brand orange; hover on
+    /// top of it brightens rather than replaces, so a selected body never looks
+    /// deselected under the pointer.
+    enum Lift {
+        case none, selected, hover
+    }
+
+    /// The hover lift, applied straight to the live material — NOT through a
+    /// geometry rebuild. Re-tessellating a document because the pointer crossed
+    /// a face is how a viewport starts dropping frames.
+    private func paint(entity name: String, lift: Lift) {
+        guard let e = centeringEntity?.findEntity(named: name) as? ModelEntity,
+              var m = e.model?.materials.first as? PhysicallyBasedMaterial else { return }
+        switch lift {
+        case .hover where isSelected(name):
+            m.emissiveColor = .init(color: NSColor(red: 1.0, green: 0.68, blue: 0.24, alpha: 1))
+            m.emissiveIntensity = 0.6
+        case .selected:
+            m.emissiveColor = .init(color: NSColor(red: 1.0, green: 0.62, blue: 0.12, alpha: 1))
+            m.emissiveIntensity = 0.35
+        case .hover:
+            m.emissiveColor = .init(color: .white)
+            m.emissiveIntensity = 0.16
+        case .none:
+            m.emissiveIntensity = 0
+        }
+        e.model?.materials = [m]
+    }
+
+    private func isSelected(_ name: String) -> Bool {
+        if let i = Int(name.dropFirst(4)), name.hasPrefix("part") {
+            return model?.highlightedParts.contains(i) ?? false
+        }
+        if let i = Int(name.dropFirst(4)), name.hasPrefix("inst") {
+            return model?.selectedInstances.contains(i) ?? false
+        }
+        return false
+    }
+
+    /// Surface readout for the inspector's "Picked" row: what kind of face, and
+    /// where, in millimetres of kernel space.
+    private func publishPick(_ hit: CollisionCastHit?) {
+        guard let model else { return }
+        guard let hit, let centering = centeringEntity else {
+            if model.pickInfo != nil { model.pickInfo = nil; model.pickPoint = nil }
+            return
+        }
+        let p = centering.convert(position: hit.position, from: nil)
+        let n = normalize(centering.convert(direction: hit.normal, from: nil))
+        let maxAxis = max(abs(n.x), max(abs(n.y), abs(n.z)))
+        let text = String(format: "%@ (%.1f, %.1f, %.1f)",
+                          maxAxis > 0.97 ? "Planar" : "Curved", p.x, p.y, p.z)
+        if model.pickInfo != text {
+            model.pickPoint = p
+            model.pickInfo = text
+        }
+    }
+
+    /// "part7" → 7; else nil.
+    private static func partIndex(_ e: Entity) -> Int? {
+        guard e.name.hasPrefix("part"), let i = Int(e.name.dropFirst(4)) else { return nil }
+        return i
+    }
+
+    /// "inst3" → 3; else nil. Assemblies draw instances, not root parts.
+    private static func instanceIndex(_ e: Entity) -> Int? {
+        guard e.name.hasPrefix("inst"), let i = Int(e.name.dropFirst(4)) else { return nil }
+        return i
+    }
+
+    /// Frame a single part: orbit around its centre, pulled in to fit it. The
+    /// double-click gesture's half of "show me this thing".
+    func frame(entityNamed name: String) {
+        guard let model,
+              let e = centeringEntity?.findEntity(named: name) else { return }
+        let b = e.visualBounds(relativeTo: nil)
+        model.stopSpin()
+        withAnimation(.smooth(duration: 0.35)) {
+            model.panOffset = b.center
+            let extent = max(b.extents.x, max(b.extents.y, b.extents.z))
+            model.distance = max(0.45, min(8.0, extent * 2.2))
+        }
+        model.pinchBaseline = model.distance
     }
 
     func hide() {
+        DockIcon.shared.stop()
         mouseMonitors.forEach { NSEvent.removeMonitor($0) }
         mouseMonitors = []
         arView = nil
@@ -164,24 +447,42 @@ struct ChromeRegion: ViewModifier {
 struct ReleasedOverlayView: View {
     @Bindable var model: EditorModel
     @Bindable var intent: IntentEngine
-    /// Bumped once after the ARView exists so the inspector can re-place itself
-    /// against the built scene — the first body pass runs before it does, and a
-    /// static scene never re-renders on its own.
-    @State private var layoutTick = 0
+
+    /// The in-flight ⌘-drag rubber band, in overlay view coords.
+    @State private var marquee: (start: CGPoint, current: CGPoint)?
+    /// Where the last click landed and how far into that point's stack of parts
+    /// it selected — clicking the same spot again walks to the part behind.
+    @State private var cycleAnchor: CGPoint?
+    @State private var cycleDepth = 0
+
+    /// What the built scene is a function of. Assembled as a String rather than
+    /// interpolated inline: one seven-way interpolation inside a view builder is
+    /// enough to blow the type-checker's budget.
+    private var geometryKey: String {
+        var parts: [String] = []
+        parts.append(String(describing: model.source))
+        parts.append(String(describing: model.baseShape))
+        parts.append(String(describing: model.modifier))
+        parts.append(String(model.modifierValue))
+        parts.append(String(model.triangleCount))
+        parts.append(String(model.zebraMode))
+        parts.append(String(model.sketching))
+        return parts.joined(separator: "|")
+    }
 
     var body: some View {
         ZStack(alignment: .topLeading) {
             ReleasedScene(model: model,
                           cameraPosition: model.cameraPosition,
                           lookAt: model.panOffset,
-                          geometryKey: "\(model.baseShape)|\(model.modifier)|\(model.modifierValue)|\(model.triangleCount)|\(model.zebraMode)|\(model.highlightedParts.sorted())|\(model.hiddenParts.sorted())|\(String(describing: model.isolatedPart))|\(model.sketching)")
+                          geometryKey: geometryKey)
                 .ignoresSafeArea()
             // ARView consumes mouse events — capture orbit/zoom on a clear
             // layer above it instead.
             Color.clear
                 .contentShape(Rectangle())
                 .ignoresSafeArea()
-                .gesture(orbitGesture)
+                .gesture(marqueeOrOrbitGesture)
                 .simultaneousGesture(zoomGesture)
                 .gesture(SpatialTapGesture(coordinateSpace: .local).modifiers(.command)
                     .onEnded { value in tapSelect(at: value.location, additive: true) })
@@ -190,6 +491,19 @@ struct ReleasedOverlayView: View {
                         if model.sketching { sketchTap(at: value.location) }
                         else { tapSelect(at: value.location, additive: false) }
                     })
+                // Double-click to frame the part under the pointer — the
+                // universal "show me this thing" of every 3D app. Ordered after
+                // the single tap so the part is selected by the time it frames.
+                .gesture(SpatialTapGesture(count: 2, coordinateSpace: .local)
+                    .onEnded { value in
+                        guard !model.sketching,
+                              let pi = partIndex(at: value.location) else { return }
+                        ReleaseWindowController.shared.frame(entityNamed: "part\(pi)")
+                    })
+                // Right-click acts on whatever the pointer is over. It can only
+                // ever fire over geometry or chrome: everywhere else the window
+                // is transparent to the mouse and the click goes to the desktop.
+                .contextMenu { partContextMenu }
                 .onContinuousHover(coordinateSpace: .local) { phase in
                     guard model.sketching else { return }
                     switch phase {
@@ -200,18 +514,28 @@ struct ReleasedOverlayView: View {
                     }
                     refreshSketchInk()
                 }
+            if let m = marquee {
+                let r = CGRect(x: min(m.start.x, m.current.x), y: min(m.start.y, m.current.y),
+                               width: abs(m.current.x - m.start.x),
+                               height: abs(m.current.y - m.start.y))
+                Rectangle()
+                    .fill(Color.accentColor.opacity(0.12))
+                    .overlay(Rectangle().strokeBorder(Color.accentColor.opacity(0.8), lineWidth: 1))
+                    .frame(width: r.width, height: r.height)
+                    .offset(x: r.minX, y: r.minY)
+                    .allowsHitTesting(false)
+            }
             // BCB-style tool windows, hosted in the overlay itself (separate
             // NSPanels break SwiftUI hit testing after auto-resize).
             VStack(alignment: .leading, spacing: 12) {
-                ComponentPaletteWindow(model: model)
-                    .modifier(ChromeRegion(key: "palette"))
-                ScrollView {
-                    FeatureTreeView(model: model)
+                if model.showsPalette {
+                    ComponentPaletteWindow(model: model)
+                        .modifier(ChromeRegion(key: "palette"))
                 }
-                .frame(width: 230)
-                .frame(maxHeight: 380)
-                .fixedSize(horizontal: false, vertical: true)
-                .modifier(ChromeRegion(key: "tree"))
+                if model.showsTree {
+                    FeatureTreeWindow(model: model)
+                        .modifier(ChromeRegion(key: "tree"))
+                }
                 // Dynamics, as its own tool window. Released mode floats over
                 // the desktop, so the studio's single scrolling inspector has
                 // no home here — the BCB idiom is one window per concern.
@@ -225,15 +549,43 @@ struct ReleasedOverlayView: View {
             // tracks the selected part's projected screen position (and so
             // follows it through orbits and drags), parking under the palette
             // when nothing is selected.
-            ObjectInspectorWindow(model: model)
-                .modifier(ChromeRegion(key: "inspector"))
-                .offset(x: inspectorOrigin.x, y: inspectorOrigin.y)
-                .animation(Motion.smooth, value: model.selectedPartIndex)
+        }
+        .background {
+            // Esc clears the selection. In release-to-desktop an empty-space
+            // click is NOT a deselect — the window is transparent to the mouse
+            // there, so that click belongs to whatever is behind us. Disabled
+            // while sketching or armed so those cancels win Esc first.
+            Button("") { model.deselectAll() }
+                .keyboardShortcut(.cancelAction)
+                .frame(width: 0, height: 0).opacity(0)
+                .accessibilityHidden(true)
+                .disabled(!model.hasSelection || model.sketching || model.armedShape != nil)
         }
         .overlay(alignment: .topTrailing) {
-            ReleaseReturnPill(model: model)
-                .padding(16)
-                .modifier(ChromeRegion(key: "pill"))
+            // The right rail: identity + the inspector, docked to the screen
+            // edge. (It used to chase the selected part around the viewport,
+            // which reads as clever for one part and as a moving target for a
+            // real assembly — CAD inspectors live in a fixed rail.)
+            VStack(alignment: .trailing, spacing: 12) {
+                HStack(spacing: 10) {
+                    IdentityStatusBar(model: model)
+                        .modifier(ChromeRegion(key: "identity"))
+                    PanelsPill(model: model)
+                        .modifier(ChromeRegion(key: "pill"))
+                }
+                if model.showsInspector {
+                    if model.source.isGripper {
+                        ReceiptLedgerWindow(model: model)
+                            .modifier(ChromeRegion(key: "inspector"))
+                    } else {
+                        ObjectInspectorWindow(model: model)
+                            .modifier(ChromeRegion(key: "inspector"))
+                    }
+                }
+            }
+            .padding(16)
+            .animation(Motion.panel, value: model.showsInspector)
+            .animation(Motion.panel, value: model.source.isGripper)
         }
         .overlay(alignment: .top) {
             // Cross-domain gripper receipt — the released twin of the studio's
@@ -276,18 +628,25 @@ struct ReleasedOverlayView: View {
             .animation(Motion.smooth, value: model.timeline == nil)
             .animation(Motion.panel, value: model.sketching)
         }
-        .task {
-            // A few settling passes: the scene builds (and can rebuild from a
-            // document load) over the first moments after the overlay appears.
-            for _ in 0..<12 {
-                try? await Task.sleep(for: .milliseconds(150))
-                layoutTick += 1
-            }
+        .onChange(of: model.hoveredInstances) { _, _ in
+            // The feature tree can set the hover too; the renderer only ever
+            // heard from the pointer.
+            ReleaseWindowController.shared.syncHoverPaint()
+        }
+        .onChange(of: model.hoveredPartIndex) { _, _ in
+            ReleaseWindowController.shared.syncHoverPaint()
+        }
+        .onChange(of: model.armedShape) { _, shape in
+            // Armed mode is modal over the desktop, like sketching: the overlay
+            // owns the mouse everywhere so the placing click cannot fall through
+            // to whatever window happens to be behind the part.
+            ReleaseWindowController.shared.sketchModal = shape != nil || model.sketching
+            if shape == nil { NSCursor.arrow.set() }
         }
         .onChange(of: model.sketching) { _, on in
             // Sketch is modal over the desktop: own the mouse everywhere while
             // drawing, hand non-chrome/non-part mouse back when done.
-            ReleaseWindowController.shared.sketchModal = on
+            ReleaseWindowController.shared.sketchModal = on || model.armedShape != nil
             refreshSketchInk(force: true)
         }
         .onChange(of: model.sketchDirty) { _, dirty in
@@ -298,25 +657,6 @@ struct ReleasedOverlayView: View {
     /// Top-left origin for the floating Object Inspector: just right of the
     /// selected part's projected center, clamped inside the overlay. With no
     /// selection it parks under the Component Palette.
-    private var inspectorOrigin: CGPoint {
-        _ = layoutTick
-        let ctl = ReleaseWindowController.shared
-        let size = ctl.chromeRects["inspector"]?.size ?? CGSize(width: 320, height: 260)
-        let bounds = ctl.overlaySize
-        let parked = CGPoint(x: 16, y: (ctl.chromeRects["palette"]?.maxY ?? 140) + 12)
-        guard let pi = model.selectedPartIndex, bounds.width > 0,
-              let p = ctl.viewPoint(forPart: pi, from: model.cameraPosition,
-                                    lookAt: model.panOffset) else { return parked }
-        let gap: CGFloat = 28
-        // Prefer the right of the part; flip to its left when that would run
-        // off the edge.
-        var x = p.x + gap
-        if x + size.width + 16 > bounds.width { x = p.x - gap - size.width }
-        let y = p.y - size.height / 2
-        return CGPoint(x: min(max(16, x), max(16, bounds.width - size.width - 16)),
-                       y: min(max(16, y), max(16, bounds.height - size.height - 16)))
-    }
-
     /// Screen point → kernel-space ray, through the ARView's native ray and
     /// the kernel-frame (centering) entity — no hand-rolled camera math.
     private func kernelRay(at p: CGPoint) -> (o: SIMD3<Float>, d: SIMD3<Float>)? {
@@ -355,19 +695,141 @@ struct ReleasedOverlayView: View {
         model.sketchDirty = false
     }
 
+    /// The entity name of the body under a screen point — a root part or an
+    /// assembly instance.
+    private func bodyName(at p: CGPoint) -> String? {
+        ReleaseWindowController.shared.hits(atViewPoint: p).first {
+            $0.entity.name.hasPrefix("part") || $0.entity.name.hasPrefix("inst")
+        }?.entity.name
+    }
+
+    /// The part under a screen point, if any.
+    private func partIndex(at p: CGPoint) -> Int? {
+        guard let e = ReleaseWindowController.shared.hits(atViewPoint: p).first?.entity,
+              e.name.hasPrefix("part") else { return nil }
+        return Int(e.name.dropFirst(4))
+    }
+
+    /// The right-click menu: what you can do to the part under the pointer,
+    /// then the view-wide actions. Built from the live hover, so it always
+    /// describes the thing you actually pointed at.
+    @ViewBuilder private var partContextMenu: some View {
+        let pi = ReleaseWindowController.shared.hoveredPart
+        if let ii = ReleaseWindowController.shared.hoveredInstance {
+            Text(model.instanceName(ii) ?? "Instance \(ii)")
+            Divider()
+            Button("Frame") { ReleaseWindowController.shared.frame(entityNamed: "inst\(ii)") }
+            Button("Select") { model.selectInstance(ii) }
+            Divider()
+        }
+        if let pi, model.usesDocumentTree {
+            let name = model.featureNodes.first(where: { $0.partIndex == pi })?.name ?? "Part \(pi)"
+            Text(name)
+            Divider()
+            Button("Frame") { ReleaseWindowController.shared.frame(entityNamed: "part\(pi)") }
+            Button(model.isolatedPart == pi ? "Exit Isolate" : "Isolate") { model.isolate(part: pi) }
+            Button(model.isPartVisible(pi) ? "Hide" : "Show") { model.toggleVisibility(part: pi) }
+            Menu("Material") {
+                ForEach(MaterialPreset.grouped, id: \.category) { group in
+                    Section(group.category.capitalized) {
+                        ForEach(group.items) { m in
+                            Button(m.name) { model.setPartMaterial(pi, m.key) }
+                        }
+                    }
+                }
+            }
+            Divider()
+        }
+        if model.hasHiddenParts {
+            Button("Show All Parts") { model.showAllParts() }
+        }
+        Button("Deselect All") { model.deselectAll() }
+            .disabled(model.selectedPartIndex == nil && model.multiSelectedParts.isEmpty)
+        Divider()
+        Button("Frame All") { model.resetCamera() }
+    }
+
     /// Click a part to select it (⌘-click for the boolean multi-selection,
     /// empty space to deselect) — the released twin of the studio's pick.
+    /// Stopwatch for the click path, behind VCAD_PERF=1. Writes one line per
+    /// click to /tmp/vcad_perf.log.
+    private func perf(_ label: String, _ t0: CFAbsoluteTime) {
+        guard perfLogging else { return }
+        let ms = (CFAbsoluteTimeGetCurrent() - t0) * 1000
+        let line = String(format: "[PERF] %@ %.1f ms\n", label, ms)
+        if let fh = FileHandle(forWritingAtPath: "/tmp/vcad_perf.log") {
+            fh.seekToEndOfFile(); fh.write(Data(line.utf8)); try? fh.close()
+        } else {
+            try? Data(line.utf8).write(to: URL(fileURLWithPath: "/tmp/vcad_perf.log"))
+        }
+    }
+
     private func tapSelect(at p: CGPoint, additive: Bool) {
+        let t0 = CFAbsoluteTimeGetCurrent()
+        defer { perf("tapSelect", t0) }
+
+        // Double-click frames the body — read off the CLICK COUNT of the event
+        // we are already handling, not a second `SpatialTapGesture(count: 2)`.
+        // A separate double-tap gesture forces SwiftUI to disambiguate, so every
+        // single click sat waiting out the double-click interval before it could
+        // fire: selection measured 0.2 ms of work behind ~half a second of
+        // nothing. This is also how AppKit does it — the first click selects,
+        // the second frames.
+        if (NSApp.currentEvent?.clickCount ?? 1) >= 2, !model.sketching,
+           let name = bodyName(at: p) {
+            ReleaseWindowController.shared.frame(entityNamed: name)
+        }
         guard model.usesDocumentTree,
               let ar = ReleaseWindowController.shared.arView else { return }
-        if let e = ar.hitTest(p).first?.entity, e.name.hasPrefix("part"),
-           let pi = Int(e.name.dropFirst(4)),
-           let fid = model.featureNodes.first(where: { $0.partIndex == pi })?.id {
+
+        // An armed palette tool consumes the click: this is a placement, not a
+        // selection (BCB: pick the component, then click where it goes).
+        if let shape = model.armedShape {
+            if let point = placementPoint(at: p) {
+                model.addPrimitive(shape, at: point)
+            } else {
+                model.addPrimitive(shape)
+            }
+            model.disarm()
+            NSCursor.arrow.set()
+            return
+        }
+
+        // Assemblies draw instances; a click on a link selects that instance and
+        // walks the tree to the part def it draws.
+        if model.assemblyInstanceCount > 0 {
+            if let e = ReleaseWindowController.shared.hits(atViewPoint: p)
+                .first(where: { $0.entity.name.hasPrefix("inst") })?.entity,
+               let i = Int(e.name.dropFirst(4)) {
+                model.selectInstance(i)
+            } else if !additive {
+                model.deselectAll()
+            }
+            return
+        }
+
+        // Every part under the pointer, nearest first. Clicking the same spot
+        // twice walks INTO the stack instead of re-selecting the front part —
+        // without it, a part inside an enclosure is unreachable without hiding
+        // the shell.
+        let stack = ReleaseWindowController.shared.hits(atViewPoint: p).compactMap { hit -> Int? in
+            guard hit.entity.name.hasPrefix("part") else { return nil }
+            return Int(hit.entity.name.dropFirst(4))
+        }
+        var depth = 0
+        if let a = cycleAnchor, hypot(a.x - p.x, a.y - p.y) < 5, !stack.isEmpty {
+            depth = (cycleDepth + 1) % stack.count
+        }
+        cycleAnchor = p
+        cycleDepth = depth
+
+        if depth < stack.count,
+           let fid = model.featureNodes.first(where: { $0.partIndex == stack[depth] })?.id {
             // Modifiers come from the gesture (.modifiers(.command)), not
             // NSEvent.modifierFlags — that reads hardware key state and misses
             // synthetic events (and some tap orderings).
             if additive {
-                model.toggleMultiSelect(part: pi, featureID: fid)
+                model.toggleMultiSelect(part: stack[depth], featureID: fid)
             } else {
                 model.selectFeature(fid)
             }
@@ -377,15 +839,40 @@ struct ReleasedOverlayView: View {
         model.selectionDirty = false   // released view rebuilds via geometryKey
     }
 
-    private var orbitGesture: some Gesture {
+    /// Where an armed primitive should land: on the surface under the pointer if
+    /// there is one, else on the ground plane (kernel z = 0). Falls back to the
+    /// origin when the ray misses everything (a camera looking at the horizon).
+    private func placementPoint(at p: CGPoint) -> SIMD3<Float>? {
+        if let centering = ReleaseWindowController.shared.centeringEntity,
+           let hit = ReleaseWindowController.shared.hits(atViewPoint: p)
+               .first(where: { $0.entity.name.hasPrefix("part") }) {
+            return centering.convert(position: hit.position, from: nil)
+        }
+        guard let ray = kernelRay(at: p), abs(ray.d.z) > 1e-5 else { return nil }
+        let t = -ray.o.z / ray.d.z
+        guard t > 0 else { return nil }
+        return ray.o + ray.d * t
+    }
+
+    private var marqueeOrOrbitGesture: some Gesture {
         DragGesture(minimumDistance: 2)
             .onChanged { value in
+                // ⌘-drag from empty space is a rubber band, matching ⌘-click's
+                // "add to the selection". A plain drag stays an orbit: rebinding
+                // orbit to a modifier to make room for marquee would break the
+                // muscle memory of every 3D app.
+                if marquee != nil || (model.lastDrag == .zero && !model.draggingHandle
+                                      && model.usesDocumentTree
+                                      && NSEvent.modifierFlags.contains(.command)
+                                      && partIndex(at: value.startLocation) == nil) {
+                    marquee = (value.startLocation, value.location)
+                    return
+                }
                 if model.lastDrag == .zero && !model.draggingHandle {
                     // A drag that starts on a gizmo handle is a part transform,
                     // not an orbit — same split the studio's targeted gesture
                     // makes, done here via hitTest (the clear layer owns events).
-                    if let ar = ReleaseWindowController.shared.arView,
-                       let name = ar.hitTest(value.startLocation)
+                    if let name = ReleaseWindowController.shared.hits(atViewPoint: value.startLocation)
                            .first(where: { model.gizmoHandle(for: $0.entity.name) != nil })?.entity.name,
                        let ray = kernelRay(at: value.startLocation) {
                         model.draggingHandle = true
@@ -412,6 +899,12 @@ struct ReleasedOverlayView: View {
                 model.lastDrag = value.translation
             }
             .onEnded { _ in
+                if let m = marquee {
+                    commitMarquee(from: m.start, to: m.current)
+                    marquee = nil
+                    model.lastDrag = .zero
+                    return
+                }
                 model.lastDrag = .zero
                 if model.draggingHandle {
                     NSCursor.arrow.set()
@@ -422,6 +915,23 @@ struct ReleasedOverlayView: View {
                     model.endOrbit()
                 }
             }
+    }
+
+    /// Select every part whose projected centre falls inside the rubber band.
+    /// Centres, not silhouettes: a projected bounding box would catch a long
+    /// part the band merely grazes, which reads as selecting the wrong thing.
+    private func commitMarquee(from a: CGPoint, to b: CGPoint) {
+        let r = CGRect(x: min(a.x, b.x), y: min(a.y, b.y),
+                       width: abs(b.x - a.x), height: abs(b.y - a.y))
+        guard r.width > 3, r.height > 3 else { return }
+        let ctl = ReleaseWindowController.shared
+        let caught = (0..<model.partCount).filter { i in
+            guard model.isPartVisible(i),
+                  let p = ctl.viewPoint(forPart: i, from: model.cameraPosition,
+                                        lookAt: model.panOffset) else { return false }
+            return r.contains(p)
+        }
+        model.selectParts(caught)
     }
 
     /// Live-sync the dragged part: re-evaluate the document meshes in place and
@@ -464,12 +974,25 @@ struct ReleasedARView: NSViewRepresentable {
     /// gets this for free because a `RealityView`'s update closure observes the
     /// model directly.
     let poseTick: Int
+    /// The model's own "the geometry changed" flag, the same one the studio
+    /// rebuilt on. `geometryKey` alone cannot carry a document swap: opening a
+    /// document (or the gripper) leaves every field the key is built from
+    /// untouched until the new scene is built, so the key never changed, the
+    /// rebuild never ran, and the old part stayed on screen — the geometry was
+    /// waiting on a rebuild that was waiting on the geometry.
+    let geometryDirty: Bool
+    let selection: Set<Int>
+    let selectedInstances: Set<Int>
+    let visibility: VisibilityState
     let geometryKey: String
 
     final class Coordinator {
         var camera: PerspectiveCamera?
         var anchor: AnchorEntity?
         var builtKey = ""
+        var builtSelection: Set<Int> = []
+        var builtInstances: Set<Int> = []
+        var builtVisibility = VisibilityState(hidden: [], isolated: nil)
         /// Instance entities in scene order, captured at build time.
         ///
         /// `findEntity(named:)` walks the whole descendant tree; doing that
@@ -525,7 +1048,32 @@ struct ReleasedARView: NSViewRepresentable {
     }
 
     func updateNSView(_ ar: ARView, context: Context) {
-        if context.coordinator.builtKey != geometryKey {
+        // Selecting a part used to rebuild the whole scene: `highlightedParts`
+        // was part of `geometryKey`, so a click re-evaluated the document,
+        // re-tessellated every part, rebuilt every entity and regenerated every
+        // collider — to change one material's emissive. That was the click lag.
+        if context.coordinator.builtSelection != selection
+            || context.coordinator.builtInstances != selectedInstances {
+            let t0 = CFAbsoluteTimeGetCurrent()
+            context.coordinator.builtSelection = selection
+            context.coordinator.builtInstances = selectedInstances
+            ReleaseWindowController.shared.repaintAll()
+            let tPaint = CFAbsoluteTimeGetCurrent()
+            rebuildGizmo(context.coordinator)
+            if perfLogging {
+                let line = String(format: "[PERF] selectionUpdate repaint %.1f ms gizmo %.1f ms\n",
+                                  (tPaint - t0) * 1000,
+                                  (CFAbsoluteTimeGetCurrent() - tPaint) * 1000)
+                if let fh = FileHandle(forWritingAtPath: "/tmp/vcad_perf.log") {
+                    fh.seekToEndOfFile(); fh.write(Data(line.utf8)); try? fh.close()
+                }
+            }
+        }
+        if context.coordinator.builtVisibility != visibility {
+            context.coordinator.builtVisibility = visibility
+            applyVisibility()
+        }
+        if geometryDirty || context.coordinator.builtKey != geometryKey {
             rebuild(in: context.coordinator.anchor, coordinator: context.coordinator)
             applyLighting(ar)
         }
@@ -549,11 +1097,55 @@ struct ReleasedARView: NSViewRepresentable {
         guard let camera = c.camera else { return }
         camera.position = cameraPosition
         camera.look(at: lookAt, from: cameraPosition, relativeTo: nil)
+        // Constant on-screen gizmo size, the way every desktop CAD tool does it.
+        // The studio rescaled the gizmo on every camera update and the released
+        // view never did, so the handles were sized for whatever distance the
+        // camera happened to be at when the scene was built — comically large
+        // once you zoomed in, invisible once you pulled back.
+        if let gizmo = ReleaseWindowController.shared.centeringEntity?
+            .findEntity(named: "gizmoRoot") {
+            gizmo.scale = SIMD3<Float>(repeating: gizmoScreenScale(model: model))
+        }
+    }
+
+    /// The gizmo follows the selection, and the selection no longer rebuilds the
+    /// scene — so it has to be re-hung on its own. It is a handful of entities;
+    /// rebuilding it is nothing like rebuilding the model.
+    private func rebuildGizmo(_ c: Coordinator) {
+        guard let centering = ReleaseWindowController.shared.centeringEntity else { return }
+        centering.findEntity(named: "gizmoRoot")?.removeFromParent()
+        guard model.showsGizmo else { return }
+        let gizmo = buildGizmo(model: model)
+        gizmo.scale = SIMD3<Float>(repeating: gizmoScreenScale(model: model))
+        centering.addChild(gizmo)
+    }
+
+    /// Show/hide parts in place — `isEnabled` on the built entities, no rebuild.
+    private func applyVisibility() {
+        guard let centering = ReleaseWindowController.shared.centeringEntity else { return }
+        for i in 0..<model.partCount {
+            centering.findEntity(named: "part\(i)")?.isEnabled = model.isPartVisible(i)
+        }
     }
 
     private func rebuild(in anchor: AnchorEntity?, coordinator: Coordinator) {
         guard let anchor else { return }
+        let tRebuild = CFAbsoluteTimeGetCurrent()
+        defer {
+            if perfLogging,
+               let fh = FileHandle(forWritingAtPath: "/tmp/vcad_perf.log") {
+                let ms = (CFAbsoluteTimeGetCurrent() - tRebuild) * 1000
+                fh.seekToEndOfFile()
+                fh.write(Data(String(format: "[PERF] REBUILD %.1f ms\n", ms).utf8))
+                try? fh.close()
+            }
+        }
         coordinator.builtKey = geometryKey
+        coordinator.builtSelection = model.highlightedParts
+        coordinator.builtInstances = model.selectedInstances
+        coordinator.builtVisibility = VisibilityState(hidden: model.hiddenParts,
+                                                      isolated: model.isolatedPart)
+        model.geometryDirty = false
         coordinator.instanceEntities.removeAll(keepingCapacity: true)
         anchor.children.filter { $0.name == "geomRoot" }.forEach { $0.removeFromParent() }
 
@@ -627,6 +1219,8 @@ struct ReleasedARView: NSViewRepresentable {
         zUp.addChild(centering)
         zUp.orientation = simd_quatf(angle: -.pi / 2, axis: [1, 0, 0])
 
+        ReleaseWindowController.shared.repaintHover()
+
         let geomRoot = Entity()
         geomRoot.name = "geomRoot"
         geomRoot.addChild(zUp)
@@ -676,45 +1270,172 @@ struct ToolWindow<Content: View>: View {
     }
 }
 
-/// The Component Palette: create + modify sections and a document-action
-/// cluster (undo/redo, zebra analysis, export) — the BCB palette, HIG-ified.
+/// The Component Palette, after Borland C++ Builder: a speedbar of document
+/// actions, a tab strip, a dense grid of icon tools, and a hint line that
+/// explains whatever the pointer is over. BCB's palette was icon-only and
+/// stable — same tile in the same place every time you reach for it — with the
+/// words living in the hint bar rather than under every glyph. That is what is
+/// modernised here (SF Symbols, a segmented tab strip, HIG focus rings), not
+/// the 1997 bevels.
 struct ComponentPaletteWindow: View {
     @Bindable var model: EditorModel
+    /// What the pointer is over, for the hint line. BCB put hints in the status
+    /// bar; a palette-local line keeps the explanation next to the thing.
+    @State private var hovered: Tool.ID?
+    @State private var hoveredAction: String?
+
+    private let paletteWidth: CGFloat = 236
+    private let tile: CGFloat = 34
 
     var body: some View {
-        ToolWindow(title: "Components", onClose: { model.releaseMode = false }) {
+        ToolWindow(title: "Components", onClose: { model.showsPalette = false }) {
             VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 10) {
-                    // Same tabs, same tools, same enable/hint logic as the
-                    // in-studio palette: one source of truth (model.tools(for:)).
-                    Picker("", selection: $model.toolTab) {
-                        ForEach(availableTabs) { t in Text(t.label).tag(t) }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .controlSize(.small)
-                    .fixedSize()
-                    Divider().frame(height: 22)
-                    HStack(spacing: 2) {
-                        iconButton("Zebra", "line.3.horizontal", enabled: true,
-                                   active: model.zebraMode) { model.zebraMode.toggle() }
-                        iconButton("Undo", "arrow.uturn.backward", enabled: model.canUndo) { model.undo() }
-                        iconButton("Redo", "arrow.uturn.forward", enabled: model.canRedo) { model.redo() }
-                        iconButton("STL", "square.and.arrow.up", enabled: model.canExport) {
-                            exportPanel(ext: "stl") { model.exportSTL(to: $0) }
-                        }
-                        iconButton("USDZ", "arkit", enabled: model.canExport) {
-                            exportPanel(ext: "usdz") { model.exportUSDZ(to: $0) }
-                        }
-                    }
-                }
-                HStack(spacing: 2) {
-                    ForEach(model.tools(for: activeTab)) { tool in
-                        toolButton(tool)
-                    }
-                }
+                speedbar
+                Divider()
+                tabStrip
+                toolGrid
+                hintLine
+            }
+            .frame(width: paletteWidth, alignment: .leading)
+            .background {
+                Button("") { model.disarm() }
+                    .keyboardShortcut(.cancelAction)
+                    .frame(width: 0, height: 0).opacity(0)
+                    .accessibilityHidden(true)
+                    .disabled(model.armedShape == nil)
             }
         }
+    }
+
+    // MARK: speedbar — the document actions, not components
+
+    /// BCB kept the speedbar (open/save/run) separate from the palette proper;
+    /// mixing them put "export USDZ" one pixel from "add a cube". Same split
+    /// here, and every action is also a menu item with a key equivalent.
+    private var speedbar: some View {
+        HStack(spacing: 2) {
+            speedButton("Undo", "arrow.uturn.backward", enabled: model.canUndo,
+                        hint: "Undo the last edit (⌘Z)") { model.undo() }
+            speedButton("Redo", "arrow.uturn.forward", enabled: model.canRedo,
+                        hint: "Redo (⇧⌘Z)") { model.redo() }
+            speedDivider
+            speedButton("Zebra", "line.3.horizontal", enabled: true, active: model.zebraMode,
+                        hint: "Zebra curvature analysis (Z)") { model.zebraMode.toggle() }
+            speedDivider
+            speedButton("Export STL", "square.and.arrow.up", enabled: model.canExport,
+                        hint: "Export the document as STL (⌘E)") {
+                exportPanel(ext: "stl") { model.exportSTL(to: $0) }
+            }
+            speedButton("Export USDZ", "arkit", enabled: model.canExport,
+                        hint: "Export as USDZ for Quick Look (⇧⌘E)") {
+                exportPanel(ext: "usdz") { model.exportUSDZ(to: $0) }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var speedDivider: some View {
+        Rectangle().fill(.separator).frame(width: 1, height: 16).padding(.horizontal, 3)
+    }
+
+    // MARK: tabs
+
+    private var tabStrip: some View {
+        Picker("", selection: $model.toolTab) {
+            ForEach(availableTabs) { t in Text(t.label).tag(t) }
+        }
+        .pickerStyle(.segmented)
+        .labelsHidden()
+        .controlSize(.small)
+        // Number keys switch tabs, as they did on the studio palette. Zero-sized
+        // rather than absent: a shortcut only fires while its button is in the
+        // view hierarchy.
+        .background {
+            ForEach(Array(availableTabs.enumerated()), id: \.element) { idx, tab in
+                Button("") { model.toolTab = tab }
+                    .keyboardShortcut(KeyEquivalent(Character("\(idx + 1)")), modifiers: [])
+                    .frame(width: 0, height: 0)
+                    .opacity(0)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+
+    // MARK: the palette proper
+
+    private var toolGrid: some View {
+        LazyVGrid(columns: [GridItem(.adaptive(minimum: tile), spacing: 4, alignment: .leading)],
+                  alignment: .leading, spacing: 4) {
+            ForEach(model.tools(for: activeTab)) { tool in
+                toolTile(tool)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .animation(Motion.snappy, value: activeTab)
+    }
+
+    private func toolTile(_ tool: Tool) -> some View {
+        Button(action: tool.action) {
+            Image(systemName: tool.symbol)
+                .font(.system(size: 15))
+                .frame(width: tile, height: tile)
+                .foregroundStyle(tool.isActive ? AnyShapeStyle(Color.accentColor)
+                                 : tool.enabled ? AnyShapeStyle(.primary)
+                                 : AnyShapeStyle(.tertiary))
+                .background(background(active: tool.isActive, hovered: hovered == tool.id && tool.enabled),
+                            in: RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .overlay(RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .strokeBorder(tool.isActive ? Color.accentColor.opacity(0.55) : .clear,
+                                  lineWidth: 1))
+                // .plain buttons only hit-test opaque pixels; without this,
+                // clicks in the transparent padding do nothing.
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!tool.enabled)
+        .onHover { inside in
+            hovered = inside ? tool.id : (hovered == tool.id ? nil : hovered)
+        }
+        .help(tool.hint.isEmpty ? tool.label : "\(tool.label) — \(tool.hint)")
+        .accessibilityLabel(tool.label)
+    }
+
+    private func background(active: Bool, hovered: Bool) -> AnyShapeStyle {
+        if active { return AnyShapeStyle(.selection) }
+        if hovered { return AnyShapeStyle(.quaternary) }
+        return AnyShapeStyle(.clear)
+    }
+
+    // MARK: hint line
+
+    /// One line, always present (never collapsing — a palette that changes
+    /// height as the pointer moves is a palette you cannot aim at).
+    private var hintLine: some View {
+        Text(hintText)
+            .font(.system(size: 10))
+            .foregroundStyle(hintIsBlocked ? AnyShapeStyle(Color.orange)
+                             : model.armedShape != nil ? AnyShapeStyle(Color.accentColor)
+                             : AnyShapeStyle(.secondary))
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(width: paletteWidth, height: 13, alignment: .leading)
+            .animation(nil, value: hintText)
+    }
+
+    private var hoveredTool: Tool? {
+        model.tools(for: activeTab).first { $0.id == hovered }
+    }
+
+    private var hintIsBlocked: Bool {
+        if let t = hoveredTool { return !t.enabled }
+        return false
+    }
+
+    private var hintText: String {
+        if let s = model.armedShape { return "Click in the scene to place \(s.label) · Esc" }
+        if let a = hoveredAction { return a }
+        guard let t = hoveredTool else { return activeTab.paletteHint }
+        return t.hint.isEmpty ? t.label : "\(t.label) — \(t.hint)"
     }
 
     /// Combine only exists for documents (needs two selected parts).
@@ -725,25 +1446,27 @@ struct ComponentPaletteWindow: View {
         availableTabs.contains(model.toolTab) ? model.toolTab : .create
     }
 
-    private func toolButton(_ tool: Tool) -> some View {
-        Button(action: tool.action) {
-            VStack(spacing: 3) {
-                Image(systemName: tool.symbol).font(.system(size: 14))
-                Text(tool.label).font(.system(size: 9)).lineLimit(1)
-            }
-            .frame(minWidth: 52, minHeight: 40)
-            .padding(.horizontal, 4)
-            .foregroundStyle(tool.isActive ? Color.accentColor
-                             : tool.enabled ? Color.primary : Color.secondary.opacity(0.4))
-            .background(tool.isActive ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
-                        in: RoundedRectangle(cornerRadius: 7))
-            // .plain buttons only hit-test opaque pixels; without this, clicks
-            // in the transparent padding between glyph and label do nothing.
-            .contentShape(Rectangle())
+    private func speedButton(_ label: String, _ symbol: String, enabled: Bool,
+                             active: Bool = false, hint: String,
+                             action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: symbol)
+                .font(.system(size: 12))
+                .frame(width: 26, height: 22)
+                .foregroundStyle(active ? AnyShapeStyle(Color.accentColor)
+                                 : enabled ? AnyShapeStyle(.secondary)
+                                 : AnyShapeStyle(.tertiary))
+                .background(active ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
+                            in: RoundedRectangle(cornerRadius: 5, style: .continuous))
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .disabled(!tool.enabled)
-        .help(tool.hint.isEmpty ? tool.label : tool.hint)
+        .disabled(!enabled)
+        .onHover { inside in
+            hoveredAction = inside ? (enabled ? hint : "\(label) — unavailable") : nil
+        }
+        .help(hint)
+        .accessibilityLabel(label)
     }
 
     private func exportPanel(ext: String, _ export: @escaping (URL) -> Bool) {
@@ -754,36 +1477,116 @@ struct ComponentPaletteWindow: View {
             _ = export(url)
         }
     }
-
-    private func iconButton(_ label: String, _ symbol: String, enabled: Bool,
-                            active: Bool = false,
-                            action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            VStack(spacing: 3) {
-                Image(systemName: symbol).font(.system(size: 14))
-                Text(label).font(.system(size: 9))
-            }
-            .frame(width: 52, height: 40)
-            .foregroundStyle(active ? Color.accentColor
-                             : enabled ? Color.primary : Color.secondary.opacity(0.4))
-            .background(active ? AnyShapeStyle(.selection) : AnyShapeStyle(.clear),
-                        in: RoundedRectangle(cornerRadius: 7))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(!enabled)
-    }
 }
 
-/// The Object Inspector: parameters, camera, material, and measurements.
+/// The Object Inspector: what the selected feature is, its live parameters,
+/// the document's named parameters, camera, and measurements.
 struct ObjectInspectorWindow: View {
     @Bindable var model: EditorModel
 
     var body: some View {
-        ToolWindow(title: "Object Inspector", onClose: { model.releaseMode = false }) {
+        ToolWindow(title: "Object Inspector", onClose: { model.showsInspector = false }) {
+            VStack(alignment: .leading, spacing: 8) {
+                if model.usesDocumentTree {
+                    documentSections
+                } else {
+                    sandboxSection
+                }
+                if !model.docParameters.isEmpty {
+                    Divider()
+                    header("Document Parameters")
+                    Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                        docParameterRows
+                    }
+                }
+                Divider()
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                    viewRows
+                    Divider().gridCellUnsizedAxes(.horizontal)
+                    measurementRows
+                }
+            }
+            .frame(width: 236, alignment: .leading)
+        }
+    }
+
+    // MARK: document (a .vcad's feature tree)
+
+    /// The selected feature: what it is, what it is made of, and — for the ops
+    /// that declare editable parameters — live scrub fields. This is the studio
+    /// inspector's job, and it is the same `FeatureParamEditors` doing it, so a
+    /// newly editable op shows up in both places at once.
+    @ViewBuilder private var documentSections: some View {
+        if let ii = model.selectedInstanceIndex {
+            header(model.instanceName(ii) ?? "Instance \(ii)")
             Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
-                row("Shape", model.baseShape.label)
-                row("Modifier", model.modifier.label)
+                row("Kind", "Assembly instance")
+                if let def = model.instancePartDefName(ii) { row("Part", def) }
+            }
+            if let node = model.instanceFeatureNode(ii) {
+                Divider()
+                // The geometry an instance draws lives in its part def, so the
+                // editors act on the definition: change the link's cube here and
+                // every instance of that link follows.
+                header("\(node.name) — shared by every instance")
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                    row("Operation", DocumentGraph.label(node.opType))
+                    if InspectorView.editableOps.contains(node.opType) {
+                        FeatureParamEditors(model: model, node: node) { snapshot in
+                            ReleaseWindowController.shared.refreshGeometry(model: model,
+                                                                           collisions: snapshot)
+                        }
+                    }
+                }
+            }
+        } else if let node = model.selectedFeatureNode {
+            header(node.name)
+            Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                row("Operation", DocumentGraph.label(node.opType))
+                if let pi = node.partIndex {
+                    GridRow {
+                        Text("Material").font(.system(size: 11)).foregroundStyle(.secondary)
+                        materialMenu(pi)
+                    }
+                    if !model.isPartVisible(pi) {
+                        GridRow {
+                            Text("Visibility").font(.system(size: 11)).foregroundStyle(.secondary)
+                            Label("Hidden", systemImage: "eye.slash").font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            if InspectorView.editableOps.contains(node.opType) {
+                Divider()
+                header("Parameters")
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                    // Edits re-solve the bound nodes; the released scene swaps
+                    // meshes in place (collisions only on commit — per-tick
+                    // regen stutters big documents).
+                    FeatureParamEditors(model: model, node: node) { snapshot in
+                        ReleaseWindowController.shared.refreshGeometry(model: model,
+                                                                       collisions: snapshot)
+                    }
+                }
+            } else if let d = node.detail {
+                Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+                    row("Value", d)
+                }
+            }
+        } else {
+            Text("Select a feature in the tree")
+                .font(.system(size: 11)).foregroundStyle(.tertiary)
+        }
+    }
+
+    // MARK: sandbox (the built-in primitive + modifier)
+
+    @ViewBuilder private var sandboxSection: some View {
+        Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 7) {
+            row("Shape", model.baseShape.label)
+            row("Modifier", model.modifier.label)
+            if model.modifier != .none && model.modifierEffective {
                 GridRow {
                     Text(model.modifier.paramLabel)
                         .font(.system(size: 11)).foregroundStyle(.secondary)
@@ -795,69 +1598,108 @@ struct ObjectInspectorWindow: View {
                             .font(.system(size: 11).monospacedDigit())
                     }
                 }
-                if model.usesDocumentTree {
-                    GridRow {
-                        Text("Material").font(.system(size: 11)).foregroundStyle(.secondary)
-                        Picker("", selection: materialBinding) {
-                            ForEach(MaterialPreset.grouped, id: \.category) { group in
-                                Section(group.category.capitalized) {
-                                    ForEach(group.items) { m in Text(m.name).tag(m.key) }
-                                }
-                            }
-                        }
-                        .labelsHidden()
-                        .controlSize(.small)
-                        .frame(width: 150)
-                    }
-                }
-                if !model.docParameters.isEmpty {
-                    Divider().gridCellUnsizedAxes(.horizontal)
-                    // Document-level named parameters — the web app's property
-                    // panel scrub, floating over the desktop. Edits re-solve
-                    // every bound node and mesh-swap in place (no rebuild pop).
-                    ForEach(model.docParameters) { p in
-                        GridRow {
-                            Text(p.name).font(.system(size: 11)).foregroundStyle(.secondary)
-                                .help(p.description ?? p.name)
-                            if let v = p.value {
-                                ScrubField(label: "", value: v, unit: p.unit ?? "mm",
-                                           sensitivity: InspectorView.paramSensitivity(p),
-                                           minValue: p.min ?? -.greatestFiniteMagnitude) { v, s in
-                                    model.editParameter(p.name, value: v, snapshot: s)
-                                    // Collisions on typed commits / scrub start
-                                    // only — per-tick regen would stutter big docs.
-                                    ReleaseWindowController.shared.refreshGeometry(model: model, collisions: s)
-                                }
-                                .frame(width: 150)
-                            } else if let f = p.formula {
-                                Text("= \(f)").font(.system(size: 11).monospacedDigit())
-                                    .foregroundStyle(.tertiary)
-                            }
-                        }
-                    }
-                }
-                Divider().gridCellUnsizedAxes(.horizontal)
+            } else if model.modifier != .none {
                 GridRow {
-                    Text("Camera").font(.system(size: 11)).foregroundStyle(.secondary)
-                    HStack(spacing: 2) {
-                        camButton("Iso", az: .pi / 5, el: .pi / 7)
-                        camButton("Front", az: 0, el: 0)
-                        camButton("Right", az: .pi / 2, el: 0)
-                        camButton("Top", az: 0, el: 1.45)
-                    }
+                    Text("").font(.system(size: 11))
+                    Label("No edges on a sphere", systemImage: "info.circle")
+                        .font(.system(size: 11)).foregroundStyle(.secondary)
                 }
-                GridRow {
-                    Text("Zoom").font(.system(size: 11)).foregroundStyle(.secondary)
-                    Slider(value: zoomBinding, in: 0...1)
-                        .controlSize(.mini)
-                        .frame(width: 150)
-                }
-                Divider().gridCellUnsizedAxes(.horizontal)
-                row("Triangles", "\(model.triangleCount)")
-                row("Bounds", String(format: "%.0f × %.0f × %.0f mm",
-                                     model.sizeMM.x, model.sizeMM.y, model.sizeMM.z))
             }
         }
+    }
+
+    @ViewBuilder private var docParameterRows: some View {
+        ForEach(model.docParameters) { p in
+            GridRow {
+                Text(p.name).font(.system(size: 11)).foregroundStyle(.secondary)
+                    .help(p.description ?? p.name)
+                if let v = p.value {
+                    ScrubField(label: "", value: v, unit: p.unit ?? "mm",
+                               sensitivity: InspectorView.paramSensitivity(p),
+                               minValue: p.min ?? -.greatestFiniteMagnitude) { v, s in
+                        model.editParameter(p.name, value: v, snapshot: s)
+                        // Collisions on typed commits / scrub start only —
+                        // per-tick regen would stutter big docs.
+                        ReleaseWindowController.shared.refreshGeometry(model: model, collisions: s)
+                    }
+                    .frame(width: 140)
+                } else if let f = p.formula {
+                    Text("= \(f)").font(.system(size: 11).monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var viewRows: some View {
+        GridRow {
+            Text("Camera").font(.system(size: 11)).foregroundStyle(.secondary)
+            HStack(spacing: 2) {
+                camButton("Iso", az: .pi / 5, el: .pi / 7)
+                camButton("Front", az: 0, el: 0)
+                camButton("Right", az: .pi / 2, el: 0)
+                camButton("Top", az: 0, el: 1.45)
+            }
+        }
+        GridRow {
+            Text("Zoom").font(.system(size: 11)).foregroundStyle(.secondary)
+            Slider(value: zoomBinding, in: 0...1)
+                .controlSize(.mini)
+                .frame(width: 140)
+        }
+    }
+
+    @ViewBuilder private var measurementRows: some View {
+        row("Triangles", model.triangleCount.formatted())
+        row("Bounds", String(format: "%.1f × %.1f × %.1f mm",
+                             abs(model.sizeMM.x), abs(model.sizeMM.y), abs(model.sizeMM.z)))
+        row("Solve", String(format: "%.1f ms", model.solveMillis))
+        if let info = model.pickInfo {
+            GridRow {
+                Text("Picked").font(.system(size: 11)).foregroundStyle(.secondary)
+                Text(info).font(.system(size: 11).monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .frame(width: 140, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func header(_ t: String) -> some View {
+        Text(t.uppercased())
+            .font(.system(size: 9, weight: .semibold))
+            .tracking(0.6)
+            .foregroundStyle(.tertiary)
+    }
+
+    /// Material assignment for a part — swatch + grouped presets, the studio
+    /// inspector's control rather than a bare Picker (which showed a checkmark
+    /// against "aluminum" for parts that had no material at all).
+    private func materialMenu(_ pi: Int) -> some View {
+        let current = model.materialName(forPart: pi) ?? "default"
+        let resolved = model.resolvedMaterial(forPart: pi)
+        return Menu {
+            ForEach(MaterialPreset.grouped, id: \.category) { group in
+                Section(group.category.capitalized) {
+                    ForEach(group.items) { m in
+                        Button { model.setPartMaterial(pi, m.key) } label: {
+                            if m.key == current { Label(m.name, systemImage: "checkmark") }
+                            else { Text(m.name) }
+                        }
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Circle().fill(Color(portedColor: resolved.color)).frame(width: 10, height: 10)
+                    .overlay(Circle().strokeBorder(.white.opacity(0.25), lineWidth: 0.5))
+                Text(MaterialPreset.byKey(current)?.name ?? current.capitalized)
+                    .font(.system(size: 11))
+                Image(systemName: "chevron.up.chevron.down").font(.system(size: 8)).opacity(0.5)
+            }
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
     }
 
     /// Zoom slider ∈ [0,1] mapped onto the orbit distance (inverted: right = closer).
@@ -869,13 +1711,6 @@ struct ObjectInspectorWindow: View {
                 model.distance = 0.45 + Float(1 - $0) * (8.0 - 0.45)
                 model.pinchBaseline = model.distance
             })
-    }
-
-    private var materialBinding: Binding<String> {
-        let pi = model.selectedPartIndex ?? 0
-        return Binding(
-            get: { model.materialName(forPart: pi) ?? "aluminum" },
-            set: { model.setPartMaterial(pi, $0) })
     }
 
     private func camButton(_ label: String, az: Float, el: Float) -> some View {
@@ -894,6 +1729,48 @@ struct ObjectInspectorWindow: View {
         GridRow {
             Text(k).font(.system(size: 11)).foregroundStyle(.secondary)
             Text(v).font(.system(size: 11).monospacedDigit())
+        }
+    }
+}
+
+/// The feature tree / history, as a closable tool window. It carried no title
+/// or close button while every other panel had both.
+struct FeatureTreeWindow: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        ToolWindow(title: model.usesDocumentTree ? "Features" : "History",
+                   onClose: { model.showsTree = false }) {
+            ScrollViewReader { proxy in
+                ScrollView {
+                    FeatureTreeView(model: model)
+                }
+                // Clicking geometry selects a row that may be scrolled out of
+                // sight — a sync you cannot see is not a sync.
+                .onChange(of: model.selectedFeatureID) { _, id in
+                    guard let id else { return }
+                    withAnimation(Motion.snappy) { proxy.scrollTo(id, anchor: .center) }
+                }
+            }
+            .frame(width: 230)
+            .frame(maxHeight: 380)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+}
+
+/// The cross-domain Receipt, in the inspector's slot. The gripper is neither a
+/// sandbox primitive nor a feature-tree document, so the Object Inspector has
+/// nothing true to say about it — the studio swapped the whole inspector for
+/// this ledger, and so does the released desktop.
+struct ReceiptLedgerWindow: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        ToolWindow(title: "Receipt", onClose: { model.showsInspector = false }) {
+            ReceiptLedger(model: model)
+                .frame(width: 264)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 }
@@ -922,6 +1799,16 @@ struct SimulationWindow: View {
 }
 
 
+/// Opt-in click/frame timing (VCAD_PERF=1), read once rather than per event.
+let perfLogging = ProcessInfo.processInfo.environment["VCAD_PERF"] == "1"
+
+/// Which parts are hidden — an input to the released view, so a visibility
+/// change repaints rather than rebuilds.
+struct VisibilityState: Equatable {
+    let hidden: Set<Int>
+    let isolated: Int?
+}
+
 /// Wraps the released ARView so that only *this* view observes `poseTick`.
 ///
 /// Reading a 50 Hz counter directly in `ReleasedOverlayView.body` re-evaluates
@@ -941,6 +1828,194 @@ struct ReleasedScene: View {
                        cameraPosition: cameraPosition,
                        lookAt: lookAt,
                        poseTick: model.poseTick,
+                       geometryDirty: model.geometryDirty,
+                       // Selection and visibility are appearance, not geometry:
+                       // they ride as their own inputs so `updateNSView` runs and
+                       // repaints, instead of changing the key and rebuilding.
+                       selection: model.highlightedParts,
+                       selectedInstances: model.selectedInstances,
+                       visibility: VisibilityState(hidden: model.hiddenParts,
+                                                   isolated: model.isolatedPart),
                        geometryKey: geometryKey)
+    }
+}
+
+
+/// The only chrome that is never closable: show/hide the tool windows. (It
+/// replaces the old "Return to Studio" pill — there is no studio to return to,
+/// release-to-desktop being the app's only mode.)
+struct PanelsPill: View {
+    @Bindable var model: EditorModel
+
+    private var anyShown: Bool { model.showsPalette || model.showsTree || model.showsInspector }
+
+    var body: some View {
+        Button {
+            withAnimation(Motion.panel) {
+                model.setPanels(shown: !anyShown)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: anyShown ? "sidebar.squares.left" : "sidebar.squares.leading")
+                    .font(.system(size: 11, weight: .semibold))
+                Text(anyShown ? "Hide Panels" : "Show Panels")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(.ultraThinMaterial, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .help("Show or hide the floating tool windows (⌘⇧Space)")
+    }
+}
+
+// MARK: - Live Dock icon
+//
+// Release-to-desktop has no window to represent it in Mission Control and no
+// thumbnail anywhere — the app IS the parts floating over your desktop. So the
+// Dock tile becomes the viewport: whatever you are looking at, shrunk. Orbit
+// the model and the icon orbits with it.
+
+/// Keeps `NSApp.applicationIconImage` in step with the released viewport.
+@MainActor
+final class DockIcon {
+    static let shared = DockIcon()
+
+    /// The tile the app launched with, restored when there is nothing to show.
+    private lazy var appIcon: NSImage? = NSImage(named: "NSApplicationIcon")
+    private var timer: Timer?
+    private var inFlight = false
+    /// What the tile currently depicts. The Dock redraws on every assignment,
+    /// so a still scene must stop feeding it identical frames.
+    private var shownKey = ""
+
+    /// Start following the viewport. Cheap when nothing changes: the capture
+    /// only runs when the scene key moves, and never more than twice a second —
+    /// a Dock tile is 128 points and nobody is reading it at 60 fps.
+    func follow(model: EditorModel) {
+        guard timer == nil else { return }
+        let t = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick(model: model) }
+        }
+        // Common mode: the default run-loop mode stops firing while a menu is
+        // open or a window is being dragged, and a frozen Dock icon during an
+        // orbit is exactly when someone would look at it.
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
+    }
+
+    func stop() {
+        timer?.invalidate()
+        timer = nil
+        if let appIcon { NSApp.applicationIconImage = appIcon }
+    }
+
+    private func tick(model: EditorModel) {
+        guard !inFlight, let ar = ReleaseWindowController.shared.arView else { return }
+        // Everything that changes what the viewport looks like. Camera included:
+        // an orbit changes nothing about the document and everything about the
+        // picture.
+        // Distance and pan are deliberately absent: the tile crops to the
+        // model, so zooming and panning cannot change the picture. Only
+        // rotation does.
+        let key = [
+            String(describing: model.source), String(model.triangleCount),
+            String(format: "%.2f,%.2f", model.azimuth, model.elevation),
+            String(describing: model.highlightedParts.sorted()),
+            String(describing: model.selectedInstances.sorted()),
+            String(model.poseTick),                 // a running simulation
+        ].joined(separator: "|")
+        guard key != shownKey else { return }
+        guard model.triangleCount > 0 else { return }   // nothing to depict yet
+
+        inFlight = true
+        ar.snapshot(saveToHDR: false) { [weak self] image in
+            // Reduce to a CGImage here, in the callback: NSImage is not
+            // Sendable, so it must not cross into the main-actor hop.
+            let cg = image?.cgImage(forProposedRect: nil, context: nil, hints: nil)
+            Task { @MainActor in
+                defer { self?.inFlight = false }
+                guard let self, let cg, let tile = Self.tile(from: cg) else { return }
+                NSApp.applicationIconImage = tile
+                self.shownKey = key
+            }
+        }
+    }
+
+    /// Fit the capture into a square tile, framed on the MODEL rather than on
+    /// the viewport.
+    ///
+    /// Cropping to the centre of the frame ties the icon to the camera: zoom out
+    /// and the model becomes a speck in the tile, zoom in and it gets sliced.
+    /// The icon should be a portrait of the document, not a screenshot — so this
+    /// finds the drawn content and frames that. The viewport renders on a clear
+    /// background, which makes the alpha channel an exact silhouette mask; the
+    /// content bounds fall straight out of it.
+    private static func tile(from cg: CGImage) -> NSImage? {
+        guard let content = contentBounds(cg) else { return nil }
+        // Square up around the content's centre, then breathe: a subject that
+        // touches all four edges reads as cropped rather than composed.
+        let side = max(content.width, content.height) * 1.18
+        let square = CGRect(x: content.midX - side / 2, y: content.midY - side / 2,
+                            width: side, height: side)
+            .intersection(CGRect(x: 0, y: 0, width: cg.width, height: cg.height))
+        let cropped = cg.cropping(to: square.integral) ?? cg
+
+        let size = NSSize(width: 512, height: 512)
+        let out = NSImage(size: size)
+        out.lockFocus()
+        NSGraphicsContext.current?.imageInterpolation = .high
+        // Aspect-fit, centred: `square` can come back non-square after the
+        // clamp (a model against the edge of the viewport), and stretching it
+        // to the tile would shear the part.
+        let scale = min(size.width / CGFloat(cropped.width), size.height / CGFloat(cropped.height))
+        let w = CGFloat(cropped.width) * scale, h = CGFloat(cropped.height) * scale
+        NSImage(cgImage: cropped, size: .zero)
+            .draw(in: NSRect(x: (size.width - w) / 2, y: (size.height - h) / 2, width: w, height: h),
+                  from: .zero, operation: .copy, fraction: 1)
+        out.unlockFocus()
+        return out
+    }
+
+    /// The bounding box of everything the renderer drew, in `cg`'s pixel space.
+    ///
+    /// Scanned on a downsampled copy — a Dock tile does not need the silhouette
+    /// to the pixel, and scanning six megapixels twice a second would cost more
+    /// than the render it is framing.
+    private static func contentBounds(_ cg: CGImage) -> CGRect? {
+        let n = 96
+        var alpha = [UInt8](repeating: 0, count: n * n)
+        guard let ctx = CGContext(data: &alpha, width: n, height: n, bitsPerComponent: 8,
+                                  bytesPerRow: n, space: CGColorSpaceCreateDeviceGray(),
+                                  bitmapInfo: CGImageAlphaInfo.alphaOnly.rawValue)
+        else { return nil }
+        ctx.draw(cg, in: CGRect(x: 0, y: 0, width: n, height: n))
+
+        var minX = n, minY = n, maxX = -1, maxY = -1
+        for y in 0..<n {
+            for x in 0..<n where alpha[y * n + x] > 12 {   // ignore antialiased dust
+                if x < minX { minX = x }
+                if x > maxX { maxX = x }
+                if y < minY { minY = y }
+                if y > maxY { maxY = y }
+            }
+        }
+        guard maxX >= minX, maxY >= minY else { return nil }   // nothing drawn
+
+        // MIND THE ORIGIN. `CGContext` draws bottom-up, so row 0 of the buffer
+        // is the BOTTOM of the image, while `CGImage.cropping(to:)` measures
+        // from the top. Using the scan rows directly would crop the mirror
+        // image of the model — invisible on a centred subject, wrong the moment
+        // it sits off centre.
+        let top = n - 1 - maxY
+        let bottom = n - 1 - minY
+        let sx = CGFloat(cg.width) / CGFloat(n), sy = CGFloat(cg.height) / CGFloat(n)
+        // The scan grid is coarse, so pad by one cell rather than clipping the
+        // edge of the silhouette.
+        return CGRect(x: CGFloat(minX - 1) * sx, y: CGFloat(top - 1) * sy,
+                      width: CGFloat(maxX - minX + 3) * sx,
+                      height: CGFloat(bottom - top + 3) * sy)
+            .intersection(CGRect(x: 0, y: 0, width: cg.width, height: cg.height))
     }
 }

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -50,10 +50,15 @@ struct EditorView: View {
                     // Dev hook: VCAD_GRIPPER=1 [VCAD_CONNECTOR_X=n] launches into
                     // the cross-domain gripper (used to verify without driving the UI).
                     let env = ProcessInfo.processInfo.environment
-                    // Dev hook: VCAD_OPEN=<path> opens a .vcad on launch (handy
-                    // for verifying the feature tree against a real document).
-                    if let path = env["VCAD_OPEN"], !path.isEmpty {
-                        model.openDocument(URL(fileURLWithPath: path))
+                    AppInstance.currentModel = model
+                    // Pick up documents other instances opened while this one
+                    // was already running.
+                    model.refreshRecents()
+                    // The document this instance was launched for: the argument
+                    // a spawning instance passed, the VCAD_OPEN dev hook, or a
+                    // path on the command line.
+                    if let url = AppInstance.launchDocument() {
+                        model.openDocument(url)
                     }
                     // Dev hook: VCAD_SIM=1 builds the physics simulation for the
                     // opened document and starts it running, so the whole path
@@ -146,19 +151,28 @@ struct DocumentCommands: Commands {
 
     var body: some Commands {
         CommandGroup(replacing: .newItem) {
-            Button("New Sandbox") { model.newDocument() }.keyboardShortcut("n")
+            // ⌘N opens another COPY OF THE APP, so the new document gets its own
+            // Dock tile and its own ⌘-Tab entry (see AppInstance for why that
+            // cannot be a second window).
+            Button("New Document") { AppInstance.open() }.keyboardShortcut("n")
+            Button("Reset This Document") { model.newDocument() }
+                .keyboardShortcut("n", modifiers: [.command, .shift])
             Button("Cross-domain Gripper") { model.openGripper() }
             Divider()
             Button("Open…") { openPanel(model) }.keyboardShortcut("o")
             Menu("Open Recent") {
                 ForEach(model.recents, id: \.self) { url in
-                    Button(url.deletingPathExtension().lastPathComponent) { model.openDocument(url) }
+                    Button(url.deletingPathExtension().lastPathComponent) {
+                        AppInstance.opening(url, from: model)
+                    }
                 }
             }
             .disabled(model.recents.isEmpty)
             Menu("Examples") {
                 ForEach(model.examples, id: \.path) { ex in
-                    Button(ex.name) { model.openDocument(URL(fileURLWithPath: ex.path)) }
+                    Button(ex.name) {
+                        AppInstance.opening(URL(fileURLWithPath: ex.path), from: model)
+                    }
                 }
             }
         }
@@ -248,10 +262,17 @@ struct DocumentCommands: Commands {
 @MainActor func openPanel(_ model: EditorModel) {
     let panel = NSOpenPanel()
     panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
-    panel.allowsMultipleSelection = false
+    // Several documents at once are several instances, so a multiple selection
+    // is a perfectly good thing to ask for.
+    panel.allowsMultipleSelection = true
     panel.canChooseDirectories = false
     panel.prompt = "Open"
-    if panel.runModal() == .OK, let url = panel.url { model.openDocument(url) }
+    guard panel.runModal() == .OK else { return }
+    for (i, url) in panel.urls.enumerated() {
+        // The first one may claim this instance if it is a scratch; the rest
+        // always get their own.
+        if i == 0 { AppInstance.opening(url, from: model) } else { AppInstance.open(document: url) }
+    }
 }
 
 @MainActor private func savePanel(name: String, ext: String, prompt: String,

--- a/apple/VcadApp/Sources/VcadApp/Shell.swift
+++ b/apple/VcadApp/Sources/VcadApp/Shell.swift
@@ -31,110 +31,22 @@ extension View {
 }
 
 #if os(macOS)  // mac window root + document menu
+/// The app's only mode is release-to-desktop: the parts float over the desktop
+/// in a borderless transparent overlay (see ReleasedDesktop.swift). This view is
+/// the WindowGroup's root only because SwiftUI needs one — it owns the model and
+/// the intent engine, hides its own window before it can ever paint, and hands
+/// both to the overlay controller.
 struct EditorView: View {
-    @State private var model = EditorModel()
-    @State private var intent = IntentEngine()
+    let model: EditorModel
+    let intent: IntentEngine
 
     var body: some View {
-        GeometryReader { geo in
-            let compact = geo.size.width < 760
-            ViewportView(model: model)
-                .ignoresSafeArea()
-                .background(ReleaseWindowConfigurator(release: model.releaseMode))
-                .containerBackground(
-                    model.releaseMode ? AnyShapeStyle(.clear) : AnyShapeStyle(.background),
-                    for: .window)
-                .overlay(alignment: .topLeading) {
-                    if !compact && !model.releaseMode {
-                        FeatureTreeView(model: model)
-                            .frame(width: 206)
-                            .padding(14)
-                            .transition(.move(edge: .leading).combined(with: .opacity))
-                    }
-                }
-                .overlay(alignment: .top) {
-                    if showsTools && !model.releaseMode && model.toolPlacement == .header {
-                        toolStrip(header: true)
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-                }
-                .overlay(alignment: .top) {
-                    if model.source.isGripper && !model.releaseMode {
-                        GripperReceiptPill(model: model).padding(.top, 14)
-                    }
-                }
-                .overlay(alignment: .topTrailing) {
-                    if model.releaseMode {
-                        ReleaseReturnPill(model: model).padding(14)
-                    } else if model.source.isGripper {
-                        // The cross-domain Receipt takes the inspector slot — the
-                        // adaptive inspector adapting to a multi-domain part.
-                        ReceiptLedger(model: model)
-                            .frame(width: compact ? 248 : 300)
-                            .padding(14)
-                            .transition(.move(edge: .trailing).combined(with: .opacity))
-                    } else {
-                        InspectorView(model: model)
-                            .frame(width: compact ? 224 : 280)
-                            .padding(14)
-                    }
-                }
-                .overlay(alignment: .bottom) {
-                  if !model.releaseMode {
-                    VStack(spacing: 10) {
-                        if model.sketching {
-                            SketchHintBar(model: model)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
-                        } else if model.source.isSandbox && intent.draft.isEmpty && !intent.isThinking {
-                            ExampleChips(intent: intent)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
-                        }
-                        // Transports live here, in the SAME bottom overlay as the
-                        // composer — not in ViewportView's own bottom overlay.
-                        // Two bottom-aligned overlays on one view do not stack,
-                        // they coincide, and this one is applied outermost, so
-                        // anything the viewport draws at the bottom ends up
-                        // underneath the composer and the tool palette. (That is
-                        // where PlaybackBar used to be, and why it was invisible
-                        // whenever the footer palette was showing.)
-                        //
-                        // Kinematic playback above physics: both write the same
-                        // instance transforms, so only one drives at a time —
-                        // starting the simulation pauses playback.
-                        if model.hasPlayback {
-                            PlaybackBar(model: model)
-                        }
-                        if model.canSimulate {
-                            SimBar(model: model)
-                        }
-                        ComposerBar(engine: intent, model: model)
-                        if showsTools && model.toolPlacement == .footer {
-                            toolStrip(header: false)
-                                .transition(.move(edge: .bottom).combined(with: .opacity))
-                        }
-                    }
-                    .padding(.bottom, 14)
-                    .animation(Motion.smooth, value: model.source.isSandbox)
-                    .animation(Motion.smooth, value: intent.draft.isEmpty)
-                    .animation(Motion.panel, value: model.sketching)
-                    .animation(Motion.panel, value: model.toolPlacement)
-                  }
-                }
-                .toolbar {
-                    ToolbarItem(placement: .navigation) { BrandMark() }
-                    ToolbarItem(placement: .principal) { IdentityStatusBar(model: model) }
-                    ToolbarItem(placement: .primaryAction) { CollabAvatars() }
-                }
-                .navigationTitle(model.documentName)
-                .onChange(of: model.releaseMode) { _, released in
-                    if released {
-                        ReleaseWindowController.shared.show(model: model, intent: intent)
-                    } else {
-                        ReleaseWindowController.shared.hide()
-                    }
-                }
-                .animation(.smooth(duration: 0.3), value: compact)
-                .task {
+        Color.clear
+            .frame(width: 1, height: 1)
+            .background(HostWindowHider {
+                ReleaseWindowController.shared.show(model: model, intent: intent)
+            })
+            .task {
                     // Dev hook: VCAD_GRIPPER=1 [VCAD_CONNECTOR_X=n] launches into
                     // the cross-domain gripper (used to verify without driving the UI).
                     let env = ProcessInfo.processInfo.environment
@@ -142,14 +54,6 @@ struct EditorView: View {
                     // for verifying the feature tree against a real document).
                     if let path = env["VCAD_OPEN"], !path.isEmpty {
                         model.openDocument(URL(fileURLWithPath: path))
-                    }
-                    // Release-to-desktop is the default launch mode; VCAD_RELEASE=0
-                    // opts out (studio window on launch, handy for dev/debugging).
-                    // The 1s delay lets the window exist before the release
-                    // controller reparents it.
-                    if env["VCAD_RELEASE"] != "0" {
-                        try? await Task.sleep(for: .seconds(1))
-                        model.releaseMode = true
                     }
                     // Dev hook: VCAD_SIM=1 builds the physics simulation for the
                     // opened document and starts it running, so the whole path
@@ -195,124 +99,168 @@ struct EditorView: View {
                             + "segments=\(segs.count) unrouted=\(model.copperUnrouted)\n"
                         FileHandle.standardError.write(Data(line.utf8))
                     }
-                }
+            }
+    }
+}
+
+/// Hides the WindowGroup's window and opens the released overlay in its place.
+/// Done from an NSViewRepresentable rather than a `.task` because the overlay
+/// controller needs the host window to exist (it hides it), and a view's window
+/// is nil until AppKit has attached it — the old code waited out that race with
+/// a 1s sleep, which is exactly the studio flash this removes.
+struct HostWindowHider: NSViewRepresentable {
+    /// Called once, on the main actor, as soon as the host window exists.
+    let onAttach: () -> Void
+
+    func makeNSView(context: Context) -> NSView { HiderView(onAttach: onAttach) }
+    func updateNSView(_ view: NSView, context: Context) {}
+
+    final class HiderView: NSView {
+        private let onAttach: () -> Void
+        private var fired = false
+        init(onAttach: @escaping () -> Void) {
+            self.onAttach = onAttach
+            super.init(frame: .zero)
         }
-    }
+        required init?(coder: NSCoder) { fatalError("unused") }
 
-    private var showsTools: Bool {
-        model.sketching || model.source.isSandbox || model.usesDocumentTree
-    }
-
-    /// The active tool strip — the sketch palette while drawing, otherwise the
-    /// tool palette, rendered as a docked header bar or a floating footer card.
-    @ViewBuilder private func toolStrip(header: Bool) -> some View {
-        if model.sketching {
-            SketchPaletteView(model: model)
-                .padding(.top, header ? 8 : 0)
-        } else if header {
-            ToolPaletteView(model: model, axis: .horizontal, docked: true)
-        } else {
-            ToolPaletteView(model: model, axis: .horizontal)
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            guard let w = window, !fired else { return }
+            fired = true
+            // Zero alpha first: orderOut alone can still flash a frame if the
+            // window was ordered in earlier in this pass.
+            w.alphaValue = 0
+            w.orderOut(nil)
+            onAttach()
         }
     }
 }
 
-struct DocumentMenu: View {
+/// The app's real menu bar. Release-to-desktop has no window chrome to hang a
+/// document menu off, so every document action lives here — where a Mac user
+/// looks for it anyway, and where the key equivalents work no matter which
+/// floating panel has focus.
+struct DocumentCommands: Commands {
     @Bindable var model: EditorModel
-    var body: some View {
-        Menu {
+
+    var body: some Commands {
+        CommandGroup(replacing: .newItem) {
             Button("New Sandbox") { model.newDocument() }.keyboardShortcut("n")
             Button("Cross-domain Gripper") { model.openGripper() }
             Divider()
-            Button("Open…") { openPanel() }.keyboardShortcut("o")
-            if !model.recents.isEmpty {
-                Menu("Open Recent") {
-                    ForEach(model.recents, id: \.self) { url in
-                        Button(url.deletingPathExtension().lastPathComponent) { model.openDocument(url) }
-                    }
+            Button("Open…") { openPanel(model) }.keyboardShortcut("o")
+            Menu("Open Recent") {
+                ForEach(model.recents, id: \.self) { url in
+                    Button(url.deletingPathExtension().lastPathComponent) { model.openDocument(url) }
                 }
             }
+            .disabled(model.recents.isEmpty)
             Menu("Examples") {
                 ForEach(model.examples, id: \.path) { ex in
                     Button(ex.name) { model.openDocument(URL(fileURLWithPath: ex.path)) }
                 }
             }
+        }
+        CommandGroup(replacing: .saveItem) {
+            Button("Save") { model.saveDocument() }
+                .keyboardShortcut("s").disabled(!model.usesDocumentTree || !model.documentDirty)
+            Button("Save As…") { saveAsPanel(model) }
+                .keyboardShortcut("s", modifiers: [.command, .shift])
+                .disabled(!model.usesDocumentTree)
+            Button("Revert Changes") { model.revertDocument() }
+                .disabled(!model.usesDocumentTree || !model.documentDirty)
             Divider()
+            Button("Export STL…") { exportSTLPanel(model) }
+                .keyboardShortcut("e").disabled(!model.canExport)
+            Button("Export USDZ…") { exportUSDZPanel(model) }
+                .keyboardShortcut("e", modifiers: [.command, .shift]).disabled(!model.canExport)
+        }
+        CommandGroup(replacing: .undoRedo) {
             Button("Undo") { model.undo() }.keyboardShortcut("z").disabled(!model.canUndo)
             Button("Redo") { model.redo() }
                 .keyboardShortcut("z", modifiers: [.command, .shift]).disabled(!model.canRedo)
-            Divider()
-            if model.usesDocumentTree {
-                Button("Save") { model.saveDocument() }
-                    .keyboardShortcut("s").disabled(!model.documentDirty)
-                Button("Save As…") { saveAsPanel() }
-                    .keyboardShortcut("s", modifiers: [.command, .shift])
-                if model.documentDirty {
-                    Button("Revert Changes") { model.revertDocument() }
-                }
+        }
+        CommandMenu("View") {
+            Button(model.showsPalette ? "Hide Components" : "Show Components") {
+                model.showsPalette.toggle()
             }
-            Button("Export STL…") { exportPanel() }.keyboardShortcut("e").disabled(!model.canExport)
-            Button("Export USDZ…") { exportUSDZPanel() }
-                .keyboardShortcut("e", modifiers: [.command, .shift]).disabled(!model.canExport)
-            Divider()
-            Picker("Tool Palette", selection: $model.toolPlacement) {
-                ForEach(ToolPlacement.allCases) { p in Text(p.label).tag(p) }
+            .keyboardShortcut("1", modifiers: .command)
+            Button(model.showsTree ? "Hide Feature Tree" : "Show Feature Tree") {
+                model.showsTree.toggle()
             }
-            Button("Toggle Tool Palette") { model.cycleToolPlacement() }.keyboardShortcut("t")
-            Button(model.zebraMode ? "Zebra Analysis ✓" : "Zebra Analysis") { model.zebraMode.toggle() }
-                .keyboardShortcut("z", modifiers: [])
-            Button(model.releaseMode ? "Return to Studio" : "Release to Desktop") {
-                withAnimation(Motion.panel) { model.releaseMode.toggle() }
+            .keyboardShortcut("2", modifiers: .command)
+            Button(model.showsInspector ? "Hide Object Inspector" : "Show Object Inspector") {
+                model.showsInspector.toggle()
+            }
+            .keyboardShortcut("3", modifiers: .command)
+            Button(anyPanel ? "Hide Panels" : "Show Panels") {
+                model.setPanels(shown: !anyPanel)
             }
             .keyboardShortcut(.space, modifiers: [.command, .shift])
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: model.source.isSandbox ? "cube" : "doc").font(.system(size: 12))
-                Text(model.documentName).font(.system(size: 13, weight: .medium))
-                if model.documentDirty {
-                    Circle().fill(Color.accentColor).frame(width: 5, height: 5)
-                }
-                Image(systemName: "chevron.down").font(.system(size: 9)).opacity(0.55)
+            Divider()
+            Button(model.zebraMode ? "Zebra Analysis ✓" : "Zebra Analysis") {
+                model.zebraMode.toggle()
             }
+            .keyboardShortcut("z", modifiers: [])
+            Divider()
+            // ⌃-digit, not bare digits: the palette already claims 1/2/3 for
+            // its tabs, and a bare key equivalent fires from the composer too.
+            Button("Isometric") { camera(az: .pi / 5, el: .pi / 7) }
+                .keyboardShortcut("0", modifiers: .control)
+            Button("Front") { camera(az: 0, el: 0) }.keyboardShortcut("1", modifiers: .control)
+            Button("Right") { camera(az: .pi / 2, el: 0) }.keyboardShortcut("2", modifiers: .control)
+            Button("Top") { camera(az: 0, el: 1.45) }.keyboardShortcut("3", modifiers: .control)
         }
-        .menuStyle(.borderlessButton)
-        .fixedSize()
     }
 
-    private func exportPanel() {
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "stl") ?? .data]
-        panel.nameFieldStringValue = "\(model.documentName).stl"
-        panel.prompt = "Export"
-        if panel.runModal() == .OK, let url = panel.url { _ = model.exportSTL(to: url) }
-    }
+    private var anyPanel: Bool { model.showsPalette || model.showsTree || model.showsInspector }
 
-    private func exportUSDZPanel() {
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [.usdz]
-        panel.nameFieldStringValue = "\(model.documentName).usdz"
-        panel.prompt = "Export"
-        if panel.runModal() == .OK, let url = panel.url { _ = model.exportUSDZ(to: url) }
+    private func camera(az: Float, el: Float) {
+        model.stopSpin()
+        withAnimation(.smooth(duration: 0.25)) {
+            model.azimuth = az
+            model.elevation = el
+        }
     }
+}
 
-    private func saveAsPanel() {
-        let panel = NSSavePanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
-        panel.nameFieldStringValue = "\(model.documentName).vcad"
-        panel.prompt = "Save"
-        if panel.runModal() == .OK, let url = panel.url { model.saveDocumentAs(url) }
-    }
+// MARK: document panels (shared by the menu bar and the Components palette)
 
-    private func openPanel() {
-        #if os(macOS)
-        let panel = NSOpenPanel()
-        panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
-        panel.allowsMultipleSelection = false
-        panel.canChooseDirectories = false
-        panel.prompt = "Open"
-        if panel.runModal() == .OK, let url = panel.url { model.openDocument(url) }
-        #endif
+@MainActor func exportSTLPanel(_ model: EditorModel) {
+    savePanel(name: "\(model.documentName).stl", ext: "stl", prompt: "Export") {
+        _ = model.exportSTL(to: $0)
     }
+}
+
+@MainActor func exportUSDZPanel(_ model: EditorModel) {
+    savePanel(name: "\(model.documentName).usdz", ext: "usdz", prompt: "Export") {
+        _ = model.exportUSDZ(to: $0)
+    }
+}
+
+@MainActor func saveAsPanel(_ model: EditorModel) {
+    savePanel(name: "\(model.documentName).vcad", ext: "vcad", prompt: "Save") {
+        model.saveDocumentAs($0)
+    }
+}
+
+@MainActor func openPanel(_ model: EditorModel) {
+    let panel = NSOpenPanel()
+    panel.allowedContentTypes = [UTType(filenameExtension: "vcad") ?? .json]
+    panel.allowsMultipleSelection = false
+    panel.canChooseDirectories = false
+    panel.prompt = "Open"
+    if panel.runModal() == .OK, let url = panel.url { model.openDocument(url) }
+}
+
+@MainActor private func savePanel(name: String, ext: String, prompt: String,
+                                  _ done: @escaping (URL) -> Void) {
+    let panel = NSSavePanel()
+    panel.allowedContentTypes = [UTType(filenameExtension: ext) ?? .data]
+    panel.nameFieldStringValue = name
+    panel.prompt = prompt
+    if panel.runModal() == .OK, let url = panel.url { done(url) }
 }
 
 // MARK: top chrome — brand · centered identity + status · presence
@@ -329,15 +277,37 @@ struct BrandMark: View {
 }
 
 #if os(macOS)
-/// Centered identity (the document menu) + a compact live status readout.
+/// Document identity + a compact live status readout. In release-to-desktop
+/// there is no title bar to carry the document name, so this floats with the
+/// rest of the chrome; the actions it used to front now live in the menu bar.
 struct IdentityStatusBar: View {
     @Bindable var model: EditorModel
     var body: some View {
         HStack(spacing: 10) {
-            DocumentMenu(model: model)
+            HStack(spacing: 6) {
+                Image(systemName: model.source.isSandbox ? "cube" : "doc")
+                    .font(.system(size: 11))
+                Text(model.documentName).font(.system(size: 12, weight: .medium))
+                if model.documentDirty {
+                    Circle().fill(Color.accentColor).frame(width: 5, height: 5)
+                        .help("Unsaved changes")
+                }
+            }
             Divider().frame(height: 13)
-            StatusStrip(model: model)
+            if let err = model.loadError {
+                Label(err, systemImage: "exclamationmark.triangle.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+                    .lineLimit(1)
+                    .frame(maxWidth: 420, alignment: .leading)
+                    .help(err)
+            } else {
+                StatusStrip(model: model)
+            }
         }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 7)
+        .background(.ultraThinMaterial, in: Capsule())
     }
 }
 
@@ -598,6 +568,8 @@ struct SketchPaletteView: View {
                     .padding(6)
             }
             .buttonStyle(.plain)
+            // The help text promised Esc; nothing was listening for it.
+            .keyboardShortcut(.cancelAction)
             .help("Cancel sketch (Esc)")
         }
         .padding(8)
@@ -738,8 +710,12 @@ struct FeatureRowView: View {
         return !model.isPartVisible(pi)
     }
     /// Hovered via the tree row itself OR via the viewport (bidirectional).
+    /// `hoveredFeatureID` covers assembly instances, whose rows are part defs
+    /// and therefore have no part index of their own.
     private var hovered: Bool {
-        hovering || (node.partIndex != nil && node.partIndex == model.hoveredPartIndex)
+        hovering
+            || model.hoveredFeatureID == node.id
+            || (node.partIndex != nil && node.partIndex == model.hoveredPartIndex)
     }
     private var rowBackground: Color {
         if selected { return Color.accentColor.opacity(0.20) }
@@ -749,6 +725,9 @@ struct FeatureRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             row
+                // Addressable by the ScrollViewReader that keeps the selected
+                // row in view when the selection comes from the viewport.
+                .id(node.id)
             if expanded {
                 ForEach(node.children) { child in
                     FeatureRowView(model: model, node: child, depth: depth + 1)
@@ -796,7 +775,12 @@ struct FeatureRowView: View {
         .foregroundStyle(selected ? AnyShapeStyle(.primary) : AnyShapeStyle(.secondary))
         .opacity(dimmed ? 0.45 : 1)
         .contentShape(Rectangle())
-        .onHover { hovering = $0 }
+        .onHover { inside in
+            hovering = inside
+            // Row → viewport: light the geometry this row drew.
+            if inside { model.hoverFeature(node) }
+            else if model.hoveredFeatureID == node.id { model.hoverFeature(nil) }
+        }
         .onTapGesture {
             guard model.renamingFeatureID != node.id else { return }
             // ⌘-click a part row → toggle it in the multi-selection (for booleans).
@@ -879,7 +863,7 @@ struct InspectorView: View {
                         }
                     }
                     if Self.editableOps.contains(node.opType) {
-                        section("Parameters") { paramEditors(node) }
+                        section("Parameters") { FeatureParamEditors(model: model, node: node) }
                     } else if let d = node.detail {
                         section("Parameters") { row("Value", d) }
                     }
@@ -1025,82 +1009,102 @@ struct InspectorView: View {
         "Translate", "Rotate", "Scale", "Revolve", "LinearPattern", "CircularPattern",
     ]
 
+}
+
+/// Scrub/stepper editors for a feature node's parameters — each writes back
+/// into the live document and re-evaluates (parity with the web app's scrub
+/// inputs). Shared by the studio inspector and the released Object Inspector so
+/// the two cannot drift: a new editable op appears in both at once.
+struct FeatureParamEditors: View {
+    @Bindable var model: EditorModel
+    let node: FeatureNode
+    /// Called after every edit, so the released overlay can mesh-swap in place.
+    /// `snapshot` is true on a typed commit or the first tick of a scrub.
+    var onEdit: (Bool) -> Void = { _ in }
+
+    var body: some View { editors }
+
     /// Scrub/stepper editors for the selected feature — each writes back into the
     /// live document and re-evaluates (parity with the web app's scrub inputs).
-    @ViewBuilder private func paramEditors(_ node: FeatureNode) -> some View {
-        let op = model.opDict(nodeId: node.nodeId) ?? [:]
-        let id = node.nodeId
-        switch node.opType {
-        case "Cube":
-            axisField(op, id, "Width", "size", "x", minV: 0.1)
-            axisField(op, id, "Depth", "size", "y", minV: 0.1)
-            axisField(op, id, "Height", "size", "z", minV: 0.1)
-        case "Cylinder":
-            scalarField(op, id, "Radius", "radius"); scalarField(op, id, "Height", "height")
-        case "Sphere":
-            scalarField(op, id, "Radius", "radius")
-        case "Cone":
-            scalarField(op, id, "Radius 1", "radius1", minV: 0)
-            scalarField(op, id, "Radius 2", "radius2", minV: 0)
-            scalarField(op, id, "Height", "height")
-        case "Fillet":
-            scalarField(op, id, "Radius", "radius", sens: 0.05, minV: 0)
-        case "Chamfer":
-            scalarField(op, id, "Distance", "distance", sens: 0.05, minV: 0)
-        case "Shell":
-            scalarField(op, id, "Thickness", "thickness", sens: 0.05, minV: 0.1)
-        case "Translate":
-            axisField(op, id, "X", "offset", "x"); axisField(op, id, "Y", "offset", "y")
-            axisField(op, id, "Z", "offset", "z")
-        case "Rotate":
-            axisField(op, id, "X", "angles", "x", unit: "°", sens: 0.5)
-            axisField(op, id, "Y", "angles", "y", unit: "°", sens: 0.5)
-            axisField(op, id, "Z", "angles", "z", unit: "°", sens: 0.5)
-        case "Scale":
-            axisField(op, id, "X", "factor", "x", unit: "", sens: 0.01, minV: 0.01)
-            axisField(op, id, "Y", "factor", "y", unit: "", sens: 0.01, minV: 0.01)
-            axisField(op, id, "Z", "factor", "z", unit: "", sens: 0.01, minV: 0.01)
-        case "Revolve":
-            scalarField(op, id, "Angle", "angle_deg", unit: "°", sens: 0.5, minV: 0)
-        case "LinearPattern":
-            countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
-        case "CircularPattern":
-            countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
-            scalarField(op, id, "Span", "angle_deg", unit: "°", sens: 0.5, minV: 0)
-        default:
-            EmptyView()
-        }
+    @ViewBuilder private var editors: some View {
+    let op = model.opDict(nodeId: node.nodeId) ?? [:]
+    let id = node.nodeId
+    switch node.opType {
+    case "Cube":
+        axisField(op, id, "Width", "size", "x", minV: 0.1)
+        axisField(op, id, "Depth", "size", "y", minV: 0.1)
+        axisField(op, id, "Height", "size", "z", minV: 0.1)
+    case "Cylinder":
+        scalarField(op, id, "Radius", "radius"); scalarField(op, id, "Height", "height")
+    case "Sphere":
+        scalarField(op, id, "Radius", "radius")
+    case "Cone":
+        scalarField(op, id, "Radius 1", "radius1", minV: 0)
+        scalarField(op, id, "Radius 2", "radius2", minV: 0)
+        scalarField(op, id, "Height", "height")
+    case "Fillet":
+        scalarField(op, id, "Radius", "radius", sens: 0.05, minV: 0)
+    case "Chamfer":
+        scalarField(op, id, "Distance", "distance", sens: 0.05, minV: 0)
+    case "Shell":
+        scalarField(op, id, "Thickness", "thickness", sens: 0.05, minV: 0.1)
+    case "Translate":
+        axisField(op, id, "X", "offset", "x"); axisField(op, id, "Y", "offset", "y")
+        axisField(op, id, "Z", "offset", "z")
+    case "Rotate":
+        axisField(op, id, "X", "angles", "x", unit: "°", sens: 0.5)
+        axisField(op, id, "Y", "angles", "y", unit: "°", sens: 0.5)
+        axisField(op, id, "Z", "angles", "z", unit: "°", sens: 0.5)
+    case "Scale":
+        axisField(op, id, "X", "factor", "x", unit: "", sens: 0.01, minV: 0.01)
+        axisField(op, id, "Y", "factor", "y", unit: "", sens: 0.01, minV: 0.01)
+        axisField(op, id, "Z", "factor", "z", unit: "", sens: 0.01, minV: 0.01)
+    case "Revolve":
+        scalarField(op, id, "Angle", "angle_deg", unit: "°", sens: 0.5, minV: 0)
+    case "LinearPattern":
+        countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
+    case "CircularPattern":
+        countStepper(id, (op["count"] as? NSNumber)?.intValue ?? 0)
+        scalarField(op, id, "Span", "angle_deg", unit: "°", sens: 0.5, minV: 0)
+    default:
+        EmptyView()
     }
+}
 
     private func scalarField(_ op: [String: Any], _ id: Int, _ label: String, _ key: String,
-                             unit: String = "mm", sens: Double = 0.1, minV: Double = 0.1) -> some View {
-        let value = (op[key] as? NSNumber)?.doubleValue ?? 0
-        return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
-            model.editScalar(nodeId: id, key: key, value: v, snapshot: s)
-        }
+                         unit: String = "mm", sens: Double = 0.1, minV: Double = 0.1) -> some View {
+    let value = (op[key] as? NSNumber)?.doubleValue ?? 0
+    return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
+        model.editScalar(nodeId: id, key: key, value: v, snapshot: s)
+        onEdit(s)
     }
+}
 
     private func axisField(_ op: [String: Any], _ id: Int, _ label: String, _ key: String, _ a: String,
-                           unit: String = "mm", sens: Double = 0.1,
-                           minV: Double = -.greatestFiniteMagnitude) -> some View {
-        let value = ((op[key] as? [String: Any])?[a] as? NSNumber)?.doubleValue ?? 0
-        return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
-            model.editVec(nodeId: id, key: key, axis: a, value: v, snapshot: s)
-        }
+                       unit: String = "mm", sens: Double = 0.1,
+                       minV: Double = -.greatestFiniteMagnitude) -> some View {
+    let value = ((op[key] as? [String: Any])?[a] as? NSNumber)?.doubleValue ?? 0
+    return ScrubField(label: label, value: value, unit: unit, sensitivity: sens, minValue: minV) { v, s in
+        model.editVec(nodeId: id, key: key, axis: a, value: v, snapshot: s)
+        onEdit(s)
     }
+}
 
     private func countStepper(_ id: Int, _ count: Int) -> some View {
-        Stepper(value: Binding(
-            get: { count },
-            set: { model.editInt(nodeId: id, key: "count", value: max(1, $0), snapshot: true) }
-        ), in: 1...200) {
-            HStack {
-                Text("Count").font(.system(size: 12))
-                Spacer()
-                Text("\(count)").font(.system(size: 12).monospacedDigit()).foregroundStyle(.secondary)
-            }
+    Stepper(value: Binding(
+        get: { count },
+        set: {
+            model.editInt(nodeId: id, key: "count", value: max(1, $0), snapshot: true)
+            onEdit(true)
+        }
+    ), in: 1...200) {
+        HStack {
+            Text("Count").font(.system(size: 12))
+            Spacer()
+            Text("\(count)").font(.system(size: 12).monospacedDigit()).foregroundStyle(.secondary)
         }
     }
+}
 }
 
 /// A numeric field — the native take on the web app's scrub inputs. Drag the
@@ -1342,75 +1346,10 @@ struct PlaybackBar: View {
     }
 }
 
-/// Applies/reverts the transparent-window styling for release-to-desktop mode.
-/// Lives as an invisible background NSView so it can reach the hosting NSWindow.
-#if os(macOS)  // release window plumbing + studio viewport
-struct ReleaseWindowConfigurator: NSViewRepresentable {
-    var release: Bool
-
-    func makeNSView(context: Context) -> NSView { NSView() }
-
-    func updateNSView(_ view: NSView, context: Context) {
-        let release = release
-        DispatchQueue.main.async {
-            guard let w = view.window else { return }
-            w.isOpaque = !release
-            w.backgroundColor = release ? .clear : .windowBackgroundColor
-            w.hasShadow = !release
-            w.titlebarAppearsTransparent = release
-            w.titleVisibility = release ? .hidden : .visible
-            w.toolbar?.isVisible = !release
-            if release {
-                w.styleMask.insert(.fullSizeContentView)
-                w.level = .floating
-            } else {
-                w.styleMask.remove(.fullSizeContentView)
-                w.level = .normal
-            }
-            // RealityKit's drawable clears opaque — punch through every metal
-            // layer in the hierarchy so the desktop shows behind the parts.
-            if let content = w.contentView { Self.setMetalLayersOpaque(!release, in: content) }
-        }
-    }
-
-    private static func setMetalLayersOpaque(_ opaque: Bool, in view: NSView) {
-        if let layer = view.layer { walkLayers(layer, opaque: opaque) }
-        for sub in view.subviews { setMetalLayersOpaque(opaque, in: sub) }
-    }
-
-    private static func walkLayers(_ layer: CALayer, opaque: Bool) {
-        if layer is CAMetalLayer {
-            layer.isOpaque = opaque
-            layer.backgroundColor = opaque ? nil : NSColor.clear.cgColor
-        }
-        for sub in layer.sublayers ?? [] { walkLayers(sub, opaque: opaque) }
-    }
-}
-
-/// The only chrome left in release mode: a small pill to come back inside.
-struct ReleaseReturnPill: View {
-    @Bindable var model: EditorModel
-
-    var body: some View {
-        Button {
-            withAnimation(Motion.panel) { model.releaseMode = false }
-        } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "arrow.down.forward.and.arrow.up.backward")
-                    .font(.system(size: 11, weight: .semibold))
-                Text("Return to Studio").font(.system(size: 12, weight: .medium))
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 7)
-            .background(.ultraThinMaterial, in: Capsule())
-        }
-        .buttonStyle(.plain)
-        .help("Bring vcad back into its window (⌘⇧Space)")
-    }
-}
-
-#endif  // os(macOS) — release window plumbing
-#if os(macOS)  // studio viewport (camera RealityView + extensions to EOF)
+#if os(macOS)  // shared RealityKit scene code (extensions to EOF)
+// The studio viewport: no longer presented (release-to-desktop is the only
+// mode), but still the home of the shared RealityKit scene code the released
+// ARView builds on — environments, materials, gizmo and mesh construction.
 struct ViewportView: View {
     let model: EditorModel
 
@@ -1420,7 +1359,7 @@ struct ViewportView: View {
              model.pickDirty, model.connectorX, model.hoveredHandle, model.panOffset,
              model.copperDirty, model.copperStale, model.visibilityDirty, model.selectionDirty,
              model.docParamDirty, model.sketchDirty, model.hoverDirty, model.gizmoDirty,
-             model.playbackTime, model.playbackDirty, model.zebraDirty, model.releaseDirty)
+             model.playbackTime, model.playbackDirty, model.zebraDirty)
 
         return GeometryReader { geo in
           RealityView { content in
@@ -1447,11 +1386,6 @@ struct ViewportView: View {
                 var mutableContent = content
                 applyZebra(&mutableContent, on: model.zebraMode)
                 model.zebraDirty = false
-            }
-            if model.releaseDirty {
-                var mutableContent = content
-                applyRelease(&mutableContent, on: model.releaseMode)
-                model.releaseDirty = false
             }
             if model.geometryDirty {
                 rebuildGeometry(content)
@@ -2203,7 +2137,7 @@ struct ViewportView: View {
         UnlitMaterial(color: NSColor(white: 0.09, alpha: 1.0))
     }()
 }
-#endif  // os(macOS) — studio viewport
+#endif  // os(macOS) — shared RealityKit scene code
 
 // MARK: sketch preview overlay (shared: studio viewport + released desktop)
 

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -311,4 +311,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
     func applicationShouldTerminateAfterLastWindowClosed(_ app: NSApplication) -> Bool { true }
+
+    /// Implementing `application(_:open:)` below tells AppKit this app opens
+    /// documents, which by default suppresses the untitled window at launch —
+    /// and this app's whole UI hangs off that window. Say yes explicitly.
+    func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool { true }
+
+    /// Finder double-click, drag onto the icon, `open file.vcad`. macOS hands
+    /// these to a RUNNING instance rather than launching one, so this is the
+    /// path that would otherwise replace the document you are looking at.
+    func application(_ application: NSApplication, open urls: [URL]) {
+        MainActor.assumeIsolated {
+            guard let model = AppInstance.currentModel else {
+                // Nothing to reuse (the view has not come up yet): let each URL
+                // have its own instance rather than dropping it.
+                urls.forEach { AppInstance.open(document: $0) }
+                return
+            }
+            for (i, url) in urls.enumerated() {
+                if i == 0 { AppInstance.opening(url, from: model) }
+                else { AppInstance.open(document: url) }
+            }
+        }
+    }
 }

--- a/apple/VcadApp/Sources/VcadApp/VcadApp.swift
+++ b/apple/VcadApp/Sources/VcadApp/VcadApp.swift
@@ -49,12 +49,18 @@ struct VcadApp: App {
         }
     }
 
+    /// The document lives at app scope, not in the window: the WindowGroup's
+    /// window is hidden at launch (release-to-desktop is the only mode), and the
+    /// menu bar commands need the same model the floating overlay is editing.
+    @State private var model = EditorModel()
+    @State private var intent = IntentEngine()
+
     var body: some Scene {
         WindowGroup {
-            EditorView()
-                .frame(minWidth: 560, minHeight: 600)
+            EditorView(model: model, intent: intent)
         }
         .windowStyle(.automatic)
+        .commands { DocumentCommands(model: model) }
     }
 }
 

--- a/apple/VcadVision/Sources/CVcadFFI/vcad_ffi.h
+++ b/apple/VcadVision/Sources/CVcadFFI/vcad_ffi.h
@@ -107,6 +107,16 @@ VcadEdges *vcad_mesh_edges(const VcadMesh *mesh, float angle_deg);
 VcadEdgesView vcad_edges_view(const VcadEdges *edges);
 void vcad_edges_free(VcadEdges *edges);
 
+/* Per-triangle FACE ids for a scene part: one u32 per triangle of
+ * vcad_scene_part_mesh, naming which face of the solid produced it (ordinal
+ * within the shell). UINT32_MAX marks a triangle with no face (bridging fill).
+ * Writes the count to out_len; returns NULL when the part carries no tags
+ * (e.g. a frozen or imported mesh with no B-rep), so face picking is an
+ * optional capability. Borrows the scene; valid until the scene is freed.
+ * NOT durable across edits — any change to the B-rep renumbers the ordinals. */
+const uint32_t *vcad_scene_part_face_ids(const VcadScene *scene, size_t index,
+                                         size_t *out_len);
+
 /* Direct BRep ray tracing (pixel-perfect mode): rays hit analytic surfaces,
  * no tessellation. Kernel coords (Z-up, mm); colors = 3 f32 per part
  * (linear RGB); RGBA8 row-major output. CPU renderer today, signature is

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -1746,6 +1746,7 @@ fn slice_file(
         indices: combined_idxs,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
 
     // Resolve printer profile

--- a/crates/vcad-eval/src/cache.rs
+++ b/crates/vcad-eval/src/cache.rs
@@ -183,7 +183,10 @@ fn kernel_knobs() -> Vec<(String, String)> {
 // without serde and a truncated or foreign file decodes to `None`.
 
 const MESH_MAGIC: &[u8; 4] = b"VCRM";
-const MESH_FORMAT: u32 = 1;
+// Bumped to 2 when per-triangle face ids joined the record. Old entries are
+// rejected rather than misread: a v1 record has no id block, and silently
+// treating its trailing bytes as one would hand the viewport garbage faces.
+const MESH_FORMAT: u32 = 2;
 
 /// Serialize a mesh to the cache's on-disk record format.
 pub fn encode_mesh(mesh: &EvaluatedMesh) -> Vec<u8> {
@@ -191,7 +194,8 @@ pub fn encode_mesh(mesh: &EvaluatedMesh) -> Vec<u8> {
         16 + mesh.positions.len() * 4
             + mesh.indices.len() * 4
             + mesh.normals.as_ref().map_or(0, |n| n.len() * 4)
-            + mesh.face_kinds.as_ref().map_or(0, |k| k.len()),
+            + mesh.face_kinds.as_ref().map_or(0, |k| k.len())
+            + mesh.face_ids.as_ref().map_or(0, |f| f.len() * 4),
     );
     out.extend_from_slice(MESH_MAGIC);
     out.extend_from_slice(&MESH_FORMAT.to_le_bytes());
@@ -209,6 +213,13 @@ pub fn encode_mesh(mesh: &EvaluatedMesh) -> Vec<u8> {
             out.push(1);
             out.extend_from_slice(&(k.len() as u64).to_le_bytes());
             out.extend_from_slice(k);
+        }
+        None => out.push(0),
+    }
+    match &mesh.face_ids {
+        Some(f) => {
+            out.push(1);
+            put_u32s(&mut out, f);
         }
         None => out.push(0),
     }
@@ -240,6 +251,11 @@ pub fn decode_mesh(bytes: &[u8]) -> Option<EvaluatedMesh> {
         }
         _ => return None,
     };
+    let face_ids = match r.u8()? {
+        0 => None,
+        1 => Some(r.f32s_as_u32s()?),
+        _ => return None,
+    };
     if r.at != bytes.len() {
         return None;
     }
@@ -253,6 +269,7 @@ pub fn decode_mesh(bytes: &[u8]) -> Option<EvaluatedMesh> {
         indices,
         normals,
         face_kinds,
+        face_ids,
     })
 }
 
@@ -628,6 +645,7 @@ mod tests {
             indices: vec![0, 1, 0],
             normals: Some(vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
             face_kinds: Some(vec![1]),
+            face_ids: Some(vec![7]),
         };
         let bytes = encode_mesh(&mesh);
         let back = decode_mesh(&bytes).unwrap();
@@ -641,6 +659,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: None,
             face_kinds: None,
+            face_ids: None,
         };
         let back = decode_mesh(&encode_mesh(&bare)).unwrap();
         assert_eq!(back.normals, None);
@@ -657,6 +676,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: None,
             face_kinds: None,
+            face_ids: None,
         };
         let bytes = encode_mesh(&mesh);
         assert!(decode_mesh(&bytes[..bytes.len() - 1]).is_none());
@@ -669,6 +689,7 @@ mod tests {
             indices: vec![0, 1, 7],
             normals: None,
             face_kinds: None,
+            face_ids: None,
         };
         assert!(decode_mesh(&encode_mesh(&bad)).is_none());
     }
@@ -685,6 +706,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: None,
             face_kinds: None,
+            face_ids: None,
         };
         cache.put(&key, &mesh);
         assert_eq!(cache.get(&key).unwrap().indices, vec![0, 1, 2]);

--- a/crates/vcad-eval/src/evaluate.rs
+++ b/crates/vcad-eval/src/evaluate.rs
@@ -923,6 +923,7 @@ fn evaluate_op_timed(
                     .map(|n| n.iter().map(|v| *v as f32).collect())
                     .unwrap_or_else(|| vec![0.0; n_verts * 3]),
                 face_kinds: Vec::new(),
+                face_ids: Vec::new(),
             })))
         }
 
@@ -1004,6 +1005,7 @@ fn evaluate_op_timed(
                     .map(|n| n.iter().map(|v| *v as f32).collect())
                     .unwrap_or_else(|| vec![0.0; n_verts * 3]),
                 face_kinds: Vec::new(),
+                face_ids: Vec::new(),
             })))
         }
 
@@ -1129,6 +1131,7 @@ fn evaluate_op_timed(
                     indices: all_indices,
                     normals: vec![],
                     face_kinds: vec![],
+                    face_ids: vec![],
                 };
                 board_solid = Solid::from_mesh(merged);
             }
@@ -1575,6 +1578,7 @@ fn evaluate_text_extrude(
             indices: all_indices,
             normals: all_normals,
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         Some(Solid::from_mesh(merged))
     } else {
@@ -1785,6 +1789,7 @@ fn transform_imported_mesh(data: &ImportedMeshData) -> EvaluatedMesh {
         indices: data.indices.clone(),
         normals,
         face_kinds: None,
+        face_ids: None,
     }
 }
 
@@ -2480,6 +2485,11 @@ fn tri_to_evaluated(tri: &TriangleMesh) -> EvaluatedMesh {
         } else {
             None
         },
+        face_ids: if tri.face_ids.len() == tri.indices.len() / 3 {
+            Some(tri.face_ids.clone())
+        } else {
+            None
+        },
     }
 }
 
@@ -2504,6 +2514,13 @@ fn tri_to_evaluated_render(mut tri: TriangleMesh) -> EvaluatedMesh {
         },
         face_kinds: if tri.face_kinds.len() == tri_count {
             Some(tri.face_kinds)
+        } else {
+            None
+        },
+        // The render bake unindexes (a vertex per triangle corner) but never
+        // reorders triangles, so the per-triangle ids stay aligned.
+        face_ids: if tri.face_ids.len() == tri_count {
+            Some(tri.face_ids)
         } else {
             None
         },

--- a/crates/vcad-eval/src/lib.rs
+++ b/crates/vcad-eval/src/lib.rs
@@ -252,6 +252,14 @@ pub struct EvaluatedMesh {
     /// 4=Cone, 5=Bilinear, 6=Torus, 7=BSpline, 8=FanFill.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub face_kinds: Option<Vec<u8>>,
+    /// Optional per-triangle FACE id (one u32 per `indices / 3`): which face of
+    /// the solid contributed each triangle, by shell ordinal. `face_kinds` says
+    /// a triangle came from a plane; this says which plane — what a viewport
+    /// needs to hover, select, or measure a single face. `u32::MAX` marks a
+    /// triangle with no face (bridging fill). Not durable across edits: any
+    /// change to the B-rep renumbers the ordinals.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub face_ids: Option<Vec<u32>>,
 }
 
 impl EvaluatedMesh {
@@ -262,6 +270,7 @@ impl EvaluatedMesh {
             indices: Vec::new(),
             normals: None,
             face_kinds: None,
+            face_ids: None,
         }
     }
 }

--- a/crates/vcad-ffi/include/vcad_ffi.h
+++ b/crates/vcad-ffi/include/vcad_ffi.h
@@ -105,6 +105,16 @@ VcadEdges *vcad_mesh_edges(const VcadMesh *mesh, float angle_deg);
 VcadEdgesView vcad_edges_view(const VcadEdges *edges);
 void vcad_edges_free(VcadEdges *edges);
 
+/* Per-triangle FACE ids for a scene part: one u32 per triangle of
+ * vcad_scene_part_mesh, naming which face of the solid produced it (ordinal
+ * within the shell). UINT32_MAX marks a triangle with no face (bridging fill).
+ * Writes the count to out_len; returns NULL when the part carries no tags
+ * (e.g. a frozen or imported mesh with no B-rep), so face picking is an
+ * optional capability. Borrows the scene; valid until the scene is freed.
+ * NOT durable across edits — any change to the B-rep renumbers the ordinals. */
+const uint32_t *vcad_scene_part_face_ids(const VcadScene *scene, size_t index,
+                                         size_t *out_len);
+
 /* Direct BRep ray tracing (pixel-perfect mode): rays hit analytic surfaces,
  * no tessellation. Kernel coords (Z-up, mm); colors = 3 f32 per part
  * (linear RGB); RGBA8 row-major output. CPU renderer today, signature is

--- a/crates/vcad-ffi/src/lib.rs
+++ b/crates/vcad-ffi/src/lib.rs
@@ -452,6 +452,52 @@ pub extern "C" fn vcad_scene_part_mesh(scene: *const VcadScene, index: usize) ->
     eval_mesh_view(&part.mesh)
 }
 
+/// Borrow the `index`-th part's per-triangle FACE ids: one `u32` per triangle
+/// of [`vcad_scene_part_mesh`], naming which face of the solid produced it.
+///
+/// This is what turns "you clicked part 3" into "you clicked the top face of
+/// part 3": a ray test gives a triangle, and this gives that triangle's face.
+/// `u32::MAX` marks a triangle with no face (bridging fill). Writes the element
+/// count to `out_len` and returns null when the part carries no tags (a frozen
+/// or imported mesh has no B-rep to name faces in), so callers must treat
+/// face picking as an optional capability rather than assuming it.
+///
+/// The pointer borrows the scene and is valid until the scene is freed.
+///
+/// The ids are ordinals within the solid's shell — stable across
+/// re-tessellation of the same solid, renumbered by any edit that changes the
+/// B-rep. They are a handle for this session's hover/selection, NOT a durable
+/// reference to persist in a document.
+#[no_mangle]
+pub extern "C" fn vcad_scene_part_face_ids(
+    scene: *const VcadScene,
+    index: usize,
+    out_len: *mut usize,
+) -> *const u32 {
+    if !out_len.is_null() {
+        unsafe { *out_len = 0 };
+    }
+    if scene.is_null() {
+        return ptr::null();
+    }
+    let s: &VcadScene = unsafe { &*scene };
+    let Some(part) = s.inner.parts.get(index) else {
+        return ptr::null();
+    };
+    let Some(ids) = part.mesh.face_ids.as_ref() else {
+        return ptr::null();
+    };
+    // Only hand back a tag array that matches the mesh the caller is drawing;
+    // a stale or partial array would point hover at the wrong face.
+    if ids.len() != part.mesh.indices.len() / 3 {
+        return ptr::null();
+    }
+    if !out_len.is_null() {
+        unsafe { *out_len = ids.len() };
+    }
+    ids.as_ptr()
+}
+
 /// Extract the `index`-th part's feature edges (boundary + creases sharper
 /// than `angle_deg`) for a wireframe/edge overlay. Returns an owned handle;
 /// read it with [`vcad_edges_view`] and release it with [`vcad_edges_free`].
@@ -2211,6 +2257,37 @@ mod tests {
         assert!(view.indices_len % 3 == 0, "indices form whole triangles");
         vcad_mesh_free(mesh);
         vcad_solid_free(solid);
+    }
+
+    /// The contract the viewport's face picking rests on: one id per triangle
+    /// of the very mesh the caller draws, and more than one face in a real
+    /// part. (The exact face count of a primitive is pinned in the tessellator's
+    /// own tests; here what matters is the array lines up with the mesh.)
+    #[test]
+    fn part_face_ids_cover_every_triangle() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../../examples/plate.vcad");
+        let json = std::fs::read(path).expect("read example .vcad");
+        let scene = vcad_scene_from_json(json.as_ptr(), json.len());
+        assert!(!scene.is_null(), "example document should evaluate");
+        let view = vcad_scene_part_mesh(scene, 0);
+        let tris = view.indices_len / 3;
+        assert!(tris > 0);
+
+        let mut len = 0usize;
+        let ids = vcad_scene_part_face_ids(scene, 0, &mut len);
+        assert!(!ids.is_null(), "a B-rep part should carry face tags");
+        assert_eq!(len, tris, "one id per triangle of the mesh being drawn");
+
+        let slice = unsafe { std::slice::from_raw_parts(ids, len) };
+        let unique: std::collections::HashSet<u32> =
+            slice.iter().copied().filter(|&f| f != u32::MAX).collect();
+        assert!(unique.len() > 1, "expected several faces, got {unique:?}");
+
+        // Out of range is a null, not a crash or a stale borrow.
+        let mut oob = 7usize;
+        assert!(vcad_scene_part_face_ids(scene, 99, &mut oob).is_null());
+        assert_eq!(oob, 0, "out_len is cleared on the null path");
+        vcad_scene_free(scene);
     }
 
     #[test]

--- a/crates/vcad-ffi/src/lib.rs
+++ b/crates/vcad-ffi/src/lib.rs
@@ -307,22 +307,36 @@ pub extern "C" fn vcad_scene_from_json(json: *const u8, json_len: usize) -> *mut
     if json.is_null() {
         return ptr::null_mut();
     }
+    err::clear_error();
     catch_unwind(AssertUnwindSafe(|| {
         let bytes = unsafe { std::slice::from_raw_parts(json, json_len) };
         let text = match std::str::from_utf8(bytes) {
             Ok(t) => t,
-            Err(_) => return ptr::null_mut(),
+            Err(e) => {
+                err::set_error(format!("document is not UTF-8: {e}"));
+                return ptr::null_mut();
+            }
         };
+        // Why the diagnosis matters here: serde names the offending field and
+        // line ("missing field `partDefId` at line 107"), and dropping it left
+        // callers to render an empty scene with no way to say why. A schema
+        // mismatch then presents as a renderer bug.
         let doc = match Document::from_json(text) {
             Ok(d) => d,
-            Err(_) => return ptr::null_mut(),
+            Err(e) => {
+                err::set_error(format!("parse: {e}"));
+                return ptr::null_mut();
+            }
         };
         match evaluate_document(&doc, &EvalOptions::default()) {
             Ok(scene) => Box::into_raw(Box::new(VcadScene {
                 inner: scene,
                 doc: Some(doc),
             })),
-            Err(_) => ptr::null_mut(),
+            Err(e) => {
+                err::set_error(format!("evaluate: {e}"));
+                ptr::null_mut()
+            }
         }
     }))
     .unwrap_or(ptr::null_mut())
@@ -345,13 +359,19 @@ pub extern "C" fn vcad_scene_from_json_in(
     if json.is_null() {
         return ptr::null_mut();
     }
+    err::clear_error();
     catch_unwind(AssertUnwindSafe(|| {
         let bytes = unsafe { std::slice::from_raw_parts(json, json_len) };
         let Ok(text) = std::str::from_utf8(bytes) else {
+            err::set_error("document is not UTF-8");
             return ptr::null_mut();
         };
-        let Ok(mut doc) = Document::from_json(text) else {
-            return ptr::null_mut();
+        let mut doc = match Document::from_json(text) {
+            Ok(d) => d,
+            Err(e) => {
+                err::set_error(format!("parse: {e}"));
+                return ptr::null_mut();
+            }
         };
         if !base_dir.is_null() && base_dir_len > 0 {
             let db = unsafe { std::slice::from_raw_parts(base_dir, base_dir_len) };
@@ -364,7 +384,10 @@ pub extern "C" fn vcad_scene_from_json_in(
                 inner: scene,
                 doc: Some(doc),
             })),
-            Err(_) => ptr::null_mut(),
+            Err(e) => {
+                err::set_error(format!("evaluate: {e}"));
+                ptr::null_mut()
+            }
         }
     }))
     .unwrap_or(ptr::null_mut())

--- a/crates/vcad-kernel-drafting/examples/bracket_drawing.rs
+++ b/crates/vcad-kernel-drafting/examples/bracket_drawing.rs
@@ -75,6 +75,7 @@ fn make_bracket_mesh() -> TriangleMesh {
         indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/crates/vcad-kernel-drafting/examples/cube_drafting.rs
+++ b/crates/vcad-kernel-drafting/examples/cube_drafting.rs
@@ -84,5 +84,6 @@ fn make_cube_mesh(size: f64) -> TriangleMesh {
         indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }

--- a/crates/vcad-kernel-drafting/examples/section_test.rs
+++ b/crates/vcad-kernel-drafting/examples/section_test.rs
@@ -40,6 +40,7 @@ fn make_cube(size: f64) -> TriangleMesh {
         indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/crates/vcad-kernel-drafting/src/edge_extract.rs
+++ b/crates/vcad-kernel-drafting/src/edge_extract.rs
@@ -392,6 +392,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-kernel-drafting/src/hidden_line.rs
+++ b/crates/vcad-kernel-drafting/src/hidden_line.rs
@@ -272,6 +272,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-kernel-drafting/src/lib.rs
+++ b/crates/vcad-kernel-drafting/src/lib.rs
@@ -108,6 +108,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-kernel-drafting/src/section.rs
+++ b/crates/vcad-kernel-drafting/src/section.rs
@@ -1077,6 +1077,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-kernel-drafting/tests/shop_drawing_golden.rs
+++ b/crates/vcad-kernel-drafting/tests/shop_drawing_golden.rs
@@ -40,6 +40,7 @@ fn make_block() -> TriangleMesh {
         indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/crates/vcad-kernel-drafting/tests/view_orientation.rs
+++ b/crates/vcad-kernel-drafting/tests/view_orientation.rs
@@ -103,6 +103,7 @@ fn front_view_shows_near_geometry_and_back_view_hides_it() {
         indices: Vec::new(),
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
     // Big slab behind (y ∈ [10, 20]).
     push_box(&mut mesh, [0.0, 10.0, 0.0], [20.0, 20.0, 20.0]);

--- a/crates/vcad-kernel-physics/src/colliders.rs
+++ b/crates/vcad-kernel-physics/src/colliders.rs
@@ -261,6 +261,7 @@ mod tests {
             ],
             normals: vec![],
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-kernel-physics/src/stl.rs
+++ b/crates/vcad-kernel-physics/src/stl.rs
@@ -70,5 +70,6 @@ pub fn load_stl(path: &Path, scale: Option<Vec3>) -> Result<TriangleMesh, Physic
         indices,
         normals,
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     })
 }

--- a/crates/vcad-kernel-physics/src/world.rs
+++ b/crates/vcad-kernel-physics/src/world.rs
@@ -1929,6 +1929,7 @@ impl PhysicsWorld {
                     indices: indices.clone(),
                     normals: normals_f32,
                     face_kinds: Vec::new(),
+                    face_ids: Vec::new(),
                 }))
             }
             _ => Ok(None),

--- a/crates/vcad-kernel-raytrace/src/bvh.rs
+++ b/crates/vcad-kernel-raytrace/src/bvh.rs
@@ -1055,6 +1055,7 @@ mod tests {
             // the same direction — the test isolates "vertex or geometric?".
             normals: vec![0.0, 0.6, 0.8, 0.0, 0.6, 0.8, 0.0, 0.6, 0.8],
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         let bvh = Bvh::build_mesh(&mesh);
 
@@ -1080,6 +1081,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         let bvh = Bvh::build_mesh(&mesh);
 
@@ -1098,6 +1100,7 @@ mod tests {
             indices: vec![0, 1, 2, 0, 0, 1, 0, 1, 99],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         let bvh = Bvh::build_mesh(&mesh);
 

--- a/crates/vcad-kernel-shell/src/lib.rs
+++ b/crates/vcad-kernel-shell/src/lib.rs
@@ -464,6 +464,7 @@ pub fn shell_mesh(mesh: &TriangleMesh, thickness: f64) -> TriangleMesh {
         indices: combined_indices,
         normals: Vec::new(), // Let renderer compute normals
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/crates/vcad-kernel-tessellate/src/creased_normals.rs
+++ b/crates/vcad-kernel-tessellate/src/creased_normals.rs
@@ -195,6 +195,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         apply_creased_normals(&mut mesh, DEFAULT_CREASE_ANGLE_RAD);
@@ -240,6 +241,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         apply_creased_normals(&mut mesh, DEFAULT_CREASE_ANGLE_RAD);
@@ -275,6 +277,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         apply_creased_normals(&mut mesh, DEFAULT_CREASE_ANGLE_RAD);

--- a/crates/vcad-kernel-tessellate/src/lib.rs
+++ b/crates/vcad-kernel-tessellate/src/lib.rs
@@ -84,7 +84,24 @@ pub struct TriangleMesh {
     /// for debugging / inspection. Empty when the mesh was built
     /// without tagging (legacy paths).
     pub face_kinds: Vec<u8>,
+    /// One id per triangle (same length as `indices / 3`) naming WHICH face of
+    /// the solid contributed it — the ordinal of the face within its shell.
+    /// `face_kinds` says a triangle came from *a plane*; this says it came from
+    /// *that* plane, which is what a viewport needs to hover, select, or
+    /// measure one face rather than a whole part.
+    ///
+    /// NOT a durable name. The ordinal is stable for a given topology, so it
+    /// survives re-tessellation of the same solid, but any edit that changes
+    /// the B-rep renumbers it. Persisting a face reference across edits is the
+    /// topological-naming problem and needs its own scheme.
+    ///
+    /// `u32::MAX` marks a triangle whose provenance was lost (padding, legacy
+    /// paths); empty means the mesh was never tagged.
+    pub face_ids: Vec<u32>,
 }
+
+/// Marks a triangle whose originating face is unknown.
+pub const FACE_ID_UNKNOWN: u32 = u32::MAX;
 
 impl TriangleMesh {
     /// Create an empty mesh.
@@ -94,6 +111,7 @@ impl TriangleMesh {
             indices: Vec::new(),
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 
@@ -168,6 +186,17 @@ impl TriangleMesh {
         } else if !self.face_kinds.is_empty() {
             for _ in 0..other_tri {
                 self.face_kinds.push(FaceKindTag::Unknown as u8);
+            }
+        }
+        // Same lockstep rule for face ids.
+        if !other.face_ids.is_empty() {
+            while self.face_ids.len() < self_tri_before {
+                self.face_ids.push(FACE_ID_UNKNOWN);
+            }
+            self.face_ids.extend_from_slice(&other.face_ids);
+        } else if !self.face_ids.is_empty() {
+            for _ in 0..other_tri {
+                self.face_ids.push(FACE_ID_UNKNOWN);
             }
         }
     }
@@ -860,8 +889,10 @@ fn heal_t_junctions_pass(mesh: &mut TriangleMesh) -> bool {
 
     let has_normals = mesh.normals.len() == mesh.vertices.len();
     let has_kinds = mesh.face_kinds.len() == mesh.indices.len() / 3;
+    let has_ids = mesh.face_ids.len() == mesh.indices.len() / 3;
     let mut new_indices: Vec<u32> = Vec::with_capacity(mesh.indices.len());
     let mut new_kinds: Vec<u8> = Vec::new();
+    let mut new_ids: Vec<u32> = Vec::new();
     let mut added_verts: Vec<f32> = Vec::new();
     let mut added_normals: Vec<f32> = Vec::new();
     let base_vert_count = mesh.num_vertices() as u32;
@@ -874,6 +905,11 @@ fn heal_t_junctions_pass(mesh: &mut TriangleMesh) -> bool {
             mesh.indices[t * 3 + 2],
         ];
         let kind = if has_kinds { mesh.face_kinds[t] } else { 0 };
+        let face_id = if has_ids {
+            mesh.face_ids[t]
+        } else {
+            FACE_ID_UNKNOWN
+        };
         let mut loop_idx: Vec<u32> = Vec::with_capacity(3);
         let mut inserted = false;
 
@@ -896,6 +932,9 @@ fn heal_t_junctions_pass(mesh: &mut TriangleMesh) -> bool {
             new_indices.extend_from_slice(&corners);
             if has_kinds {
                 new_kinds.push(kind);
+            }
+            if has_ids {
+                new_ids.push(face_id);
             }
             continue;
         }
@@ -930,6 +969,12 @@ fn heal_t_junctions_pass(mesh: &mut TriangleMesh) -> bool {
             if has_kinds {
                 new_kinds.push(kind);
             }
+            // The healed fan inherits the face of the triangle it replaced —
+            // a T-junction split does not create new geometry, it re-triangulates
+            // the same face.
+            if has_ids {
+                new_ids.push(face_id);
+            }
         }
     }
 
@@ -943,6 +988,9 @@ fn heal_t_junctions_pass(mesh: &mut TriangleMesh) -> bool {
     mesh.indices = new_indices;
     if has_kinds {
         mesh.face_kinds = new_kinds;
+    }
+    if has_ids {
+        mesh.face_ids = new_ids;
     }
     true
 }
@@ -1004,6 +1052,12 @@ fn weld_coincident_vertices(mesh: &mut TriangleMesh) {
     } else {
         Vec::new()
     };
+    let had_face_ids = mesh.face_ids.len() == mesh.indices.len() / 3;
+    let mut new_face_ids: Vec<u32> = if had_face_ids {
+        Vec::with_capacity(mesh.face_ids.len())
+    } else {
+        Vec::new()
+    };
     let tri_count = mesh.indices.len() / 3;
     for t in 0..tri_count {
         let a = remap[mesh.indices[3 * t] as usize];
@@ -1016,12 +1070,18 @@ fn weld_coincident_vertices(mesh: &mut TriangleMesh) {
         if had_face_kinds {
             new_face_kinds.push(mesh.face_kinds[t]);
         }
+        if had_face_ids {
+            new_face_ids.push(mesh.face_ids[t]);
+        }
     }
     mesh.vertices = new_vertices;
     mesh.normals = new_normals;
     mesh.indices = new_indices;
     if had_face_kinds {
         mesh.face_kinds = new_face_kinds;
+    }
+    if had_face_ids {
+        mesh.face_ids = new_face_ids;
     }
 
     // Invariant restated for release builds: the welded mesh carries either no
@@ -1341,6 +1401,10 @@ fn fill_tiny_boundary_loops(
             }
             if !mesh.face_kinds.is_empty() {
                 mesh.face_kinds.push(FaceKindTag::FanFill as u8);
+            }
+            // Fill triangles belong to no face: they bridge between them.
+            if !mesh.face_ids.is_empty() {
+                mesh.face_ids.push(FACE_ID_UNKNOWN);
             }
         }
     }
@@ -5837,7 +5901,9 @@ pub fn tessellate(brep: &BRepSolid, segments: u32) -> TriangleMesh {
 
     let mut mesh = TriangleMesh::new();
 
-    for &face_id in &shell.faces {
+    for (face_ordinal, &face_id) in shell.faces.iter().enumerate() {
+        let face_ordinal = face_ordinal as u32;
+        let pre_face_tris = mesh.indices.len() / 3;
         let face = &brep.topology.faces[face_id];
         let surface = &brep.geometry.surfaces[face.surface_index];
         let reversed = face.orientation == Orientation::Reversed;
@@ -5909,6 +5975,14 @@ pub fn tessellate(brep: &BRepSolid, segments: u32) -> TriangleMesh {
                 mesh.merge(&face_mesh);
             }
         }
+
+        // Which face each triangle came from — the same tagging
+        // `tessellate_brep` does, so both entry points produce pickable meshes.
+        let post_face_tris = mesh.indices.len() / 3;
+        while mesh.face_ids.len() < post_face_tris {
+            mesh.face_ids.push(FACE_ID_UNKNOWN);
+        }
+        mesh.face_ids[pre_face_tris..post_face_tris].fill(face_ordinal);
     }
 
     mesh
@@ -5932,7 +6006,8 @@ pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
     let mut sphere_vert_keys: std::collections::HashSet<[i64; 3]> =
         std::collections::HashSet::new();
 
-    for &face_id in &shell.faces {
+    for (face_ordinal, &face_id) in shell.faces.iter().enumerate() {
+        let face_ordinal = face_ordinal as u32;
         let face = &brep.topology.faces[face_id];
         let surface = &brep.geometry.surfaces[face.surface_index];
         let reversed = face.orientation == Orientation::Reversed;
@@ -6040,6 +6115,12 @@ pub fn tessellate_brep(brep: &BRepSolid, segments: u32) -> TriangleMesh {
             mesh.face_kinds.push(FaceKindTag::Unknown as u8);
         }
         mesh.face_kinds[pre_face_tris..post_face_tris].fill(face_kind_tag);
+        // …and with WHICH face, by shell ordinal. Same overwrite-not-extend
+        // reasoning as the kind tag above.
+        while mesh.face_ids.len() < post_face_tris {
+            mesh.face_ids.push(FACE_ID_UNKNOWN);
+        }
+        mesh.face_ids[pre_face_tris..post_face_tris].fill(face_ordinal);
     }
 
     weld_coincident_vertices(&mut mesh);
@@ -6076,6 +6157,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         // A second mesh with vertices but NO normals (the bug trigger). Placed
         // at z=1 so weld won't collapse it into `a`.
@@ -6084,6 +6166,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         a.merge(&b);
@@ -6164,6 +6247,7 @@ mod tests {
             indices: vec![0, 1, 2, 3, 4, 5],
             normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0], // 3 of 6
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         weld_coincident_vertices(&mut mesh);
@@ -6180,6 +6264,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         let mut acc = TriangleMesh::new();
         acc.merge(&face);
@@ -6750,6 +6835,56 @@ mod tests {
                 err * 100.0
             );
             assert!(vol > 0.0, "torus volume must be positive, got {vol:.3}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod face_id_tests {
+    use super::*;
+    use vcad_kernel_primitives::{make_cube, make_cylinder};
+
+    /// Every triangle knows which face made it, and a cube's six planes are
+    /// six distinct ids covering every triangle.
+    #[test]
+    fn cube_triangles_carry_six_face_ids() {
+        let mesh = tessellate_brep(&make_cube(10.0, 10.0, 10.0), 16);
+        let tris = mesh.indices.len() / 3;
+        assert_eq!(mesh.face_ids.len(), tris, "one id per triangle");
+        assert!(
+            !mesh.face_ids.contains(&FACE_ID_UNKNOWN),
+            "a cube has no bridging fill, so nothing should be untagged"
+        );
+        let unique: std::collections::HashSet<u32> = mesh.face_ids.iter().copied().collect();
+        assert_eq!(unique.len(), 6, "six planes, got {unique:?}");
+    }
+
+    /// The ids survive the weld/heal passes that rewrite the triangle list,
+    /// and stay in lockstep with `face_kinds` — the failure mode this guards
+    /// is an id array that silently drifts one triangle out of step and points
+    /// hover at the neighbouring face.
+    #[test]
+    fn cylinder_face_ids_stay_in_lockstep() {
+        let mesh = tessellate_brep(&make_cylinder(5.0, 20.0, 32), 32);
+        let tris = mesh.indices.len() / 3;
+        assert_eq!(mesh.face_ids.len(), tris);
+        assert_eq!(mesh.face_kinds.len(), tris);
+        // Cylinder: two planar caps + one lateral surface.
+        let unique: std::collections::HashSet<u32> = mesh
+            .face_ids
+            .iter()
+            .copied()
+            .filter(|&f| f != FACE_ID_UNKNOWN)
+            .collect();
+        assert_eq!(unique.len(), 3, "two caps + side, got {unique:?}");
+        // Every triangle of a given id shares one surface kind: an id that
+        // spans two kinds means the ordinals slipped against the tags.
+        for id in unique {
+            let kinds: std::collections::HashSet<u8> = (0..tris)
+                .filter(|&t| mesh.face_ids[t] == id)
+                .map(|t| mesh.face_kinds[t])
+                .collect();
+            assert_eq!(kinds.len(), 1, "face {id} spans kinds {kinds:?}");
         }
     }
 }

--- a/crates/vcad-kernel-wasm/src/lib.rs
+++ b/crates/vcad-kernel-wasm/src/lib.rs
@@ -2194,6 +2194,7 @@ impl Solid {
                 indices: all_indices,
                 normals: all_normals,
                 face_kinds: Vec::new(),
+                face_ids: Vec::new(),
             };
             Some(vcad_kernel::Solid::from_mesh(merged_mesh))
         } else {
@@ -2485,6 +2486,7 @@ pub fn section_mesh_wasm(
         indices: mesh_data.indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
 
     // Parse plane
@@ -2527,6 +2529,7 @@ pub fn project_mesh_wasm(mesh_js: JsValue, view_direction: &str) -> JsValue {
         indices: mesh_data.indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
 
     let view_dir = match view_direction.to_lowercase().as_str() {
@@ -2752,6 +2755,7 @@ pub fn offset_section_mesh_wasm(
         indices: mesh_data.indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
 
     let plane: OffsetSectionPlane = match serde_json::from_str(plane_json) {
@@ -5388,6 +5392,7 @@ mod slicer_wasm {
             indices: indices.to_vec(),
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         let slice_settings: SliceSettings = settings.clone().into();
@@ -5416,6 +5421,7 @@ mod slicer_wasm {
             indices: indices.to_vec(),
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
 
         let slice_settings: SliceSettings = settings.clone().into();
@@ -7598,6 +7604,7 @@ pub fn render_bake_mesh_wasm(input_json: &str) -> Result<String, JsError> {
         indices: input.indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     };
     let opts = vcad_kernel_tessellate::RenderBakeOptions {
         crease_angle_rad: input

--- a/crates/vcad-kernel/src/lib.rs
+++ b/crates/vcad-kernel/src/lib.rs
@@ -2661,6 +2661,7 @@ mod tests {
             indices: vec![0, 1, 2],
             normals: vec![0.0; 9],
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         };
         let com = compute_center_of_mass(&mesh);
         let (min, max) = compute_bounding_box(&mesh);

--- a/crates/vcad-render/src/lib.rs
+++ b/crates/vcad-render/src/lib.rs
@@ -847,6 +847,7 @@ fn evaluate_vcad_document(raw_vcad: &str) -> Result<EvaluatedDocument, String> {
                         indices: p.mesh.indices.clone(),
                         normals: p.mesh.normals.clone().unwrap_or_default(),
                         face_kinds: p.mesh.face_kinds.clone().unwrap_or_default(),
+                        face_ids: p.mesh.face_ids.clone().unwrap_or_default(),
                     })
                 })
             });
@@ -935,6 +936,7 @@ fn evaluate_assembly_instances(
                                 indices: pd.mesh.indices.clone(),
                                 normals: pd.mesh.normals.clone().unwrap_or_default(),
                                 face_kinds: pd.mesh.face_kinds.clone().unwrap_or_default(),
+                                face_ids: pd.mesh.face_ids.clone().unwrap_or_default(),
                             })
                         })
                 })

--- a/crates/vcad-render/src/photoreal_gpu.rs
+++ b/crates/vcad-render/src/photoreal_gpu.rs
@@ -201,6 +201,7 @@ fn ground_mesh(center: Point3, z: f64, half: f64) -> TriangleMesh {
         indices: vec![0, 1, 2, 0, 2, 3],
         normals: vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/crates/vcad-slicer/src/lib.rs
+++ b/crates/vcad-slicer/src/lib.rs
@@ -371,6 +371,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-slicer/src/slice.rs
+++ b/crates/vcad-slicer/src/slice.rs
@@ -358,6 +358,7 @@ mod tests {
             indices,
             normals: Vec::new(),
             face_kinds: Vec::new(),
+            face_ids: Vec::new(),
         }
     }
 

--- a/crates/vcad-slicer/tests/profile_cube.rs
+++ b/crates/vcad-slicer/tests/profile_cube.rs
@@ -25,6 +25,7 @@ fn cube_mesh(size: f32) -> TriangleMesh {
         indices,
         normals: Vec::new(),
         face_kinds: Vec::new(),
+        face_ids: Vec::new(),
     }
 }
 

--- a/examples/robot-arm-2dof.vcad
+++ b/examples/robot-arm-2dof.vcad
@@ -6,7 +6,11 @@
       "name": "Base Block",
       "op": {
         "type": "Cube",
-        "size": { "x": 100.0, "y": 100.0, "z": 50.0 }
+        "size": {
+          "x": 100.0,
+          "y": 100.0,
+          "z": 50.0
+        }
       }
     },
     "2": {
@@ -14,7 +18,11 @@
       "name": "Link 1",
       "op": {
         "type": "Cube",
-        "size": { "x": 30.0, "y": 30.0, "z": 150.0 }
+        "size": {
+          "x": 30.0,
+          "y": 30.0,
+          "z": 150.0
+        }
       }
     },
     "3": {
@@ -22,7 +30,11 @@
       "name": "Link 2",
       "op": {
         "type": "Cube",
-        "size": { "x": 25.0, "y": 25.0, "z": 120.0 }
+        "size": {
+          "x": 25.0,
+          "y": 25.0,
+          "z": 120.0
+        }
       }
     },
     "4": {
@@ -38,7 +50,11 @@
   "materials": {
     "steel": {
       "name": "Steel",
-      "color": [0.5, 0.5, 0.55],
+      "color": [
+        0.5,
+        0.5,
+        0.55
+      ],
       "metallic": 1.0,
       "roughness": 0.3,
       "density": 7850.0,
@@ -46,7 +62,11 @@
     },
     "aluminum": {
       "name": "Aluminum",
-      "color": [0.91, 0.92, 0.93],
+      "color": [
+        0.91,
+        0.92,
+        0.93
+      ],
       "metallic": 1.0,
       "roughness": 0.4,
       "density": 2700.0,
@@ -54,7 +74,11 @@
     },
     "plastic": {
       "name": "Plastic",
-      "color": [0.2, 0.6, 0.9],
+      "color": [
+        0.2,
+        0.6,
+        0.9
+      ],
       "metallic": 0.0,
       "roughness": 0.6,
       "density": 1200.0,
@@ -67,125 +91,223 @@
     "link2": "aluminum",
     "end_effector": "plastic"
   },
-  "part_defs": {
-    "base": {
-      "id": "base",
-      "name": "Base",
-      "root": 1,
-      "default_material": "steel"
-    },
-    "link1": {
-      "id": "link1",
-      "name": "Link 1",
-      "root": 2,
-      "default_material": "aluminum"
-    },
-    "link2": {
-      "id": "link2",
-      "name": "Link 2",
-      "root": 3,
-      "default_material": "aluminum"
-    },
-    "end_effector": {
-      "id": "end_effector",
-      "name": "End Effector",
-      "root": 4,
-      "default_material": "plastic"
-    }
-  },
   "instances": [
     {
       "id": "base_inst",
-      "part_def_id": "base",
       "name": "Base",
       "transform": {
-        "translation": { "x": 0.0, "y": 0.0, "z": 0.0 },
-        "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 },
-        "scale": { "x": 1.0, "y": 1.0, "z": 1.0 }
+        "translation": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "rotation": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "scale": {
+          "x": 1.0,
+          "y": 1.0,
+          "z": 1.0
+        }
       },
-      "material": null
+      "material": null,
+      "partDefId": "base"
     },
     {
       "id": "link1_inst",
-      "part_def_id": "link1",
       "name": "Link 1",
       "transform": {
-        "translation": { "x": 35.0, "y": 50.0, "z": 50.0 },
-        "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 },
-        "scale": { "x": 1.0, "y": 1.0, "z": 1.0 }
+        "translation": {
+          "x": 35.0,
+          "y": 50.0,
+          "z": 50.0
+        },
+        "rotation": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "scale": {
+          "x": 1.0,
+          "y": 1.0,
+          "z": 1.0
+        }
       },
-      "material": null
+      "material": null,
+      "partDefId": "link1"
     },
     {
       "id": "link2_inst",
-      "part_def_id": "link2",
       "name": "Link 2",
       "transform": {
-        "translation": { "x": 37.5, "y": 50.0, "z": 200.0 },
-        "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 },
-        "scale": { "x": 1.0, "y": 1.0, "z": 1.0 }
+        "translation": {
+          "x": 37.5,
+          "y": 50.0,
+          "z": 200.0
+        },
+        "rotation": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "scale": {
+          "x": 1.0,
+          "y": 1.0,
+          "z": 1.0
+        }
       },
-      "material": null
+      "material": null,
+      "partDefId": "link2"
     },
     {
       "id": "ee_inst",
-      "part_def_id": "end_effector",
       "name": "End Effector",
       "transform": {
-        "translation": { "x": 50.0, "y": 50.0, "z": 320.0 },
-        "rotation": { "x": 0.0, "y": 0.0, "z": 0.0 },
-        "scale": { "x": 1.0, "y": 1.0, "z": 1.0 }
+        "translation": {
+          "x": 50.0,
+          "y": 50.0,
+          "z": 320.0
+        },
+        "rotation": {
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "scale": {
+          "x": 1.0,
+          "y": 1.0,
+          "z": 1.0
+        }
       },
-      "material": null
+      "material": null,
+      "partDefId": "end_effector"
     }
   ],
   "joints": [
     {
       "id": "shoulder",
       "name": "Shoulder Joint",
-      "parent_instance_id": "base_inst",
-      "child_instance_id": "link1_inst",
-      "parent_anchor": { "x": 50.0, "y": 50.0, "z": 50.0 },
-      "child_anchor": { "x": 15.0, "y": 15.0, "z": 0.0 },
       "kind": {
         "type": "Revolute",
-        "axis": { "x": 0.0, "y": 1.0, "z": 0.0 },
-        "limits": [-90.0, 90.0]
+        "axis": {
+          "x": 0.0,
+          "y": 1.0,
+          "z": 0.0
+        },
+        "limits": [
+          -90.0,
+          90.0
+        ]
       },
-      "state": 0.0
+      "state": 0.0,
+      "parentInstanceId": "base_inst",
+      "childInstanceId": "link1_inst",
+      "parentAnchor": {
+        "x": 50.0,
+        "y": 50.0,
+        "z": 50.0
+      },
+      "childAnchor": {
+        "x": 15.0,
+        "y": 15.0,
+        "z": 0.0
+      }
     },
     {
       "id": "elbow",
       "name": "Elbow Joint",
-      "parent_instance_id": "link1_inst",
-      "child_instance_id": "link2_inst",
-      "parent_anchor": { "x": 15.0, "y": 15.0, "z": 150.0 },
-      "child_anchor": { "x": 12.5, "y": 12.5, "z": 0.0 },
       "kind": {
         "type": "Revolute",
-        "axis": { "x": 0.0, "y": 1.0, "z": 0.0 },
-        "limits": [-135.0, 135.0]
+        "axis": {
+          "x": 0.0,
+          "y": 1.0,
+          "z": 0.0
+        },
+        "limits": [
+          -135.0,
+          135.0
+        ]
       },
-      "state": 0.0
+      "state": 0.0,
+      "parentInstanceId": "link1_inst",
+      "childInstanceId": "link2_inst",
+      "parentAnchor": {
+        "x": 15.0,
+        "y": 15.0,
+        "z": 150.0
+      },
+      "childAnchor": {
+        "x": 12.5,
+        "y": 12.5,
+        "z": 0.0
+      }
     },
     {
       "id": "wrist",
       "name": "Wrist Joint",
-      "parent_instance_id": "link2_inst",
-      "child_instance_id": "ee_inst",
-      "parent_anchor": { "x": 12.5, "y": 12.5, "z": 120.0 },
-      "child_anchor": { "x": 0.0, "y": 0.0, "z": 0.0 },
       "kind": {
         "type": "Fixed"
       },
-      "state": 0.0
+      "state": 0.0,
+      "parentInstanceId": "link2_inst",
+      "childInstanceId": "ee_inst",
+      "parentAnchor": {
+        "x": 12.5,
+        "y": 12.5,
+        "z": 120.0
+      },
+      "childAnchor": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 0.0
+      }
     }
   ],
-  "ground_instance_id": "base_inst",
   "roots": [
-    { "root": 1, "material": "steel" },
-    { "root": 2, "material": "aluminum" },
-    { "root": 3, "material": "aluminum" },
-    { "root": 4, "material": "plastic" }
-  ]
+    {
+      "root": 1,
+      "material": "steel"
+    },
+    {
+      "root": 2,
+      "material": "aluminum"
+    },
+    {
+      "root": 3,
+      "material": "aluminum"
+    },
+    {
+      "root": 4,
+      "material": "plastic"
+    }
+  ],
+  "partDefs": {
+    "base": {
+      "id": "base",
+      "name": "Base",
+      "root": 1,
+      "defaultMaterial": "steel"
+    },
+    "link1": {
+      "id": "link1",
+      "name": "Link 1",
+      "root": 2,
+      "defaultMaterial": "aluminum"
+    },
+    "link2": {
+      "id": "link2",
+      "name": "Link 2",
+      "root": 3,
+      "defaultMaterial": "aluminum"
+    },
+    "end_effector": {
+      "id": "end_effector",
+      "name": "End Effector",
+      "root": 4,
+      "defaultMaterial": "plastic"
+    }
+  },
+  "groundInstanceId": "base_inst"
 }


### PR DESCRIPTION
The Mac app now launches straight into release-to-desktop — parts floating over the desktop in a borderless transparent overlay — and has no other mode to reach. That meant everything the studio window carried had to find a new home, and the interaction layer had to work over the desktop rather than inside a window.

## Mode

The `WindowGroup`'s window hides itself the moment AppKit attaches it and hands the model to the overlay controller. Previously a `Task.sleep(for: .seconds(1))` raced the window into existence, so the app showed the studio window for a second before switching — the flash that started this. The in-window transparency path, the return pill, the mode toggle and the `VCAD_RELEASE` opt-out are gone.

`ViewportView` is deliberately left in place, unpresented: it is still the home of the shared RealityKit scene code (environments, materials, gizmo and mesh construction) the released view builds on. Untangling that is its own change.

## Chrome

- **Menu bar** — New/Open/Recent/Examples, Save/Save As/Revert, Export STL/USDZ, Undo/Redo, and a View menu for panels, zebra and camera presets. These lived in the title bar's document menu and were simply unreachable once release mode hid it. The model moved to app scope so the commands and the overlay edit the same document.
- **Object Inspector** — branches on the document instead of always showing sandbox rows; live scrub editors for the selected feature's parameters (Cube W/D/H, Fillet radius, pattern count, …), the swatch material menu scoped to the node's part, solve time and the pick readout. Docked to a right rail rather than chasing the selected part around the viewport. The editors are shared with the studio inspector as `FeatureParamEditors`, so a newly editable op appears in both at once.
- **Components palette** — rebuilt in the Borland C++ Builder idiom, HIG-styled: speedbar separated from the palette proper, icon-only tiles on a grid that doesn't move between tabs, and a hint line that explains whatever the pointer is over (orange when a tool is blocked). Create tiles now **arm** — the next click in the scene places the primitive where you pointed, on the surface under the cursor or the ground plane.
- **Feature tree** is a closable tool window like every other pane; the gripper gets the full Receipt in the inspector's slot; the document name and status strip return as a pill.

## Picking and mouse

- **Hover** — parts and assembly instances light under the pointer, the cursor states what a click will do, and the surface readout reaches the inspector. It rides the raycast the pass-through test was already running on every mouse-moved, so it costs no second raycast.
- **Assembly instances were entirely inert.** The renderer draws `inst0…instN` for an assembly while every hit test matched `part…` only, so no link of a robot could be hovered or clicked. They now hover, select, drive the tree, and expose their part def's parameters — editing the definition moves every instance of it.
- **Tree sync both ways** — hovering geometry lights its row and hovering a row lights the geometry it drew (all of it: one row, four elbows on a quadruped); selecting scrolls the row into view.
- Scroll to dolly, double-click to frame, right-click menu, occlusion cycling on repeated clicks in the same spot, ⌘-drag marquee, Esc to deselect (an empty-space click passes through to the desktop, so it cannot deselect).
- **Picking was mirrored** about the horizontal midline: SwiftUI hands out top-left points, `ARView.hitTest` wants the view's bottom-left space, and the click and hover paths disagreed about which needed the flip. Invisible on a single centred body — you hit the same thing either way — and obvious on a tall robot.
- The gizmo was never rescaled in this view, so its handles were sized for whatever camera distance the scene happened to be built at.

## Performance

- **Selecting no longer rebuilds the scene.** `highlightedParts` was part of the geometry key, so every click re-evaluated the document, re-tessellated every part, rebuilt every entity and regenerated every collider — to change one material's emissive value. Instrumented at **73–83 ms per click** on a 3,884-triangle plate, and it scales with the model. Selection and visibility are appearance, not geometry; they repaint in place now.
- **Every single click was waiting out the double-click interval.** A separate `SpatialTapGesture(count: 2)` forced SwiftUI to disambiguate, so ~0.2 ms of selection work sat behind ~half a second of nothing. Framing reads `clickCount` off the event being handled instead. Worth noting the timing log is what found this — it proved the handler was innocent and pointed at the gesture layer.
- Timing is available behind `VCAD_PERF=1` (writes `/tmp/vcad_perf.log`); it is off and free otherwise.

## Dock icon

The tile follows the viewport: it snapshots the ARView and frames the model by its **alpha silhouette** rather than cropping the centre of the frame, so zoom and pan cannot change the picture — the icon is a portrait of the document, not a screenshot. Capped at 2 Hz and gated on a scene key, so a still scene stops feeding the Dock identical frames.

## Notes for review

- The FFI change (first commit) touches shared kernel surface: `vcad_scene_from_json` / `_json_in` now clear and record `vcad_last_error` on UTF-8, parse and evaluate failures. The ABI is unchanged — callers that ignore errors keep working — but the diagnosis was previously dropped on the floor, which is how a schema-stale example presented as a renderer bug.
- `examples/robot-arm-2dof.vcad` is reformatted wholesale by the key rename; the substantive change is snake_case → camelCase on the assembly keys.
- The Swift files carried uncommitted work from before this session, so those commits are not a clean per-change history.
- Verified by driving the running app: hover readout, click selection on parts and instances, the arm loading at 996 triangles, and the parse error surfacing in the pill. The Dock icon's framing has been reasoned through and its alpha scan verified with a standalone harness, but I have not looked at the rendered tile.
- Known open item: one unexplained app exit during testing, with no crash report and no unified-log entry. Not reproduced; idle memory is flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added since the first review pass

### Per-triangle face ids (`d817ead3`)

Groundwork for sub-element selection — picking a face is the prerequisite for sketching on one, filleting an edge, or measuring between two.

The tessellator already tagged each triangle with its surface *kind* for the face-kind debugger, which says a triangle came from a plane but not **which** plane. `TriangleMesh.face_ids` now carries the face's ordinal within its shell alongside `face_kinds`, threaded through every pass that rewrites the triangle list — merge, T-junction heal, weld (which drops degenerates), and fan fill, whose bridging triangles belong to no face and are tagged unknown rather than guessed. Both tessellation entry points tag, so either produces a pickable mesh.

Carried to the app through `EvaluatedMesh` (the render bake unindexes but never reorders triangles, so per-triangle tags stay aligned) and a new `vcad_scene_part_face_ids`, which hands back the array **only** when it matches the mesh being drawn — a partial or stale array would point hover at the wrong face — and null when a part has no B-rep, so callers treat face picking as an optional capability. The mesh disk-cache format is bumped to 2, since a v1 record has no id block and reading its trailing bytes as one would hand the viewport garbage faces.

These ids are a handle for a session's hover and selection, **not** a durable reference: any edit that changes the B-rep renumbers them. Persisting a face across edits is the topological-naming problem and wants its own scheme.

Tests: a cube resolves to six distinct ids covering every triangle; a cylinder's caps and side stay in lockstep with `face_kinds` (the failure mode being an array that drifts one triangle and highlights the neighbour); the FFI hands back one id per triangle of the mesh it drew.

The Swift half — ray→triangle→face, the face highlight, the inspector row — is not in this PR.

### A document is an app instance (`a4fffdae`)

⌘N opens another copy of the app, so each document gets its own Dock tile (already rendering that document's viewport) and its own ⌘-Tab entry.

On macOS the Dock tile and ⌘-Tab entry belong to the *application*, not its windows — Pages with six documents open still shows one of each — so this cannot be a second window. Release-to-desktop has no window of its own anyway, so "another window" was already a fiction; another instance gives each document its own tile, menu bar, and crash domain.

⇧⌘N keeps the reset-this-document behaviour. Open/Recents/Examples reuse the current instance only when it holds an untouched sandbox, the way a Mac app reuses its empty Untitled window. The document arrives as a launch argument rather than `VCAD_OPEN`, since the environment is inherited by anything the instance spawns and a stale value would silently reopen the wrong file. Recents re-read the stored list before appending, or each instance would write back the list as it looked when *it* launched and drop what the others opened.

Verified with three instances live: separate processes, each rendering its own document, two overlays compositing over the desktop at once with the transparent one passing the mouse through to the one behind.

**Known gap:** instances anchor their chrome to the same screen corners, so two documents' inspectors stack on top of each other. Cascading the chrome per instance is the fix and is not in this PR.
