### PR TITLE
Variant parameter tables: overlays, no-scale flags, provenance (Closes #845)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7912,6 +7912,7 @@ name = "vcad-loon"
 version = "0.9.4"
 dependencies = [
  "loon-lang",
+ "serde",
  "serde_json",
  "vcad-ir",
  "vcad-parts",

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -234,6 +234,20 @@ enum Commands {
         file: PathBuf,
     },
 
+    /// Resolve and compare variant parameter tables
+    ///
+    /// A design family — a full-size part and its scaled print mules — is one
+    /// base table plus per-variant overlays, declared in a `.params.loon`
+    /// file with `[deftable ...]` and `[defvariant ... :from ... :scale ...]`.
+    /// `resolve` flattens one variant to concrete values, each carrying the
+    /// source it came from; `diff` shows what two variants disagree on and
+    /// whether the disagreement is an own override, an inherited value, or
+    /// the envelope scale.
+    Params {
+        #[command(subcommand)]
+        command: ParamsCommands,
+    },
+
     /// Take a routed .pcb.json to a complete fab package plus a DRC-delta receipt
     ///
     /// Runs the whole fab-prep pipeline in one command: (optionally) calibrate
@@ -379,6 +393,48 @@ enum Commands {
     Logout,
 }
 
+#[derive(Subcommand)]
+enum ParamsCommands {
+    /// Flatten one variant to a resolved table (JSON on stdout)
+    Resolve {
+        /// Variant (or base table) name
+        variant: String,
+        /// Parameter-table file (default: `params.loon` in the working
+        /// directory, or $VCAD_PARAMS)
+        #[arg(short, long)]
+        file: Option<PathBuf>,
+        /// Print an aligned table instead of JSON
+        #[arg(long)]
+        table: bool,
+    },
+
+    /// Show what differs between two variants, and why
+    Diff {
+        /// Left variant
+        a: String,
+        /// Right variant
+        b: String,
+        /// Parameter-table file (default: `params.loon` in the working
+        /// directory, or $VCAD_PARAMS)
+        #[arg(short, long)]
+        file: Option<PathBuf>,
+        /// Emit JSON instead of the human-readable rendering
+        #[arg(long)]
+        json: bool,
+        /// Exit 1 when the variants differ (for CI gates)
+        #[arg(long)]
+        exit_code: bool,
+    },
+
+    /// List the tables and variants a parameter-table file declares
+    List {
+        /// Parameter-table file (default: `params.loon` in the working
+        /// directory, or $VCAD_PARAMS)
+        #[arg(short, long)]
+        file: Option<PathBuf>,
+    },
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
 enum BooleanOp {
     Union,
@@ -521,6 +577,9 @@ fn main() -> Result<()> {
         }
         Some(Commands::Info { file }) => {
             show_info(&file)?;
+        }
+        Some(Commands::Params { command }) => {
+            run_params(command)?;
         }
         Some(Commands::FabPrep {
             input,
@@ -1385,6 +1444,120 @@ fn load_vcad_document_raw(file: &PathBuf) -> Result<vcad_ir::Document> {
                 .map_err(|e| anyhow::anyhow!("unrecognized .vcad file format (VCode parse: {e})"))
         }
     }
+}
+
+/// Locate the parameter-table file: the `--file` argument, else `$VCAD_PARAMS`,
+/// else `params.loon` in the working directory.
+fn params_file(explicit: Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        return Ok(p);
+    }
+    if let Ok(p) = std::env::var("VCAD_PARAMS") {
+        return Ok(PathBuf::from(p));
+    }
+    let default = PathBuf::from("params.loon");
+    if default.exists() {
+        return Ok(default);
+    }
+    anyhow::bail!(
+        "no parameter-table file — pass --file <path>, set VCAD_PARAMS, or put a \
+         params.loon in the working directory"
+    )
+}
+
+fn load_variant_set(file: Option<PathBuf>) -> Result<(PathBuf, vcad_loon::variants::VariantSet)> {
+    let path = params_file(file)?;
+    let source =
+        std::fs::read_to_string(&path).map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+    let set = vcad_loon::variants::parse(&source)
+        .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+    Ok((path, set))
+}
+
+fn run_params(command: ParamsCommands) -> Result<()> {
+    match command {
+        ParamsCommands::Resolve {
+            variant,
+            file,
+            table,
+        } => {
+            let (path, set) = load_variant_set(file)?;
+            let resolved = set
+                .resolve(&variant)
+                .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+            if table {
+                println!(
+                    "{} ({}), effective scale {}",
+                    resolved.name,
+                    resolved.chain.join(" → "),
+                    resolved.effective_scale
+                );
+                let w = resolved
+                    .params
+                    .iter()
+                    .map(|p| p.name.len())
+                    .max()
+                    .unwrap_or(0);
+                for p in &resolved.params {
+                    let value = format!("{}{}", p.value, p.unit.as_deref().unwrap_or(""));
+                    println!(
+                        "  {:<w$}  {:>10}  {}",
+                        p.name,
+                        value,
+                        p.source.explain(),
+                        w = w
+                    );
+                }
+            } else {
+                println!("{}", serde_json::to_string_pretty(&resolved)?);
+            }
+        }
+        ParamsCommands::Diff {
+            a,
+            b,
+            file,
+            json,
+            exit_code,
+        } => {
+            let (path, set) = load_variant_set(file)?;
+            let diff = set
+                .diff(&a, &b)
+                .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&diff)?);
+            } else {
+                print!("{}", diff.render());
+            }
+            if exit_code && !diff.entries.is_empty() {
+                std::process::exit(1);
+            }
+        }
+        ParamsCommands::List { file } => {
+            let (path, set) = load_variant_set(file)?;
+            println!("{}", path.display());
+            let mut tables: Vec<_> = set.tables.values().collect();
+            tables.sort_by(|a, b| a.name.cmp(&b.name));
+            for t in tables {
+                println!("  table {} ({} parameters)", t.name, t.order.len());
+            }
+            let mut variants: Vec<_> = set.variants.values().collect();
+            variants.sort_by(|a, b| a.name.cmp(&b.name));
+            for v in variants {
+                let scale = match v.scale {
+                    Some(s) => format!(", scale {s}"),
+                    None => String::new(),
+                };
+                println!(
+                    "  variant {} (from {}{}, {} overlays)",
+                    v.name,
+                    v.parent,
+                    scale,
+                    v.overlays.len()
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 fn show_info(file: &PathBuf) -> Result<()> {

--- a/crates/vcad-loon/Cargo.toml
+++ b/crates/vcad-loon/Cargo.toml
@@ -8,4 +8,5 @@ publish = false
 loon-lang = { path = "../../../loon/crates/loon-lang" }
 vcad-ir = { path = "../vcad-ir" }
 vcad-parts = { path = "../vcad-parts" }
+serde.workspace = true
 serde_json.workspace = true

--- a/crates/vcad-loon/src/lib.rs
+++ b/crates/vcad-loon/src/lib.rs
@@ -17,6 +17,7 @@ pub mod modules;
 pub mod params;
 pub mod recover;
 mod rootnames;
+pub mod variants;
 pub use convert::{value_to_document, value_to_document_in};
 pub use modules::{lib_dirs, LibPathProvider, LIB_PATH_VAR};
 

--- a/crates/vcad-loon/src/variants.rs
+++ b/crates/vcad-loon/src/variants.rs
@@ -1,0 +1,874 @@
+//! Parameter tables with variant overlays — design families in one file.
+//!
+//! A design family (rana-100 → 100b → 100c → 60c) is one design at several
+//! sizes, not four designs. Written as four generator sets, every fix has to
+//! be re-derived by hand for each variant, and the split between what scales
+//! (radii, heights) and what must not (gear module, M3 hardware, minimum
+//! wall) lives in prose. This module makes that split a property of the
+//! parameter itself.
+//!
+//! The forms extend the declaration vocabulary [`crate::params`] already
+//! speaks — `defparam` with trailing keyword options — with a table to hold
+//! them and a variant to overlay them:
+//!
+//! ```text
+//! [deftable rana
+//!   [defparam envelope_d      100.0 :unit "mm"]
+//!   [defparam gear_module       0.5 :unit "mm" :scale_with_envelope false
+//!                                   :description "m0.5 is the PLA floor"]
+//!   [defparam pocket_clearance  0.2 :unit "mm"]
+//!   [defparam bore_r "envelope_d / 8"]]
+//!
+//! [defvariant rana_60c :from rana :scale 0.6
+//!   [override pocket_clearance 0.4 :why "60c mule print: pocket ran tight"]]
+//! ```
+//!
+//! Three rules give the overlay its meaning:
+//!
+//! 1. **Scale applies to literals, not formulas.** A derived parameter
+//!    recomputes from its (already scaled) inputs, so it is never scaled
+//!    twice.
+//! 2. **`:scale_with_envelope false` holds a value through a scale.** m0.5
+//!    stays m0.5 at 0.6×. Asking for that parameter to be scaled *directly*
+//!    — `[scale gear_module 0.6]` — is an error naming the flag, not a
+//!    silent shrink.
+//! 3. **A variant's scale applies before its own overrides.** An override is
+//!    a measurement taken at the variant's own size (the mule's +0.2 mm
+//!    pocket clearance), so it lands on the scaled table verbatim.
+//!
+//! Every resolved value carries its [`Source`]: which table or variant it
+//! came from and why it has the value it has. That is what
+//! `vcad params resolve` prints and what `vcad params diff` compares.
+
+use std::collections::HashMap;
+
+use loon_lang::ast::{Expr as LExpr, ExprKind};
+use serde::Serialize;
+use vcad_ir::{Expr as IrExpr, Parameter};
+
+/// Statement heads this module owns, for programs that mix tables with
+/// geometry.
+pub const TABLE_HEADS: &[&str] = &["deftable", "defvariant"];
+
+// ============================================================================
+// Declarations
+// ============================================================================
+
+/// One row of a base parameter table.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TableParam {
+    /// Literal value or formula over other parameters in the table.
+    pub value: IrExpr,
+    /// Whether a variant's envelope scale multiplies this value. `false` for
+    /// the classes that are set by something other than the envelope: gear
+    /// module (print process), COTS hardware, minimum wall.
+    pub scale_with_envelope: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl TableParam {
+    fn literal(&self) -> Option<f64> {
+        self.value.as_number()
+    }
+}
+
+/// A named base table: an ordered set of parameters.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct Table {
+    pub name: String,
+    pub params: HashMap<String, TableParam>,
+    /// Declaration order, so output is stable and readable.
+    pub order: Vec<String>,
+}
+
+/// One overlay entry in a variant.
+#[derive(Debug, Clone, Serialize)]
+pub enum Overlay {
+    /// `[override name value :why "..."]` — replace the value outright.
+    Override {
+        name: String,
+        value: IrExpr,
+        why: Option<String>,
+    },
+    /// `[scale name factor]` — scale one parameter explicitly. Rejected for
+    /// a parameter flagged `:scale_with_envelope false`.
+    Scale {
+        name: String,
+        factor: f64,
+        why: Option<String>,
+    },
+}
+
+impl Overlay {
+    fn name(&self) -> &str {
+        match self {
+            Overlay::Override { name, .. } | Overlay::Scale { name, .. } => name,
+        }
+    }
+}
+
+/// A variant: a parent (table or another variant), an optional envelope
+/// scale, and overlays.
+#[derive(Debug, Clone, Serialize)]
+pub struct Variant {
+    pub name: String,
+    pub parent: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scale: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub overlays: Vec<Overlay>,
+}
+
+/// Everything one parameter-table document declares.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct VariantSet {
+    pub tables: HashMap<String, Table>,
+    pub variants: HashMap<String, Variant>,
+}
+
+// ============================================================================
+// Provenance
+// ============================================================================
+
+/// Where a resolved value came from, and why it has the value it has.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum Source {
+    /// A literal straight out of the base table, untouched.
+    Base { table: String },
+    /// A literal the base table set that a scale deliberately left alone
+    /// because it is flagged `scale_with_envelope: false`.
+    Held {
+        table: String,
+        /// The scale factor that did *not* apply.
+        skipped_factor: f64,
+        flag: &'static str,
+    },
+    /// A value a variant set outright.
+    Override {
+        variant: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        why: Option<String>,
+    },
+    /// A literal a variant's scale multiplied.
+    ScaleDerived {
+        variant: String,
+        factor: f64,
+        from: f64,
+        /// True when the factor came from `[scale name f]` rather than the
+        /// variant-wide `:scale`.
+        explicit: bool,
+    },
+    /// A formula, recomputed from the resolved table.
+    Derived { formula: String },
+}
+
+impl Source {
+    /// One line explaining the value, for `params diff` and error messages.
+    pub fn explain(&self) -> String {
+        match self {
+            Source::Base { table } => format!("base table '{table}'"),
+            Source::Held {
+                table,
+                skipped_factor,
+                flag,
+            } => format!(
+                "held at the '{table}' base value — {flag}: false, so the {skipped_factor}× \
+                 envelope scale does not apply"
+            ),
+            Source::Override { variant, why } => match why {
+                Some(w) => format!("own override in '{variant}' ({w})"),
+                None => format!("own override in '{variant}'"),
+            },
+            Source::ScaleDerived {
+                variant,
+                factor,
+                from,
+                explicit,
+            } => {
+                let how = if *explicit {
+                    "explicit [scale]"
+                } else {
+                    "envelope scale"
+                };
+                format!("{how} in '{variant}': {from} × {factor}")
+            }
+            Source::Derived { formula } => format!("derived: {formula}"),
+        }
+    }
+}
+
+/// One resolved parameter.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ResolvedParam {
+    pub name: String,
+    pub value: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    pub scale_with_envelope: bool,
+    pub source: Source,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A flat resolved table for one variant.
+#[derive(Debug, Clone, Serialize)]
+pub struct Resolved {
+    /// The variant (or bare table) that was resolved.
+    pub name: String,
+    /// Inheritance chain, base table first.
+    pub chain: Vec<String>,
+    /// Product of every envelope scale in the chain.
+    pub effective_scale: f64,
+    /// Parameters in base-table declaration order.
+    pub params: Vec<ResolvedParam>,
+}
+
+impl Resolved {
+    pub fn get(&self, name: &str) -> Option<&ResolvedParam> {
+        self.params.iter().find(|p| p.name == name)
+    }
+
+    pub fn value(&self, name: &str) -> Option<f64> {
+        self.get(name).map(|p| p.value)
+    }
+}
+
+// ============================================================================
+// Diff
+// ============================================================================
+
+/// One differing parameter between two resolved variants.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiffEntry {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub a: Option<ResolvedParam>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub b: Option<ResolvedParam>,
+    /// Why they differ, in one line.
+    pub reason: String,
+}
+
+/// The difference between two variants.
+#[derive(Debug, Clone, Serialize)]
+pub struct Diff {
+    pub a: String,
+    pub b: String,
+    pub entries: Vec<DiffEntry>,
+}
+
+impl Diff {
+    /// Names of the parameters that differ.
+    pub fn names(&self) -> Vec<&str> {
+        self.entries.iter().map(|e| e.name.as_str()).collect()
+    }
+
+    /// Human-readable rendering, the CLI's default output.
+    pub fn render(&self) -> String {
+        let mut s = format!("{} → {}\n", self.a, self.b);
+        if self.entries.is_empty() {
+            s.push_str("  (no differences)\n");
+            return s;
+        }
+        for e in &self.entries {
+            let show = |p: &Option<ResolvedParam>| match p {
+                Some(p) => format!("{}", p.value),
+                None => "—".to_string(),
+            };
+            s.push_str(&format!(
+                "  {}: {} → {}\n      {}\n",
+                e.name,
+                show(&e.a),
+                show(&e.b),
+                e.reason
+            ));
+        }
+        s
+    }
+}
+
+// ============================================================================
+// Parsing
+// ============================================================================
+
+fn head_sym(e: &LExpr) -> Option<(&str, &[LExpr])> {
+    let ExprKind::List(items) = &e.kind else {
+        return None;
+    };
+    let ExprKind::Symbol(head) = &items.first()?.kind else {
+        return None;
+    };
+    Some((head.as_str(), &items[1..]))
+}
+
+fn as_number(e: &LExpr) -> Option<f64> {
+    match &e.kind {
+        ExprKind::Float(f) => Some(*f),
+        ExprKind::Int(i) => Some(*i as f64),
+        _ => None,
+    }
+}
+
+fn as_str(e: &LExpr) -> Option<&str> {
+    match &e.kind {
+        ExprKind::Str(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn as_sym(e: &LExpr) -> Option<&str> {
+    match &e.kind {
+        ExprKind::Symbol(s) => Some(s.as_str()),
+        _ => None,
+    }
+}
+
+fn as_bool(e: &LExpr) -> Option<bool> {
+    match &e.kind {
+        ExprKind::Bool(b) => Some(*b),
+        _ => None,
+    }
+}
+
+/// A name argument: `[defparam envelope_d ...]` or `[override "envelope_d" ...]`
+/// — symbol or string, since both read naturally here.
+fn as_name(e: &LExpr) -> Option<&str> {
+    as_sym(e).or_else(|| as_str(e))
+}
+
+fn as_value(e: &LExpr) -> Option<IrExpr> {
+    if let Some(n) = as_number(e) {
+        return Some(IrExpr::Number(n));
+    }
+    as_str(e).map(IrExpr::formula)
+}
+
+/// Trailing `:key value` options as an association list.
+fn keyword_opts<'a>(
+    opts: &'a [LExpr],
+    allowed: &[&str],
+) -> Result<Vec<(String, &'a LExpr)>, String> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < opts.len() {
+        let ExprKind::Keyword(k) = &opts[i].kind else {
+            return Err(format!(
+                "expected a keyword option ({}), got {}",
+                allowed
+                    .iter()
+                    .map(|a| format!(":{a}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                opts[i]
+            ));
+        };
+        if !allowed.contains(&k.as_str()) {
+            return Err(format!(
+                "unknown option :{k} — expected one of {}",
+                allowed
+                    .iter()
+                    .map(|a| format!(":{a}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+        let arg = opts
+            .get(i + 1)
+            .ok_or_else(|| format!("option :{k} has no value"))?;
+        out.push((k.clone(), arg));
+        i += 2;
+    }
+    Ok(out)
+}
+
+/// Parse a parameter-table document.
+pub fn parse(source: &str) -> Result<VariantSet, String> {
+    let exprs = loon_lang::parser::parse(source).map_err(|e| e.message.clone())?;
+    let mut set = VariantSet::default();
+    for e in &exprs {
+        let Some((head, args)) = head_sym(e) else {
+            continue;
+        };
+        match head {
+            "deftable" => {
+                let table = parse_table(args)?;
+                if set.tables.contains_key(&table.name) {
+                    return Err(format!("table '{}' declared twice", table.name));
+                }
+                set.tables.insert(table.name.clone(), table);
+            }
+            "defvariant" => {
+                let variant = parse_variant(args)?;
+                if set.variants.contains_key(&variant.name) {
+                    return Err(format!("variant '{}' declared twice", variant.name));
+                }
+                set.variants.insert(variant.name.clone(), variant);
+            }
+            _ => {}
+        }
+    }
+    if set.tables.is_empty() {
+        return Err(
+            "no [deftable ...] found — a parameter-table document needs \
+                    at least one base table"
+                .to_string(),
+        );
+    }
+    for v in set.variants.values() {
+        if !set.tables.contains_key(&v.parent) && !set.variants.contains_key(&v.parent) {
+            return Err(format!(
+                "variant '{}' inherits from '{}', which is neither a table nor a variant",
+                v.name, v.parent
+            ));
+        }
+    }
+    Ok(set)
+}
+
+fn parse_table(args: &[LExpr]) -> Result<Table, String> {
+    let name = args
+        .first()
+        .and_then(as_name)
+        .ok_or_else(|| "deftable takes a name, e.g. [deftable rana ...]".to_string())?;
+    let mut table = Table {
+        name: name.to_string(),
+        ..Default::default()
+    };
+    for row in &args[1..] {
+        let Some((head, rargs)) = head_sym(row) else {
+            return Err(format!(
+                "table '{name}' contains {row}, which is not a [defparam ...] row"
+            ));
+        };
+        if head != "defparam" {
+            return Err(format!(
+                "table '{name}' contains a [{head} ...] form — a table holds \
+                 [defparam ...] rows only"
+            ));
+        }
+        let (Some(pname), Some(value)) = (
+            rargs.first().and_then(as_name),
+            rargs.get(1).and_then(as_value),
+        ) else {
+            return Err("defparam takes a name and a literal or formula string, \
+                 e.g. [defparam envelope_d 100.0]"
+                .to_string());
+        };
+        let mut p = TableParam {
+            value,
+            scale_with_envelope: true,
+            unit: None,
+            description: None,
+        };
+        for (k, arg) in keyword_opts(&rargs[2..], &["unit", "description", "scale_with_envelope"])?
+        {
+            match k.as_str() {
+                "unit" => p.unit = as_str(arg).map(str::to_string),
+                "description" => p.description = as_str(arg).map(str::to_string),
+                "scale_with_envelope" => {
+                    p.scale_with_envelope = as_bool(arg).ok_or_else(|| {
+                        format!("option :scale_with_envelope takes true or false, got {arg}")
+                    })?;
+                }
+                _ => unreachable!("keyword_opts filtered"),
+            }
+        }
+        if !p.scale_with_envelope && p.value.is_formula() {
+            return Err(format!(
+                "parameter '{pname}' is a formula and cannot be flagged \
+                 :scale_with_envelope false — a derived value follows its inputs. \
+                 Flag the inputs instead."
+            ));
+        }
+        if table.params.insert(pname.to_string(), p).is_some() {
+            return Err(format!(
+                "parameter '{pname}' declared twice in table '{name}'"
+            ));
+        }
+        table.order.push(pname.to_string());
+    }
+    Ok(table)
+}
+
+fn parse_variant(args: &[LExpr]) -> Result<Variant, String> {
+    let name = args
+        .first()
+        .and_then(as_name)
+        .ok_or_else(|| {
+            "defvariant takes a name, e.g. [defvariant rana_60c :from rana :scale 0.6 ...]"
+                .to_string()
+        })?
+        .to_string();
+
+    // Leading keyword options, then overlay rows.
+    let mut i = 1;
+    let mut parent = None;
+    let mut scale = None;
+    let mut description = None;
+    while i < args.len() {
+        let ExprKind::Keyword(k) = &args[i].kind else {
+            break;
+        };
+        let arg = args
+            .get(i + 1)
+            .ok_or_else(|| format!("option :{k} has no value"))?;
+        match k.as_str() {
+            "from" => {
+                parent = Some(
+                    as_name(arg)
+                        .ok_or_else(|| format!("option :from takes a name, got {arg}"))?
+                        .to_string(),
+                )
+            }
+            "scale" => {
+                let f = as_number(arg)
+                    .ok_or_else(|| format!("option :scale takes a number, got {arg}"))?;
+                if f <= 0.0 {
+                    return Err(format!(
+                        "variant '{name}': :scale must be positive, got {f}"
+                    ));
+                }
+                scale = Some(f);
+            }
+            "description" => description = as_str(arg).map(str::to_string),
+            other => {
+                return Err(format!(
+                    "variant '{name}': unknown option :{other} — expected :from, :scale, \
+                     or :description"
+                ))
+            }
+        }
+        i += 2;
+    }
+    let parent = parent.ok_or_else(|| {
+        format!(
+            "variant '{name}' has no :from — a variant inherits from a table or another variant"
+        )
+    })?;
+
+    let mut overlays = Vec::new();
+    for row in &args[i..] {
+        let Some((head, rargs)) = head_sym(row) else {
+            return Err(format!(
+                "variant '{name}' contains {row}, which is not an overlay row"
+            ));
+        };
+        match head {
+            "override" => {
+                let (Some(pname), Some(value)) = (
+                    rargs.first().and_then(as_name),
+                    rargs.get(1).and_then(as_value),
+                ) else {
+                    return Err(format!(
+                        "variant '{name}': override takes a name and a value, \
+                         e.g. [override pocket_clearance 0.4]"
+                    ));
+                };
+                let mut why = None;
+                for (k, arg) in keyword_opts(&rargs[2..], &["why"])? {
+                    if k == "why" {
+                        why = as_str(arg).map(str::to_string);
+                    }
+                }
+                overlays.push(Overlay::Override {
+                    name: pname.to_string(),
+                    value,
+                    why,
+                });
+            }
+            "scale" => {
+                let (Some(pname), Some(factor)) = (
+                    rargs.first().and_then(as_name),
+                    rargs.get(1).and_then(as_number),
+                ) else {
+                    return Err(format!(
+                        "variant '{name}': scale takes a name and a factor, \
+                         e.g. [scale flange_r 0.5]"
+                    ));
+                };
+                let mut why = None;
+                for (k, arg) in keyword_opts(&rargs[2..], &["why"])? {
+                    if k == "why" {
+                        why = as_str(arg).map(str::to_string);
+                    }
+                }
+                overlays.push(Overlay::Scale {
+                    name: pname.to_string(),
+                    factor,
+                    why,
+                });
+            }
+            other => {
+                return Err(format!(
+                    "variant '{name}': unknown overlay form [{other} ...] — \
+                     expected [override ...] or [scale ...]"
+                ))
+            }
+        }
+    }
+
+    Ok(Variant {
+        name,
+        parent,
+        scale,
+        description,
+        overlays,
+    })
+}
+
+// ============================================================================
+// Resolution
+// ============================================================================
+
+/// A parameter mid-resolution: its current value plus where that came from.
+#[derive(Debug, Clone)]
+struct Entry {
+    param: TableParam,
+    source: Source,
+}
+
+impl VariantSet {
+    /// Every table and variant name, sorted — for error messages and listings.
+    pub fn names(&self) -> Vec<String> {
+        let mut v: Vec<String> = self
+            .tables
+            .keys()
+            .chain(self.variants.keys())
+            .cloned()
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// The inheritance chain for a name, base table first.
+    pub fn chain(&self, name: &str) -> Result<Vec<String>, String> {
+        let mut chain = Vec::new();
+        let mut cur = name.to_string();
+        loop {
+            if chain.contains(&cur) {
+                chain.push(cur.clone());
+                return Err(format!(
+                    "cycle in variant inheritance: {}",
+                    chain.join(" → ")
+                ));
+            }
+            chain.push(cur.clone());
+            if self.tables.contains_key(&cur) {
+                break;
+            }
+            match self.variants.get(&cur) {
+                Some(v) => cur = v.parent.clone(),
+                None => {
+                    return Err(format!(
+                        "no table or variant named '{name}' — have {}",
+                        self.names().join(", ")
+                    ))
+                }
+            }
+        }
+        chain.reverse();
+        Ok(chain)
+    }
+
+    /// Resolve a variant (or a bare base table) to a flat table of values,
+    /// each carrying its provenance.
+    pub fn resolve(&self, name: &str) -> Result<Resolved, String> {
+        let chain = self.chain(name)?;
+        let table = &self.tables[&chain[0]];
+
+        let mut entries: HashMap<String, Entry> = HashMap::new();
+        for pname in &table.order {
+            let param = table.params[pname].clone();
+            let source = match &param.value {
+                IrExpr::Formula(f) => Source::Derived { formula: f.clone() },
+                IrExpr::Number(_) => Source::Base {
+                    table: table.name.clone(),
+                },
+            };
+            entries.insert(pname.clone(), Entry { param, source });
+        }
+
+        let mut effective_scale = 1.0;
+        for step in &chain[1..] {
+            let variant = &self.variants[step];
+
+            // 1. The variant-wide envelope scale, applied to literals only.
+            if let Some(factor) = variant.scale {
+                effective_scale *= factor;
+                for pname in &table.order {
+                    let entry = entries.get_mut(pname).expect("declared");
+                    let Some(current) = entry.param.literal() else {
+                        continue; // a formula recomputes from its inputs
+                    };
+                    if !entry.param.scale_with_envelope {
+                        entry.source = Source::Held {
+                            table: table.name.clone(),
+                            skipped_factor: factor,
+                            flag: "scale_with_envelope",
+                        };
+                        continue;
+                    }
+                    entry.param.value = IrExpr::Number(current * factor);
+                    entry.source = Source::ScaleDerived {
+                        variant: variant.name.clone(),
+                        factor,
+                        from: current,
+                        explicit: false,
+                    };
+                }
+            }
+
+            // 2. Then the variant's own overlays — a measurement taken at
+            //    this variant's size lands on the scaled table verbatim.
+            for overlay in &variant.overlays {
+                let pname = overlay.name();
+                let entry = entries.get_mut(pname).ok_or_else(|| {
+                    format!(
+                        "variant '{}' overlays '{pname}', which the base table '{}' \
+                         does not declare",
+                        variant.name, table.name
+                    )
+                })?;
+                match overlay {
+                    Overlay::Override { value, why, .. } => {
+                        entry.param.value = value.clone();
+                        entry.source = Source::Override {
+                            variant: variant.name.clone(),
+                            why: why.clone(),
+                        };
+                    }
+                    Overlay::Scale { factor, .. } => {
+                        if !entry.param.scale_with_envelope {
+                            return Err(format!(
+                                "variant '{}' scales '{pname}' by {factor}, but '{pname}' is \
+                                 declared :scale_with_envelope false in table '{}'{}. \
+                                 A value in that class is set by something other than the \
+                                 envelope — override it outright with \
+                                 [override {pname} <value> :why \"...\"] if it really must \
+                                 change, or drop the flag if it really does scale.",
+                                variant.name,
+                                table.name,
+                                match &entry.param.description {
+                                    Some(d) => format!(" ({d})"),
+                                    None => String::new(),
+                                }
+                            ));
+                        }
+                        let Some(current) = entry.param.literal() else {
+                            return Err(format!(
+                                "variant '{}' scales '{pname}', which is a derived formula — \
+                                 a derived value follows its inputs; scale those instead",
+                                variant.name
+                            ));
+                        };
+                        entry.param.value = IrExpr::Number(current * factor);
+                        entry.source = Source::ScaleDerived {
+                            variant: variant.name.clone(),
+                            factor: *factor,
+                            from: current,
+                            explicit: true,
+                        };
+                    }
+                }
+            }
+        }
+
+        // Evaluate formulas against the overlaid table.
+        let ir: HashMap<String, Parameter> = entries
+            .iter()
+            .map(|(k, e)| {
+                (
+                    k.clone(),
+                    Parameter {
+                        value: e.param.value.clone(),
+                        unit: e.param.unit.clone(),
+                        min: None,
+                        max: None,
+                        description: e.param.description.clone(),
+                    },
+                )
+            })
+            .collect();
+        let env = vcad_ir::resolve_parameters(&ir).map_err(|e| e.to_string())?;
+
+        let params = table
+            .order
+            .iter()
+            .map(|pname| {
+                let e = &entries[pname];
+                ResolvedParam {
+                    name: pname.clone(),
+                    value: env[pname],
+                    unit: e.param.unit.clone(),
+                    scale_with_envelope: e.param.scale_with_envelope,
+                    source: e.source.clone(),
+                    description: e.param.description.clone(),
+                }
+            })
+            .collect();
+
+        Ok(Resolved {
+            name: name.to_string(),
+            chain,
+            effective_scale,
+            params,
+        })
+    }
+
+    /// What differs between two variants, and why.
+    pub fn diff(&self, a: &str, b: &str) -> Result<Diff, String> {
+        let ra = self.resolve(a)?;
+        let rb = self.resolve(b)?;
+        let mut entries = Vec::new();
+
+        let mut names: Vec<String> = ra.params.iter().map(|p| p.name.clone()).collect();
+        for p in &rb.params {
+            if !names.contains(&p.name) {
+                names.push(p.name.clone());
+            }
+        }
+
+        for name in names {
+            let pa = ra.get(&name).cloned();
+            let pb = rb.get(&name).cloned();
+            let same = match (&pa, &pb) {
+                (Some(x), Some(y)) => (x.value - y.value).abs() <= 1e-9 * x.value.abs().max(1.0),
+                _ => false,
+            };
+            if same {
+                continue;
+            }
+            let reason = match (&pa, &pb) {
+                (Some(x), Some(y)) if x.source == y.source => {
+                    // Same provenance on both sides: a derived value whose
+                    // inputs moved, or an inherited literal seen through two
+                    // different scales.
+                    format!("{} — same rule, different inputs", y.source.explain())
+                }
+                (Some(x), Some(y)) => {
+                    format!("{} — was {}", y.source.explain(), x.source.explain())
+                }
+                (None, Some(_)) => format!("only in '{b}'"),
+                (Some(_), None) => format!("only in '{a}'"),
+                (None, None) => unreachable!(),
+            };
+            entries.push(DiffEntry {
+                name,
+                a: pa,
+                b: pb,
+                reason,
+            });
+        }
+
+        Ok(Diff {
+            a: a.to_string(),
+            b: b.to_string(),
+            entries,
+        })
+    }
+}

--- a/crates/vcad-loon/tests/fixtures/rana.params.loon
+++ b/crates/vcad-loon/tests/fixtures/rana.params.loon
@@ -1,0 +1,36 @@
+; The rana actuator family as one parameter table plus overlays.
+;
+; rana-100 is the full-size design; the 60c is the print mule — 0.6× envelope,
+; printed small to learn fit before the finding is promoted upward. What the
+; mule may shrink and what it may not is a property of each parameter here,
+; not a paragraph in a design doc.
+
+[deftable rana
+  ; --- envelope-driven: these follow the scale -----------------------------
+  [defparam envelope_d 100.0 :unit "mm"
+    :description "outer diameter of the actuator can"]
+  [defparam shell_wall 2.4 :unit "mm"]
+  [defparam rotor_r "envelope_d / 2 - shell_wall"]
+  [defparam pocket_clearance 0.2 :unit "mm"
+    :description "magnet pocket fit clearance, per side"]
+  [defparam pocket_w "magnet_block_w + 2 * pocket_clearance"]
+  [defparam pocket_l "magnet_block_l + 2 * pocket_clearance"]
+
+  ; --- held constant: set by process or by a purchased part ----------------
+  [defparam gear_module 0.5 :unit "mm" :scale_with_envelope false
+    :description "m0.5 is the PLA tooth floor — smaller teeth do not print"]
+  [defparam min_wall 0.4 :unit "mm" :scale_with_envelope false
+    :description "one 0.4 mm nozzle line"]
+  [defparam bolt_d 3.0 :unit "mm" :scale_with_envelope false
+    :description "M3 — COTS hardware does not scale"]
+  [defparam magnet_block_w 10.0 :unit "mm" :scale_with_envelope false
+    :description "N52 block, COTS"]
+  [defparam magnet_block_l 20.0 :unit "mm" :scale_with_envelope false
+    :description "N52 block, COTS"]
+  [defparam magnet_block_h 3.0 :unit "mm" :scale_with_envelope false
+    :description "N52 block, COTS"]]
+
+[defvariant rana_60c :from rana :scale 0.6
+  :description "0.6x print mule"
+  [override pocket_clearance 0.4
+    :why "60c mule first print: 0.2 pocket was interference-tight, +0.2 fits"]]

--- a/crates/vcad-loon/tests/variants.rs
+++ b/crates/vcad-loon/tests/variants.rs
@@ -1,0 +1,247 @@
+//! Variant parameter tables, tested against the real rana case.
+//!
+//! The property under test: a 0.6× print mule shrinks what the envelope
+//! drives and nothing else, an override made on the mule is visible as an
+//! override rather than as noise, and asking the scale to touch a held
+//! parameter fails loudly instead of shrinking a gear module.
+
+use vcad_loon::variants::{self, Source};
+
+const RANA: &str = include_str!("fixtures/rana.params.loon");
+
+fn set() -> variants::VariantSet {
+    variants::parse(RANA).expect("parse rana table")
+}
+
+#[test]
+fn base_table_resolves_to_its_own_values() {
+    let r = set().resolve("rana").unwrap();
+    assert_eq!(r.value("envelope_d"), Some(100.0));
+    assert_eq!(r.value("gear_module"), Some(0.5));
+    assert_eq!(r.value("pocket_clearance"), Some(0.2));
+    assert_eq!(r.effective_scale, 1.0);
+    // rotor_r = 100/2 - 2.4
+    assert_eq!(r.value("rotor_r"), Some(47.6));
+    // pocket_w = 10 + 2*0.2
+    assert!((r.value("pocket_w").unwrap() - 10.4).abs() < 1e-12);
+}
+
+#[test]
+fn envelope_scales_and_held_parameters_do_not() {
+    let r = set().resolve("rana_60c").unwrap();
+    assert_eq!(r.chain, vec!["rana".to_string(), "rana_60c".to_string()]);
+    assert_eq!(r.effective_scale, 0.6);
+
+    // Envelope-driven: scaled.
+    assert!((r.value("envelope_d").unwrap() - 60.0).abs() < 1e-12);
+    assert!((r.value("shell_wall").unwrap() - 1.44).abs() < 1e-12);
+    // Derived from scaled inputs — recomputed, never scaled twice.
+    assert!((r.value("rotor_r").unwrap() - (30.0 - 1.44)).abs() < 1e-12);
+
+    // Held: the m0.5 / 0.4 wall / M3 / COTS-magnet class.
+    assert_eq!(r.value("gear_module"), Some(0.5));
+    assert_eq!(r.value("min_wall"), Some(0.4));
+    assert_eq!(r.value("bolt_d"), Some(3.0));
+    assert_eq!(r.value("magnet_block_w"), Some(10.0));
+    assert_eq!(r.value("magnet_block_l"), Some(20.0));
+    assert_eq!(r.value("magnet_block_h"), Some(3.0));
+}
+
+#[test]
+fn mule_override_lands_verbatim_on_the_scaled_table() {
+    let r = set().resolve("rana_60c").unwrap();
+    // The mule measured 0.4 at 0.6× — not 0.2 × 0.6.
+    assert_eq!(r.value("pocket_clearance"), Some(0.4));
+    // And the pocket that consumes it recomputes: 10 (held) + 2 × 0.4.
+    assert!((r.value("pocket_w").unwrap() - 10.8).abs() < 1e-12);
+}
+
+#[test]
+fn every_resolved_value_knows_where_it_came_from() {
+    let r = set().resolve("rana_60c").unwrap();
+
+    match &r.get("envelope_d").unwrap().source {
+        Source::ScaleDerived {
+            variant,
+            factor,
+            from,
+            explicit,
+        } => {
+            assert_eq!(variant, "rana_60c");
+            assert_eq!((*factor, *from, *explicit), (0.6, 100.0, false));
+        }
+        other => panic!("envelope_d: expected scale-derived, got {other:?}"),
+    }
+
+    match &r.get("gear_module").unwrap().source {
+        Source::Held {
+            table,
+            skipped_factor,
+            flag,
+        } => {
+            assert_eq!(table, "rana");
+            assert_eq!(*skipped_factor, 0.6);
+            assert_eq!(*flag, "scale_with_envelope");
+        }
+        other => panic!("gear_module: expected held, got {other:?}"),
+    }
+
+    match &r.get("pocket_clearance").unwrap().source {
+        Source::Override { variant, why } => {
+            assert_eq!(variant, "rana_60c");
+            assert!(why.as_deref().unwrap().contains("mule"));
+        }
+        other => panic!("pocket_clearance: expected override, got {other:?}"),
+    }
+
+    assert!(matches!(
+        r.get("rotor_r").unwrap().source,
+        Source::Derived { .. }
+    ));
+    assert!(matches!(
+        set()
+            .resolve("rana")
+            .unwrap()
+            .get("envelope_d")
+            .unwrap()
+            .source,
+        Source::Base { .. }
+    ));
+}
+
+#[test]
+fn diff_names_the_override_and_separates_it_from_the_scale() {
+    let d = set().diff("rana", "rana_60c").unwrap();
+    let names = d.names();
+
+    // The one own-override in the family.
+    let clearance = d
+        .entries
+        .iter()
+        .find(|e| e.name == "pocket_clearance")
+        .expect("pocket_clearance differs");
+    assert!(clearance.reason.contains("own override in 'rana_60c'"));
+    assert!(clearance.reason.contains("mule"));
+    assert_eq!(clearance.a.as_ref().unwrap().value, 0.2);
+    assert_eq!(clearance.b.as_ref().unwrap().value, 0.4);
+
+    // Scale-derived differences are reported as scale, not as edits.
+    let envelope = d.entries.iter().find(|e| e.name == "envelope_d").unwrap();
+    assert!(envelope.reason.contains("envelope scale"));
+
+    // Held parameters do not appear at all.
+    for held in [
+        "gear_module",
+        "min_wall",
+        "bolt_d",
+        "magnet_block_w",
+        "magnet_block_l",
+        "magnet_block_h",
+    ] {
+        assert!(
+            !names.contains(&held),
+            "{held} should not differ between rana and its 0.6x mule, diff was:\n{}",
+            d.render()
+        );
+    }
+
+    // Exactly one entry is an author's decision; the rest follow from scale.
+    let overridden: Vec<_> = d
+        .entries
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.b.as_ref().map(|p| &p.source),
+                Some(Source::Override { .. })
+            )
+        })
+        .map(|e| e.name.as_str())
+        .collect();
+    assert_eq!(overridden, vec!["pocket_clearance"]);
+}
+
+#[test]
+fn scaling_a_held_parameter_is_a_loud_error() {
+    let src = format!(
+        "{RANA}\n[defvariant rana_60c_bad :from rana :scale 0.6\n  [scale gear_module 0.6]]\n"
+    );
+    let err = variants::parse(&src)
+        .unwrap()
+        .resolve("rana_60c_bad")
+        .unwrap_err();
+    assert!(err.contains("gear_module"), "{err}");
+    assert!(err.contains("scale_with_envelope"), "{err}");
+    assert!(err.contains("PLA tooth floor"), "{err}");
+    assert!(err.contains("[override gear_module"), "{err}");
+}
+
+#[test]
+fn scaling_a_scalable_parameter_explicitly_is_allowed_and_recorded() {
+    let src = format!(
+        "{RANA}\n[defvariant rana_thin :from rana\n  [scale shell_wall 0.5 :why \"thin-wall trial\"]]\n"
+    );
+    let r = variants::parse(&src).unwrap().resolve("rana_thin").unwrap();
+    assert_eq!(r.value("shell_wall"), Some(1.2));
+    match &r.get("shell_wall").unwrap().source {
+        Source::ScaleDerived { explicit, .. } => assert!(*explicit),
+        other => panic!("expected explicit scale, got {other:?}"),
+    }
+}
+
+#[test]
+fn variants_chain_and_scales_compose() {
+    let src = format!(
+        "{RANA}\n[defvariant rana_30 :from rana_60c :scale 0.5\n  [override shell_wall 1.0]]\n"
+    );
+    let r = variants::parse(&src).unwrap().resolve("rana_30").unwrap();
+    assert_eq!(r.chain, vec!["rana", "rana_60c", "rana_30"]);
+    assert_eq!(r.effective_scale, 0.3);
+    assert!((r.value("envelope_d").unwrap() - 30.0).abs() < 1e-12);
+    // The inherited override rides through the second scale as a literal.
+    assert!((r.value("pocket_clearance").unwrap() - 0.2).abs() < 1e-12);
+    // Held stays held through the whole chain.
+    assert_eq!(r.value("gear_module"), Some(0.5));
+    assert_eq!(r.value("shell_wall"), Some(1.0));
+}
+
+#[test]
+fn a_formula_cannot_be_flagged_no_scale() {
+    let err = variants::parse(
+        "[deftable t [defparam a 1.0] [defparam b \"a * 2\" :scale_with_envelope false]]",
+    )
+    .unwrap_err();
+    assert!(err.contains("derived value follows its inputs"), "{err}");
+}
+
+#[test]
+fn overlaying_an_undeclared_parameter_is_an_error() {
+    let src = format!("{RANA}\n[defvariant oops :from rana [override nonesuch 1.0]]\n");
+    let err = variants::parse(&src).unwrap().resolve("oops").unwrap_err();
+    assert!(err.contains("nonesuch"), "{err}");
+    assert!(err.contains("does not declare"), "{err}");
+}
+
+#[test]
+fn an_unknown_parent_is_reported_at_parse_time() {
+    let src = format!("{RANA}\n[defvariant orphan :from nowhere]\n");
+    let err = variants::parse(&src).unwrap_err();
+    assert!(err.contains("orphan"), "{err}");
+    assert!(err.contains("nowhere"), "{err}");
+}
+
+#[test]
+fn resolved_table_serializes_flat_with_provenance() {
+    let r = set().resolve("rana_60c").unwrap();
+    let j = serde_json::to_value(&r).unwrap();
+    assert_eq!(j["name"], "rana_60c");
+    assert_eq!(j["effective_scale"], 0.6);
+    let params = j["params"].as_array().unwrap();
+    let gear = params
+        .iter()
+        .find(|p| p["name"] == "gear_module")
+        .expect("gear_module in json");
+    assert_eq!(gear["value"], 0.5);
+    assert_eq!(gear["scale_with_envelope"], false);
+    assert_eq!(gear["source"]["kind"], "held");
+    assert_eq!(gear["source"]["flag"], "scale_with_envelope");
+}

--- a/docs/variant-parameter-tables.md
+++ b/docs/variant-parameter-tables.md
@@ -1,0 +1,160 @@
+# Variant parameter tables
+
+A design family is one design at several sizes. The rana actuator family —
+rana-100 → 100b → 100c → 60c print mule — was four copies of one generator
+set, and the copies drifted: a fix found on the mule had to be re-derived by
+hand for the full-size part, and the split between *what scales* (radii,
+heights) and *what must not* (gear module, M3 hardware, minimum wall) lived in
+prose in a design doc, where a reviewer had to catch it when it went wrong.
+
+Variant parameter tables put that split in the parameter itself.
+
+## The forms
+
+A parameter-table document (conventionally `params.loon` or
+`<family>.params.loon`) declares one or more base tables and any number of
+variants that overlay them. The vocabulary extends the `defparam` form
+parametric loon already uses, so a table row reads the same as a declaration
+inside a model:
+
+```loon
+[deftable rana
+  [defparam envelope_d 100.0 :unit "mm"
+    :description "outer diameter of the actuator can"]
+  [defparam shell_wall 2.4 :unit "mm"]
+  [defparam rotor_r "envelope_d / 2 - shell_wall"]
+  [defparam pocket_clearance 0.2 :unit "mm"]
+  [defparam pocket_w "magnet_block_w + 2 * pocket_clearance"]
+
+  [defparam gear_module 0.5 :unit "mm" :scale_with_envelope false
+    :description "m0.5 is the PLA tooth floor — smaller teeth do not print"]
+  [defparam min_wall 0.4 :unit "mm" :scale_with_envelope false]
+  [defparam bolt_d 3.0 :unit "mm" :scale_with_envelope false
+    :description "M3 — COTS hardware does not scale"]
+  [defparam magnet_block_w 10.0 :unit "mm" :scale_with_envelope false]]
+
+[defvariant rana_60c :from rana :scale 0.6
+  :description "0.6x print mule"
+  [override pocket_clearance 0.4
+    :why "60c mule first print: 0.2 pocket was interference-tight, +0.2 fits"]]
+```
+
+- `[deftable <name> [defparam ...] ...]` — a named base table. A row's value is
+  a literal or a formula string over other rows, using loon's existing
+  expression language. Options: `:unit`, `:description`,
+  `:scale_with_envelope`.
+- `[defvariant <name> :from <parent> :scale <f> :description "..." <overlays>]`
+  — a variant. The parent is a table or another variant, so families chain.
+- `[override <name> <value> :why "..."]` — set a value outright. `:why` is
+  carried into `diff` output, which is where a finding gets read back.
+- `[scale <name> <factor> :why "..."]` — scale one parameter explicitly.
+
+## Three rules
+
+1. **Scale applies to literals, not formulas.** A derived parameter recomputes
+   from its (already scaled) inputs, so it is never scaled twice. `rotor_r`
+   above becomes `30 - 1.44`, not `47.6 × 0.6`.
+2. **`:scale_with_envelope false` holds a value through a scale.** m0.5 stays
+   m0.5 at 0.6×; M3 stays M3; a 10 mm COTS magnet block stays 10 mm. Asking for
+   such a parameter to be scaled *directly* is an error naming the flag, not a
+   silent shrink:
+
+   ```
+   $ vcad params resolve rana_60c_bad
+   error: variant 'rana_60c_bad' scales 'gear_module' by 0.6, but 'gear_module'
+   is declared :scale_with_envelope false in table 'rana' (m0.5 is the PLA tooth
+   floor — smaller teeth do not print). A value in that class is set by
+   something other than the envelope — override it outright with
+   [override gear_module <value> :why "..."] if it really must change, or drop
+   the flag if it really does scale.
+   ```
+
+   Flagging a *formula* is likewise rejected: a derived value follows its
+   inputs, so the flag belongs on the inputs.
+3. **A variant's scale applies before its own overrides.** An override is a
+   measurement taken at the variant's own size — the mule's `pocket_clearance
+   0.4` is 0.4 mm on the printed mule, not `0.2 × 0.6`. It lands on the scaled
+   table verbatim.
+
+## Worked example
+
+```
+$ vcad params resolve rana_60c --file rana.params.loon --table
+rana_60c (rana → rana_60c), effective scale 0.6
+  envelope_d              60mm  envelope scale in 'rana_60c': 100 × 0.6
+  shell_wall            1.44mm  envelope scale in 'rana_60c': 2.4 × 0.6
+  rotor_r                28.56  derived: envelope_d / 2 - shell_wall
+  pocket_clearance       0.4mm  own override in 'rana_60c' (60c mule first
+                                print: 0.2 pocket was interference-tight, +0.2 fits)
+  pocket_w                10.8  derived: magnet_block_w + 2 * pocket_clearance
+  gear_module            0.5mm  held at the 'rana' base value —
+                                scale_with_envelope: false, so the 0.6× envelope
+                                scale does not apply
+  bolt_d                   3mm  held at the 'rana' base value — …
+  magnet_block_w          10mm  held at the 'rana' base value — …
+```
+
+Without `--table`, `resolve` writes the flat table as JSON on stdout — one
+entry per parameter with `value`, `unit`, `scale_with_envelope`, and a tagged
+`source` (`base` / `held` / `override` / `scale-derived` / `derived`):
+
+```json
+{
+  "name": "gear_module",
+  "value": 0.5,
+  "unit": "mm",
+  "scale_with_envelope": false,
+  "source": {
+    "kind": "held",
+    "table": "rana",
+    "skipped_factor": 0.6,
+    "flag": "scale_with_envelope"
+  }
+}
+```
+
+`diff` answers the promotion question — *what exactly does this mule finding
+change?*
+
+```
+$ vcad params diff rana rana_60c --file rana.params.loon
+rana → rana_60c
+  envelope_d: 100 → 60
+      envelope scale in 'rana_60c': 100 × 0.6 — was base table 'rana'
+  shell_wall: 2.4 → 1.44
+      envelope scale in 'rana_60c': 2.4 × 0.6 — was base table 'rana'
+  rotor_r: 47.6 → 28.56
+      derived: envelope_d / 2 - shell_wall — same rule, different inputs
+  pocket_clearance: 0.2 → 0.4
+      own override in 'rana_60c' (60c mule first print: 0.2 pocket was
+      interference-tight, +0.2 fits) — was base table 'rana'
+  pocket_w: 10.4 → 10.8
+      derived: magnet_block_w + 2 * pocket_clearance — same rule, different inputs
+```
+
+Every held parameter is absent from the diff, which is the point: the m0.5
+module, the M3 bolt and the COTS magnet block are identical at both sizes, and
+the single line an author has to decide about when promoting the finding is
+`pocket_clearance`, marked `own override` with the reason it was made.
+
+`--json` emits the same as a machine-readable structure; `--exit-code` makes a
+non-empty diff exit 1, for a CI gate that asserts two variants agree.
+
+## Commands
+
+```
+vcad params resolve <variant> [--file <path>] [--table]
+vcad params diff <a> <b> [--file <path>] [--json] [--exit-code]
+vcad params list [--file <path>]
+```
+
+`--file` defaults to `$VCAD_PARAMS`, else `params.loon` in the working
+directory, so inside a project the commands read as `vcad params diff 100c 60c`.
+
+## Where it lives
+
+`crates/vcad-loon/src/variants.rs` — parsing, resolution and diff; the
+resolution step hands the overlaid table to `vcad_ir::resolve_parameters`, the
+same evaluator document parameters use, so formulas mean exactly what they mean
+elsewhere. Tests: `crates/vcad-loon/tests/variants.rs` against the rana fixture
+in `crates/vcad-loon/tests/fixtures/rana.params.loon`.


### PR DESCRIPTION
Closes #845

A design family is one design at several sizes. The rana actuator family (100 → 100b → 100c → 60c print mule) was four copies of one generator set, and the split between what scales (radii, heights) and what must not (m0.5 gear module, M3 hardware, 0.4 mm min wall, COTS magnet blocks) lived in prose — where a 100c-scale radius on a 60c flange had to be caught by a human in review.

This makes that split a property of the parameter.

## Syntax

A parameter-table document (`params.loon`, or `<family>.params.loon`) extends the `defparam` vocabulary parametric loon already speaks:

```loon
[deftable rana
  [defparam envelope_d 100.0 :unit "mm"]
  [defparam shell_wall 2.4 :unit "mm"]
  [defparam rotor_r "envelope_d / 2 - shell_wall"]
  [defparam pocket_clearance 0.2 :unit "mm"]
  [defparam pocket_w "magnet_block_w + 2 * pocket_clearance"]

  [defparam gear_module 0.5 :unit "mm" :scale_with_envelope false
    :description "m0.5 is the PLA tooth floor — smaller teeth do not print"]
  [defparam min_wall 0.4 :unit "mm" :scale_with_envelope false]
  [defparam bolt_d 3.0 :unit "mm" :scale_with_envelope false
    :description "M3 — COTS hardware does not scale"]
  [defparam magnet_block_w 10.0 :unit "mm" :scale_with_envelope false]]

[defvariant rana_60c :from rana :scale 0.6
  :description "0.6x print mule"
  [override pocket_clearance 0.4
    :why "60c mule first print: 0.2 pocket was interference-tight, +0.2 fits"]]
```

`[scale <name> <factor> :why "..."]` is the other overlay form, for a one-parameter scale outside the envelope.

### Three rules

1. **Scale applies to literals, not formulas.** A derived parameter recomputes from its (already scaled) inputs, so it is never scaled twice. `rotor_r` becomes `30 - 1.44`, not `47.6 × 0.6`.
2. **`:scale_with_envelope false` holds a value through a scale**, and scaling such a parameter *directly* is an error naming the flag. Flagging a formula is likewise rejected — a derived value follows its inputs, so the flag belongs on the inputs.
3. **A variant's scale applies before its own overrides.** An override is a measurement taken at that variant's size, so the mule's 0.4 mm clearance lands verbatim rather than as `0.2 × 0.6`.

Values are evaluated by `vcad_ir::resolve_parameters` — the same evaluator document parameters use, so formulas mean exactly what they mean elsewhere.

## Worked example

```
$ vcad params resolve rana_60c --file rana.params.loon --table
rana_60c (rana → rana_60c), effective scale 0.6
  envelope_d              60mm  envelope scale in 'rana_60c': 100 × 0.6
  shell_wall            1.44mm  envelope scale in 'rana_60c': 2.4 × 0.6
  rotor_r                28.56  derived: envelope_d / 2 - shell_wall
  pocket_clearance       0.4mm  own override in 'rana_60c' (60c mule first print: 0.2 pocket was interference-tight, +0.2 fits)
  pocket_w                10.8  derived: magnet_block_w + 2 * pocket_clearance
  gear_module            0.5mm  held at the 'rana' base value — scale_with_envelope: false, so the 0.6× envelope scale does not apply
  min_wall               0.4mm  held at the 'rana' base value — …
  bolt_d                   3mm  held at the 'rana' base value — …
  magnet_block_w          10mm  held at the 'rana' base value — …
```

Without `--table`, `resolve` writes the flat table as JSON, each entry carrying a tagged `source` (`base` / `held` / `override` / `scale-derived` / `derived`).

`diff` answers the promotion question — what exactly does this mule finding change?

```
$ vcad params diff rana rana_60c --file rana.params.loon
rana → rana_60c
  envelope_d: 100 → 60
      envelope scale in 'rana_60c': 100 × 0.6 — was base table 'rana'
  shell_wall: 2.4 → 1.44
      envelope scale in 'rana_60c': 2.4 × 0.6 — was base table 'rana'
  rotor_r: 47.6 → 28.56
      derived: envelope_d / 2 - shell_wall — same rule, different inputs
  pocket_clearance: 0.2 → 0.4
      own override in 'rana_60c' (60c mule first print: 0.2 pocket was interference-tight, +0.2 fits) — was base table 'rana'
  pocket_w: 10.4 → 10.8
      derived: magnet_block_w + 2 * pocket_clearance — same rule, different inputs
```

Every held parameter is absent from the diff — that is the point. The one line an author decides about when promoting the finding is `pocket_clearance`, marked `own override` with the reason it was made.

The loud error:

```
$ vcad params resolve rana_60c_bad
error: variant 'rana_60c_bad' scales 'gear_module' by 0.6, but 'gear_module' is
declared :scale_with_envelope false in table 'rana' (m0.5 is the PLA tooth floor
— smaller teeth do not print). A value in that class is set by something other
than the envelope — override it outright with [override gear_module <value>
:why "..."] if it really must change, or drop the flag if it really does scale.
```

## Commands

```
vcad params resolve <variant> [--file <path>] [--table]
vcad params diff <a> <b> [--file <path>] [--json] [--exit-code]
vcad params list [--file <path>]
```

`--file` defaults to `$VCAD_PARAMS`, else `params.loon` in the working directory, so inside a project this reads as `vcad params diff 100c 60c`. `--exit-code` makes a non-empty diff exit 1, for a CI gate asserting two variants agree.

## Tests

`crates/vcad-loon/tests/variants.rs`, 12 tests against the real rana case as a fixture (`tests/fixtures/rana.params.loon`): envelope 100 → 60, module stays 0.5, min wall and M3 and the COTS magnet block dims stay, the diff shows exactly the one clearance override, and scaling `gear_module` errors with a message naming the flag. Chained variants (`rana_30 :from rana_60c :scale 0.5`) compose to an effective 0.3. `cargo test -p vcad-loon` passes (85 + 12 + the existing suites); clippy adds no new warnings.

## Follow-up (not in this PR)

Consuming a resolved variant from a geometry program — a `[use-table ...]` form that binds a variant's resolved values as `defparam`s — is the natural next step; this PR lands the table, the flags, the CLI and the provenance first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
