### PR TITLE
vcad check: printability lint on the exported mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6970,6 +6970,7 @@ dependencies = [
  "vcad-kernel-tessellate",
  "vcad-kernel-urdf",
  "vcad-loon",
+ "vcad-printcheck",
  "vcad-render",
  "vcad-slicer",
  "vcad-slicer-bambu",
@@ -7924,6 +7925,16 @@ dependencies = [
  "serde",
  "serde_json",
  "vcad-ir",
+]
+
+[[package]]
+name = "vcad-printcheck"
+version = "0.9.4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "stl_io",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/vcad-ir",
     "crates/vcad-receipt",
     "crates/vcad-parts",
+    "crates/vcad-printcheck",
     "crates/vcad",
     "crates/vcad-kernel-math",
     "crates/vcad-kernel-topo",
@@ -105,6 +106,7 @@ default-members = [
     "crates/vcad-ir",
     "crates/vcad-receipt",
     "crates/vcad-parts",
+    "crates/vcad-printcheck",
     "crates/vcad",
     "crates/vcad-kernel-math",
     "crates/vcad-kernel-topo",
@@ -245,6 +247,7 @@ opencascade = { version = "0.2" }
 vcad-ir = { path = "crates/vcad-ir", version = "0.9.4" }
 vcad-receipt = { path = "crates/vcad-receipt", version = "0.9.4" }
 vcad-parts = { path = "crates/vcad-parts", version = "0.9.4" }
+vcad-printcheck = { path = "crates/vcad-printcheck", version = "0.9.4" }
 vcad-kernel = { path = "crates/vcad-kernel", version = "0.9.4" }
 vcad-kernel-math = { path = "crates/vcad-kernel-math", version = "0.9.4" }
 vcad-kernel-topo = { path = "crates/vcad-kernel-topo", version = "0.9.4" }

--- a/crates/vcad-cli/Cargo.toml
+++ b/crates/vcad-cli/Cargo.toml
@@ -39,6 +39,7 @@ vcad-render = { path = "../vcad-render", default-features = false }
 vcad-slicer = { path = "../vcad-slicer" }
 vcad-slicer-gcode = { path = "../vcad-slicer-gcode" }
 vcad-slicer-bambu = { path = "../vcad-slicer-bambu", default-features = false }
+vcad-printcheck = { path = "../vcad-printcheck" }
 
 # Print server (optional feature)
 axum = { version = "0.8", optional = true }

--- a/crates/vcad-cli/src/main.rs
+++ b/crates/vcad-cli/src/main.rs
@@ -358,6 +358,53 @@ enum Commands {
         explain: bool,
     },
 
+    /// Lint an EXPORTED mesh for FDM printability, in a chosen orientation
+    ///
+    /// Printability is a property of the shipped file, not of the model that
+    /// produced it: a shell can pass its author's analytic profile check while
+    /// the discretised STL carries 0.05 mm cracks. So this reads triangles and
+    /// casts rays at them, reporting floating regions and mid-air islands,
+    /// interior cracks, the overhang census, bridge spans with lengths, min
+    /// wall against the nozzle, and a manifold + closed-sections summary.
+    ///
+    /// Exit code is 0 when clean and 1 when anything failed, so it gates CI.
+    Check {
+        /// Mesh to check (.stl, binary or ASCII)
+        input: PathBuf,
+        /// Which model axis points up on the plate: z, -z, x, -x, y, -y
+        #[arg(long, default_value = "z")]
+        orientation: String,
+        /// Nozzle width in mm — nothing thinner can be extruded
+        #[arg(long, default_value = "0.4")]
+        nozzle: f64,
+        /// Longest unsupported span accepted without support material, mm
+        #[arg(long, default_value = "4")]
+        max_bridge: f64,
+        /// Material gaps below this are cracks, not channels. Never waived.
+        #[arg(long, default_value = "0.15")]
+        crack_threshold: f64,
+        /// Self-support limit in degrees from vertical
+        #[arg(long, default_value = "45")]
+        max_overhang: f64,
+        /// Fail on the overhang census instead of warning
+        #[arg(long)]
+        strict_overhangs: bool,
+        /// Distance between raycast columns, mm (default: the nozzle width)
+        #[arg(long)]
+        pitch: Option<f64>,
+        /// Section sampling pitch in mm
+        #[arg(long, default_value = "0.4")]
+        section_step: f64,
+        /// Accept unsupported spans in a height range, e.g. `--allow-bridge
+        /// 1.75:2.65`. Repeatable. Documented bridges only — a crack is never
+        /// waived by this.
+        #[arg(long = "allow-bridge", value_name = "Z0:Z1")]
+        allow_bridge: Vec<String>,
+        /// Emit the report as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Start the print relay server for web app → printer communication
     #[cfg(feature = "print-server")]
     PrintServer {
@@ -603,6 +650,33 @@ fn main() -> Result<()> {
                 bed_temp,
                 smart,
                 explain,
+            )?;
+        }
+        Some(Commands::Check {
+            input,
+            orientation,
+            nozzle,
+            max_bridge,
+            crack_threshold,
+            max_overhang,
+            strict_overhangs,
+            pitch,
+            section_step,
+            allow_bridge,
+            json,
+        }) => {
+            run_check(
+                &input,
+                &orientation,
+                nozzle,
+                max_bridge,
+                crack_threshold,
+                max_overhang,
+                strict_overhangs,
+                pitch,
+                section_step,
+                &allow_bridge,
+                json,
             )?;
         }
         #[cfg(feature = "print-server")]
@@ -1707,6 +1781,73 @@ pub fn export_file_from_doc(doc: &vcad_ir::Document, output: &PathBuf) -> Result
 }
 
 #[allow(clippy::too_many_arguments)]
+/// `vcad check` — printability lint on an exported mesh.
+///
+/// Exits the process with 1 on a dirty verdict rather than returning an error,
+/// so CI sees a lint failure (findings already printed) and not a crash.
+#[allow(clippy::too_many_arguments)]
+fn run_check(
+    input: &std::path::Path,
+    orientation: &str,
+    nozzle: f64,
+    max_bridge: f64,
+    crack_threshold: f64,
+    max_overhang: f64,
+    strict_overhangs: bool,
+    pitch: Option<f64>,
+    section_step: f64,
+    allow_bridge: &[String],
+    json: bool,
+) -> Result<()> {
+    use vcad_printcheck::{check_file, render_text, Options, Orientation};
+
+    let orientation = Orientation::parse(orientation).ok_or_else(|| {
+        anyhow::anyhow!("unknown orientation `{orientation}` (expected one of z, -z, x, -x, y, -y)")
+    })?;
+    let mut allow_bridges = Vec::new();
+    for spec in allow_bridge {
+        let (a, b) = spec
+            .split_once(':')
+            .ok_or_else(|| anyhow::anyhow!("--allow-bridge wants Z0:Z1, got `{spec}`"))?;
+        let lo: f64 = a
+            .trim()
+            .parse()
+            .map_err(|_| anyhow::anyhow!("--allow-bridge: `{a}` is not a number"))?;
+        let hi: f64 = b
+            .trim()
+            .parse()
+            .map_err(|_| anyhow::anyhow!("--allow-bridge: `{b}` is not a number"))?;
+        if hi < lo {
+            anyhow::bail!("--allow-bridge {spec}: the range runs backwards");
+        }
+        allow_bridges.push((lo, hi));
+    }
+
+    let opts = Options {
+        orientation,
+        nozzle,
+        max_bridge,
+        crack_threshold,
+        max_overhang,
+        strict_overhangs,
+        pitch: pitch.unwrap_or(nozzle),
+        section_step,
+        allow_bridges,
+        ..Default::default()
+    };
+    let report = check_file(input, &opts)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print!("{}", render_text(&report));
+    }
+    if !report.ok {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
 fn slice_file(
     input: &PathBuf,
     output: &PathBuf,

--- a/crates/vcad-printcheck/Cargo.toml
+++ b/crates/vcad-printcheck/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vcad-printcheck"
+description = "Printability lint for exported meshes: floating regions, interior cracks, overhangs, bridges, min-wall"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+stl_io = "0.8"

--- a/crates/vcad-printcheck/README.md
+++ b/crates/vcad-printcheck/README.md
@@ -1,0 +1,73 @@
+# vcad-printcheck
+
+Printability lint for an **exported** mesh, in a chosen print orientation.
+
+```
+vcad check part.stl
+vcad check part.stl --orientation -z --nozzle 0.4 --max-bridge 4 --crack-threshold 0.15
+vcad check shell.stl --allow-bridge 1.75:2.65 --allow-bridge 25.6:26.25
+vcad check part.stl --json
+```
+
+Exit code is `0` when clean and `1` when anything failed, so it gates CI.
+
+## Why it reads the export
+
+FDM printability is a property of the shipped file, not of the model that
+produced it. The rana `60c` shell passed its author's analytic profile
+verification while the discretised STL carried 0.05 mm cracks across 85% of its
+circumference; only rays cast at the export caught it. Every check here reads
+triangles.
+
+The three field-proven checkers this ports —`support-check.py`,
+`slice-check.py`, `manifold-check.py` in the rana repo — were each written
+after a print failure or a slicer warning that geometry-level checks missed.
+
+## What it reports
+
+| check | what it catches |
+| --- | --- |
+| floating regions | material starting in mid-air with nothing beneath or beside it |
+| interior cracks | material gaps below the threshold (default 0.15 mm) — a slicer reads these as floating layers |
+| bridge spans | unsupported spans with lengths, against the 4 mm convention |
+| overhang census | downward face area by bucket, with the staircase-vs-support verdict |
+| min wall / min feature | thinnest wall against the nozzle, measured along all three axes |
+| manifold + sections | bad-edge census, and whether every z-section closes |
+
+## The parts that are easy to get wrong
+
+**Parity, not winding.** Material spans come from strict crossing parity, which
+is what a slicer's mesh analysis sees. Parity reads a z-overlap between two
+*separate* bodies as an interior void — a defect worth flagging (rana finding
+#11 was a rim chamfer ring overlapping the sector columns by 0.05 mm). An
+earlier version of the rana checker used a winding sum with an inverted sign,
+saw no material anywhere, and passed vacuously for a whole revision. Hence:
+
+**Known-bad fixtures.** `tests/known_bad.rs` asserts the checker *fails* a
+0.05 mm crack, a mid-air island, a 0.2 mm wall at a 0.4 nozzle, a 12 mm bridge,
+and a holed cube — each with the specific diagnosis, not merely a non-zero
+exit. `tests/real_world.rs` asserts the shipped rana shell passes, *and* that
+removing its bridge waiver makes it fail, so the waiver cannot hide a broken
+check.
+
+**Sampling pitch follows the nozzle.** Rays are cast on a square grid whose
+pitch defaults to the nozzle width, not on a fixed column count over the
+bounding box. A 70 mm part sampled 64 columns wide puts 1.1 mm between rays,
+which straddles a 2 mm tube wall: neighbours land in air, roofs read as
+unanchored, and spans get measured across the bore.
+
+**Bridge span is distance to an anchor, doubled** — not the region's own
+footprint. A roof over a slot is unsupported across the slot but continuous
+along it, and its bounding diagonal would report the length of the slot rather
+than the span the extruder has to cross.
+
+**Three filters keep min-wall honest.** A ray must hit the surface within 60°
+of head-on (a grazing chord measures the silhouette); the faces at the two ends
+of the span must oppose each other (a chamfer feathering to an edge is not a
+thin wall); and the voids either side must be real, not hairlines (the rana
+shell is meshed as 0.5° sector prisms whose seams parity reads as 0.06 mm gaps,
+which would otherwise turn a solid 2 mm tube into a stack of 0.24 mm "walls").
+
+**A crack is never waivable.** `--allow-bridge Z0:Z1` accepts documented
+unsupported spans in a height range — the rana shell's slot roofs are accepted
+exactly this way. It has no effect on cracks.

--- a/crates/vcad-printcheck/src/checks.rs
+++ b/crates/vcad-printcheck/src/checks.rs
@@ -1,0 +1,783 @@
+//! The individual printability checks.
+//!
+//! Each `check_*` returns its own summary plus the findings it raised. The
+//! caller (`lib.rs`) decides the exit verdict from the finding severities.
+
+use std::collections::HashMap;
+
+use crate::mesh::{intervals, Mesh, RayIndex};
+use crate::{Finding, FindingKind, Options, Severity};
+
+// ---------------------------------------------------------------------------
+// manifold
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ManifoldSummary {
+    pub triangles: usize,
+    pub edges: usize,
+    /// Edges not shared by exactly two triangles.
+    pub bad_edges: usize,
+}
+
+/// Edge census, quantising vertices to 1e-3 mm — the same tolerance
+/// `rana tools/manifold-check.py` uses, which is well below any printable
+/// feature and well above STL's f32 round-trip noise.
+pub fn check_manifold(mesh: &Mesh) -> (ManifoldSummary, Vec<Finding>) {
+    let q = |v: &[f64; 3]| {
+        [
+            (v[0] * 1000.0).round() as i64,
+            (v[1] * 1000.0).round() as i64,
+            (v[2] * 1000.0).round() as i64,
+        ]
+    };
+    let mut edges: HashMap<([i64; 3], [i64; 3]), u32> = HashMap::new();
+    for t in &mesh.tris {
+        let vs = [q(&t[0]), q(&t[1]), q(&t[2])];
+        for i in 0..3 {
+            let (a, b) = (vs[i], vs[(i + 1) % 3]);
+            let key = if a <= b { (a, b) } else { (b, a) };
+            *edges.entry(key).or_insert(0) += 1;
+        }
+    }
+    let bad = edges.values().filter(|&&c| c != 2).count();
+    let summary = ManifoldSummary {
+        triangles: mesh.tris.len(),
+        edges: edges.len(),
+        bad_edges: bad,
+    };
+    let mut findings = Vec::new();
+    if bad > 0 {
+        findings.push(Finding {
+            kind: FindingKind::NonManifold,
+            severity: Severity::Fail,
+            message: format!("{bad} edges are not shared by exactly two triangles"),
+            location: None,
+            value_mm: None,
+        });
+    }
+    (summary, findings)
+}
+
+// ---------------------------------------------------------------------------
+// closed sections
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SectionSummary {
+    pub z_min: f64,
+    pub z_max: f64,
+    pub sections: usize,
+    pub empty_layers: Vec<f64>,
+    pub open_sections: Vec<(f64, usize)>,
+}
+
+/// Slice the way a slicer does and verify every cross-section closes.
+///
+/// A manifold check asks whether the whole mesh is watertight. This asks the
+/// question that actually stops a print: at height z, do the triangle/plane
+/// intersections join into closed loops? A mesh can be locally holed without
+/// being globally broken, and the slicer reports that as "can't be printed for
+/// empty layer between a and b". Ported from `rana tools/slice-check.py`.
+pub fn check_sections(mesh: &Mesh, opts: &Options) -> (SectionSummary, Vec<Finding>) {
+    let (lo, hi) = mesh.bounds();
+    let (zlo, zhi) = (lo[2], hi[2]);
+    // Horizontal faces live at these heights; a sample plane landing on one
+    // gives a degenerate section, so — like a slicer — we nudge off it.
+    let mut flat: Vec<f64> = mesh
+        .tris
+        .iter()
+        .flat_map(|t| t.iter().map(|v| (v[2] * 10000.0).round() / 10000.0))
+        .collect();
+    flat.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    flat.dedup();
+
+    let step = opts.section_step;
+    let mut empty = Vec::new();
+    let mut open = Vec::new();
+    let mut count = 0usize;
+    let mut z = zlo + step / 2.0;
+    while z < zhi {
+        if flat.binary_search_by(|p| p.partial_cmp(&z).unwrap()).is_ok()
+            || flat.iter().any(|f| (f - z).abs() < 1e-4)
+        {
+            z += step * 0.137;
+        }
+        if z >= zhi {
+            break;
+        }
+        count += 1;
+        let (segs, loose) = section(mesh, z);
+        if segs == 0 {
+            empty.push(round3(z));
+        } else if loose > 0 {
+            open.push((round3(z), loose));
+        }
+        z += step;
+    }
+
+    let mut findings = Vec::new();
+    if !empty.is_empty() {
+        findings.push(Finding {
+            kind: FindingKind::EmptyLayer,
+            severity: Severity::Fail,
+            message: format!(
+                "{} empty layer(s), first at z={:.2} — the slicer cannot print through this",
+                empty.len(),
+                empty[0]
+            ),
+            location: Some([0.0, 0.0, empty[0]]),
+            value_mm: None,
+        });
+    }
+    if !open.is_empty() {
+        let worst = open.iter().map(|o| o.1).max().unwrap_or(0);
+        findings.push(Finding {
+            kind: FindingKind::OpenSection,
+            severity: Severity::Fail,
+            message: format!(
+                "{} cross-section(s) do not close (worst {worst} loose ends, first at z={:.2})",
+                open.len(),
+                open[0].0
+            ),
+            location: Some([0.0, 0.0, open[0].0]),
+            value_mm: None,
+        });
+    }
+
+    (
+        SectionSummary {
+            z_min: round3(zlo),
+            z_max: round3(zhi),
+            sections: count,
+            empty_layers: empty,
+            open_sections: open,
+        },
+        findings,
+    )
+}
+
+/// Returns (segment count, vertices with odd degree) for the z-section.
+fn section(mesh: &Mesh, z: f64) -> (usize, usize) {
+    let mut deg: HashMap<(i64, i64), u32> = HashMap::new();
+    let mut segs = 0usize;
+    for t in &mesh.tris {
+        let mut pts: Vec<(i64, i64)> = Vec::new();
+        for i in 0..3 {
+            let (a, b) = (t[i], t[(i + 1) % 3]);
+            if (a[2] - z) * (b[2] - z) < 0.0 {
+                let f = (z - a[2]) / (b[2] - a[2]);
+                pts.push(qpt(a[0] + f * (b[0] - a[0]), a[1] + f * (b[1] - a[1])));
+            } else if (a[2] - z).abs() < 1e-9 {
+                pts.push(qpt(a[0], a[1]));
+            }
+        }
+        pts.dedup();
+        if pts.len() > 1 && pts[0] == pts[pts.len() - 1] {
+            pts.pop();
+        }
+        if pts.len() == 2 {
+            segs += 1;
+            *deg.entry(pts[0]).or_insert(0) += 1;
+            *deg.entry(pts[1]).or_insert(0) += 1;
+        }
+    }
+    let loose = deg.values().filter(|d| *d % 2 == 1).count();
+    (segs, loose)
+}
+
+fn qpt(x: f64, y: f64) -> (i64, i64) {
+    ((x * 100.0).round() as i64, (y * 100.0).round() as i64)
+}
+
+// ---------------------------------------------------------------------------
+// columns: floating regions, interior cracks, bridges
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct BridgeSpan {
+    pub z: f64,
+    pub span_mm: f64,
+    pub columns: usize,
+    pub anchored: bool,
+    pub whitelisted: bool,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ColumnSummary {
+    pub columns_sampled: usize,
+    pub columns_with_material: usize,
+    pub cracks: usize,
+    pub thinnest_gap_mm: Option<f64>,
+    pub floating_regions: usize,
+    pub bridges: Vec<BridgeSpan>,
+}
+
+struct Column {
+    iv: Vec<(f64, f64)>,
+}
+
+impl Column {
+    /// Material passes continuously through `z` from below — i.e. this column
+    /// can carry a neighbour's first layer at that height.
+    fn supports(&self, z: f64) -> bool {
+        self.iv.iter().any(|(a, b)| *a < z - 1e-6 && *b > z + 1e-6)
+    }
+}
+
+/// Per-column vertical raycast: mid-air restarts (floating regions and
+/// bridges) and interior gaps thinner than the crack threshold.
+///
+/// This is the check that caught rana finding #10: v6's z-banded build left
+/// 0.04–0.06 mm horizontal cracks where the descending cam profile ate the
+/// bands' z-overlap. An analytic profile check cannot see that; only a raycast
+/// on the final mesh can.
+pub fn check_columns(mesh: &Mesh, opts: &Options) -> (ColumnSummary, Vec<Finding>) {
+    let (lo, hi) = mesh.bounds();
+    let idx = RayIndex::build(mesh);
+    // A SQUARE sampling pitch, not `grid` columns per axis: the bridge metric
+    // counts grid steps outward to an anchor, and on a stretched grid a step
+    // in x would be worth a different number of millimetres than a step in y.
+    let (nx, ny, pitch) = grid_dims(lo, hi, opts.pitch, opts.max_columns);
+    let (cw, ch) = (pitch, pitch);
+
+    // Sample at cell centres nudged by an irrational fraction of a cell, so
+    // rays never land exactly on a seam, a vertex, or a symmetry plane — the
+    // rana checker dodges its 0.5° sector seams the same way.
+    let px = |i: usize| lo[0] + (i as f64 + 0.5 + 0.0193) * cw;
+    let py = |j: usize| lo[1] + (j as f64 + 0.5 + 0.0271) * ch;
+
+    let mut cols: Vec<Option<Column>> = Vec::with_capacity(nx * ny);
+    for j in 0..ny {
+        for i in 0..nx {
+            let cr = idx.crossings(px(i), py(j));
+            // An odd crossing count means the ray grazed an edge; parity is
+            // meaningless there, so the column is dropped rather than guessed.
+            if cr.is_empty() || cr.len() % 2 == 1 {
+                cols.push(None);
+                continue;
+            }
+            let iv = intervals(&cr);
+            if iv.is_empty() {
+                cols.push(None);
+            } else {
+                cols.push(Some(Column { iv }));
+            }
+        }
+    }
+
+    let bed = lo[2];
+    let mut findings = Vec::new();
+    let mut cracks = 0usize;
+    let mut thinnest: Option<f64> = None;
+    // (i, j, z) candidates: material that starts in mid-air.
+    let mut restarts: Vec<(usize, usize, f64)> = Vec::new();
+
+    for j in 0..ny {
+        for i in 0..nx {
+            let Some(col) = &cols[j * nx + i] else { continue };
+            for k in 0..col.iv.len() {
+                let z = col.iv[k].0;
+                if k == 0 {
+                    // A first interval starting off the bed is also material
+                    // appearing in mid-air for this column; whether it is a
+                    // defect depends on lateral anchoring, decided below.
+                    //
+                    // "Off the bed" is judged against the first layer, not
+                    // against zero. A chamfered rim touches the plate along a
+                    // ring far thinner than the sampling pitch, so every
+                    // column over the chamfer starts a few hundredths high —
+                    // and the extruder lays all of it into the first layer
+                    // regardless.
+                    if z > bed + opts.bed_tol {
+                        restarts.push((i, j, z));
+                    }
+                    continue;
+                }
+                let gap = z - col.iv[k - 1].1;
+                thinnest = Some(thinnest.map_or(gap, |t: f64| t.min(gap)));
+                if gap < opts.crack_threshold {
+                    // A gap thinner than the threshold is a crack, never a
+                    // channel — and never whitelistable. This is the failure
+                    // mode a slicer reports as a floating layer.
+                    cracks += 1;
+                    if cracks <= opts.max_reported {
+                        findings.push(Finding {
+                            kind: FindingKind::Crack,
+                            severity: Severity::Fail,
+                            message: format!(
+                                "interior crack: {:.3} mm material gap at z={:.3} (< {:.3} threshold)",
+                                gap, z, opts.crack_threshold
+                            ),
+                            location: Some([round3(px(i)), round3(py(j)), round3(z)]),
+                            value_mm: Some(round3(gap)),
+                        });
+                    }
+                } else {
+                    restarts.push((i, j, z));
+                }
+            }
+        }
+    }
+    if cracks > opts.max_reported {
+        findings.push(Finding {
+            kind: FindingKind::Crack,
+            severity: Severity::Fail,
+            message: format!(
+                "... and {} further interior cracks (use --max-reported to see more)",
+                cracks - opts.max_reported
+            ),
+            location: None,
+            value_mm: None,
+        });
+    }
+
+    // Group restarts into connected regions: adjacent columns whose restart
+    // heights agree to within a layer or so are one roof.
+    let z_tol = opts.section_step.max(0.4);
+    let mut owner: HashMap<(usize, usize, i64), usize> = HashMap::new();
+    let key = |i: usize, j: usize, z: f64| (i, j, (z / z_tol).round() as i64);
+    let mut groups: Vec<Vec<(usize, usize, f64)>> = Vec::new();
+    let mut lookup: HashMap<(usize, usize, i64), Vec<f64>> = HashMap::new();
+    for &(i, j, z) in &restarts {
+        lookup.entry(key(i, j, z)).or_default().push(z);
+    }
+    for &(i, j, z) in &restarts {
+        let k = key(i, j, z);
+        if owner.contains_key(&k) {
+            continue;
+        }
+        let gid = groups.len();
+        let mut stack = vec![k];
+        owner.insert(k, gid);
+        let mut members = Vec::new();
+        while let Some((ci, cj, cz)) = stack.pop() {
+            let zs = lookup.get(&(ci, cj, cz)).cloned().unwrap_or_default();
+            let zrep = zs.iter().copied().fold(f64::INFINITY, f64::min);
+            members.push((ci, cj, zrep));
+            for (di, dj) in [(1i64, 0i64), (-1, 0), (0, 1), (0, -1)] {
+                let ni = ci as i64 + di;
+                let nj = cj as i64 + dj;
+                if ni < 0 || nj < 0 || ni >= nx as i64 || nj >= ny as i64 {
+                    continue;
+                }
+                for dz in [-1i64, 0, 1] {
+                    let nk = (ni as usize, nj as usize, cz + dz);
+                    if lookup.contains_key(&nk) && !owner.contains_key(&nk) {
+                        owner.insert(nk, gid);
+                        stack.push(nk);
+                    }
+                }
+            }
+        }
+        groups.push(members);
+    }
+
+    let mut bridges = Vec::new();
+    let mut floating = 0usize;
+    for members in &groups {
+        let z = members
+            .iter()
+            .map(|m| m.2)
+            .fold(f64::INFINITY, f64::min);
+        let (mut x0, mut y0) = (f64::INFINITY, f64::INFINITY);
+        for &(i, j, _) in members {
+            x0 = x0.min(px(i));
+            y0 = y0.min(py(j));
+        }
+
+        // How far is this material from something that can hold it up?
+        //
+        // Measuring the region's own footprint would be wrong: a roof over a
+        // slot is unsupported across the slot but continuous along it, and its
+        // bounding diagonal would report the length of the slot rather than
+        // the span the extruder actually has to cross. So walk outward from
+        // every column that carries material continuously through this height
+        // (an anchor) and take the furthest a member sits from one. Twice that
+        // reach is the clear span.
+        let reach = anchor_reach(&cols, nx, ny, members, z, z_tol, pitch);
+        let (anchored, span) = match reach {
+            Some(r) => (true, 2.0 * r),
+            None => (false, f64::INFINITY),
+        };
+        let whitelisted = opts.allow_bridges.iter().any(|(a, b)| z >= *a && z <= *b);
+
+        if whitelisted {
+            // A documented bridge zone: the author has declared that material
+            // starting here is a roof they mean to print. The rana shell is
+            // accepted exactly this way — slot roofs at z 1.75..2.65, top leg
+            // roof wedges at z 25.6..26.25. Cracks never reach this branch:
+            // that verdict is raised above and is not waivable.
+        } else if !anchored {
+            floating += 1;
+            if floating <= opts.max_reported {
+                findings.push(Finding {
+                    kind: FindingKind::FloatingRegion,
+                    severity: Severity::Fail,
+                    message: format!(
+                        "floating region: {} column(s) of material start at z={:.3} with nothing beneath or beside them",
+                        members.len(),
+                        z
+                    ),
+                    location: Some([round3(x0), round3(y0), round3(z)]),
+                    value_mm: None,
+                });
+            }
+        } else if span > opts.max_bridge {
+            floating += 1;
+            findings.push(Finding {
+                kind: FindingKind::OverlongBridge,
+                severity: Severity::Fail,
+                message: format!(
+                    "unsupported span {:.2} mm at z={:.3} exceeds the {:.2} mm bridge limit",
+                    span, z, opts.max_bridge
+                ),
+                location: Some([round3(x0), round3(y0), round3(z)]),
+                value_mm: Some(round3(span)),
+            });
+        }
+        if anchored {
+            bridges.push(BridgeSpan {
+                z: round3(z),
+                span_mm: round3(span),
+                columns: members.len(),
+                anchored,
+                whitelisted,
+            });
+        }
+    }
+    bridges.sort_by(|a, b| b.span_mm.partial_cmp(&a.span_mm).unwrap());
+    bridges.truncate(opts.max_reported);
+
+    let summary = ColumnSummary {
+        columns_sampled: nx * ny,
+        columns_with_material: cols.iter().filter(|c| c.is_some()).count(),
+        cracks,
+        thinnest_gap_mm: thinnest.map(round3),
+        floating_regions: floating,
+        bridges,
+    };
+    (summary, findings)
+}
+
+// ---------------------------------------------------------------------------
+// overhang census
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OverhangSummary {
+    pub max_overhang_deg: f64,
+    /// Area of near-horizontal downward faces (roofs and bridges).
+    pub roof_area_mm2: f64,
+    /// Downward faces steeper than the limit — these need support.
+    pub unsupported_area_mm2: f64,
+    /// Downward faces the printer can staircase its way up.
+    pub self_supporting_area_mm2: f64,
+    pub downward_area_mm2: f64,
+    pub total_area_mm2: f64,
+    pub verdict: String,
+}
+
+/// Area-weighted census of downward-facing facets.
+///
+/// `phi` is the angle between the outward facet normal and straight down: 0°
+/// is a flat roof, 90° a vertical wall. A facet self-supports when its
+/// deviation from vertical (90 - phi) stays within `max_overhang`.
+pub fn check_overhangs(mesh: &Mesh, opts: &Options) -> (OverhangSummary, Vec<Finding>) {
+    let mut roof = 0.0;
+    let mut unsupported = 0.0;
+    let mut selfsup = 0.0;
+    let mut down = 0.0;
+    let mut total = 0.0;
+    for t in &mesh.tris {
+        let u = sub(t[1], t[0]);
+        let v = sub(t[2], t[0]);
+        let c = cross(u, v);
+        let area2 = norm(c);
+        if area2 < 1e-12 {
+            continue;
+        }
+        let area = area2 / 2.0;
+        total += area;
+        let nz = c[2] / area2;
+        if nz >= 0.0 {
+            continue;
+        }
+        down += area;
+        let phi = (-nz).clamp(-1.0, 1.0).acos().to_degrees();
+        if phi <= opts.roof_deg {
+            roof += area;
+        } else if 90.0 - phi > opts.max_overhang {
+            unsupported += area;
+        } else {
+            selfsup += area;
+        }
+    }
+
+    let mut findings = Vec::new();
+    let verdict = if unsupported <= 1e-9 {
+        format!(
+            "every sloped downward face stays within {:.0}° of vertical — staircase, no support needed",
+            opts.max_overhang
+        )
+    } else {
+        let msg = format!(
+            "{:.1} mm² of downward faces exceed {:.0}° from vertical — support material required",
+            unsupported, opts.max_overhang
+        );
+        findings.push(Finding {
+            kind: FindingKind::Overhang,
+            severity: if opts.strict_overhangs {
+                Severity::Fail
+            } else {
+                Severity::Warn
+            },
+            message: msg.clone(),
+            location: None,
+            value_mm: None,
+        });
+        msg
+    };
+
+    (
+        OverhangSummary {
+            max_overhang_deg: opts.max_overhang,
+            roof_area_mm2: round3(roof),
+            unsupported_area_mm2: round3(unsupported),
+            self_supporting_area_mm2: round3(selfsup),
+            downward_area_mm2: round3(down),
+            total_area_mm2: round3(total),
+            verdict,
+        },
+        findings,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// min wall / min feature
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct WallSummary {
+    pub nozzle_mm: f64,
+    pub min_feature_mm: Option<f64>,
+    /// Interior columns (all four in-plane neighbours also solid) whose
+    /// material is thinner than the nozzle.
+    pub thin_columns: usize,
+    pub axis: Option<&'static str>,
+}
+
+/// Minimum wall / feature thickness, measured along all three axes.
+///
+/// A vertical ray cannot see a thin vertical wall — it runs *along* it. rana
+/// shipped a 0.2 mm comb wall that no vertical analysis caught and only the
+/// failed print revealed, so this casts sideways too.
+///
+/// Two filters keep silhouettes from faking thin walls. A curved surface
+/// grazed by a ray returns a chord that says nothing about its thickness, so a
+/// span counts only when BOTH of its end faces are hit within `wall_align`
+/// of head-on; and the column must be interior, with all four in-plane
+/// neighbours solid at the same height.
+pub fn check_walls(mesh: &Mesh, opts: &Options) -> (WallSummary, Vec<Finding>) {
+    let axes = [(0usize, "x"), (1, "y"), (2, "z")];
+    let mut best: Option<(f64, &'static str, [f64; 3])> = None;
+    let mut thin_total = 0usize;
+    let mut worst_axis = None;
+
+    for (axis, name) in axes {
+        let m = mesh.permuted(axis);
+        let (lo, hi) = m.bounds();
+        let idx = RayIndex::build(&m);
+        let (nx, ny, pitch) = grid_dims(lo, hi, opts.pitch, opts.max_columns);
+        let px = |i: usize| lo[0] + (i as f64 + 0.5 + 0.0193) * pitch;
+        let py = |j: usize| lo[1] + (j as f64 + 0.5 + 0.0271) * pitch;
+        let mut cols: Vec<Vec<crate::mesh::Span>> = Vec::with_capacity(nx * ny);
+        for j in 0..ny {
+            for i in 0..nx {
+                let cr = idx.crossings(px(i), py(j));
+                if cr.len() % 2 == 1 {
+                    cols.push(Vec::new());
+                } else {
+                    cols.push(crate::mesh::solid_spans(&cr));
+                }
+            }
+        }
+        let solid_at = |i: i64, j: i64, z: f64| -> bool {
+            if i < 0 || j < 0 || i >= nx as i64 || j >= ny as i64 {
+                return false;
+            }
+            cols[j as usize * nx + i as usize]
+                .iter()
+                .any(|s| s.lo <= z && s.hi >= z)
+        };
+        for j in 0..ny {
+            for i in 0..nx {
+                for sp in &cols[j * nx + i] {
+                    if sp.align < opts.wall_align || !sp.opposing {
+                        // grazing (a silhouette chord) or a taper (a chamfer
+                        // feathering to an edge) — neither is a wall thickness
+                        continue;
+                    }
+                    if sp.void_before < opts.crack_threshold
+                        || sp.void_after < opts.crack_threshold
+                    {
+                        // Hairline either side: a mesh seam sliced out of solid
+                        // material, not a wall standing in air. Whether that
+                        // hairline is itself acceptable is the crack check's
+                        // question, not this one's.
+                        continue;
+                    }
+                    let t = sp.hi - sp.lo;
+                    let mid = (sp.lo + sp.hi) / 2.0;
+                    let interior = [(1i64, 0i64), (-1, 0), (0, 1), (0, -1)]
+                        .iter()
+                        .all(|(di, dj)| solid_at(i as i64 + di, j as i64 + dj, mid));
+                    if !interior {
+                        continue;
+                    }
+                    if best.is_none() || t < best.unwrap().0 {
+                        // report the location back in the print frame
+                        let p = match axis {
+                            0 => [mid, px(i), py(j)],
+                            1 => [py(j), mid, px(i)],
+                            _ => [px(i), py(j), mid],
+                        };
+                        best = Some((t, name, p));
+                    }
+                    if t < opts.nozzle {
+                        thin_total += 1;
+                        worst_axis = Some(name);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut findings = Vec::new();
+    if thin_total >= opts.min_thin_columns {
+        if let Some((t, name, p)) = best {
+            findings.push(Finding {
+                kind: FindingKind::ThinWall,
+                severity: Severity::Fail,
+                message: format!(
+                    "min feature {:.3} mm along {name} ({thin_total} interior samples below the {:.2} mm nozzle) — unprintable",
+                    t, opts.nozzle
+                ),
+                location: Some([round3(p[0]), round3(p[1]), round3(p[2])]),
+                value_mm: Some(round3(t)),
+            });
+        }
+    }
+
+    (
+        WallSummary {
+            nozzle_mm: opts.nozzle,
+            min_feature_mm: best.map(|b| round3(b.0)),
+            thin_columns: thin_total,
+            axis: worst_axis,
+        },
+        findings,
+    )
+}
+
+// ---------------------------------------------------------------------------
+
+/// Column counts and a square sampling pitch covering the XY footprint.
+///
+/// The pitch is set by the feature size being looked for — the nozzle — not by
+/// a fixed column count over the bounding box. A 70 mm part sampled 64 columns
+/// wide puts 1.1 mm between rays, which straddles a 2 mm tube wall: neighbours
+/// land in air, so roofs read as unanchored and spans get measured across the
+/// bore. `max_columns` keeps a large part from exploding the grid.
+fn grid_dims(lo: [f64; 3], hi: [f64; 3], pitch: f64, max_columns: usize) -> (usize, usize, f64) {
+    let sx = (hi[0] - lo[0]).max(1e-6);
+    let sy = (hi[1] - lo[1]).max(1e-6);
+    let longest = sx.max(sy);
+    let pitch = pitch.max(longest / max_columns as f64);
+    let nx = ((sx / pitch).ceil() as usize).max(1);
+    let ny = ((sy / pitch).ceil() as usize).max(1);
+    (nx, ny, pitch)
+}
+
+/// Furthest distance, in mm, from a member of `members` to the nearest column
+/// that carries material continuously through height `z`.
+///
+/// Multi-source BFS from the anchors, propagating only through columns that
+/// have material at `z` — either an anchor or a member of the region. A region
+/// no anchor can reach is floating, and returns `None`.
+fn anchor_reach(
+    cols: &[Option<Column>],
+    nx: usize,
+    ny: usize,
+    members: &[(usize, usize, f64)],
+    z: f64,
+    tol: f64,
+    pitch: f64,
+) -> Option<f64> {
+    // Anything holding material at roughly this height can carry the walk:
+    // the region's own columns, an anchor, or a neighbouring roof cell that
+    // landed in a different height bucket. Restricting the walk to this
+    // region's members alone orphans single columns off a curved roof, whose
+    // restart heights straddle a bucket boundary, and reports them as
+    // floating when they are part of the roof next door.
+    let passable = |i: usize, j: usize| -> bool {
+        cols[j * nx + i].as_ref().is_some_and(|c| {
+            c.iv.iter()
+                .any(|(a, b)| *a <= z + tol && *b >= z - tol)
+        })
+    };
+    let mut dist = vec![u32::MAX; nx * ny];
+    let mut queue = std::collections::VecDeque::new();
+    for j in 0..ny {
+        for i in 0..nx {
+            if cols[j * nx + i].as_ref().is_some_and(|c| c.supports(z)) {
+                dist[j * nx + i] = 0;
+                queue.push_back((i, j));
+            }
+        }
+    }
+    if queue.is_empty() {
+        return None;
+    }
+    while let Some((i, j)) = queue.pop_front() {
+        let d = dist[j * nx + i];
+        for (di, dj) in [(1i64, 0i64), (-1, 0), (0, 1), (0, -1)] {
+            let (ni, nj) = (i as i64 + di, j as i64 + dj);
+            if ni < 0 || nj < 0 || ni >= nx as i64 || nj >= ny as i64 {
+                continue;
+            }
+            let (ni, nj) = (ni as usize, nj as usize);
+            if dist[nj * nx + ni] != u32::MAX || !passable(ni, nj) {
+                continue;
+            }
+            dist[nj * nx + ni] = d + 1;
+            queue.push_back((ni, nj));
+        }
+    }
+    let mut worst = 0u32;
+    for &(i, j, _) in members {
+        let d = dist[j * nx + i];
+        if d == u32::MAX {
+            return None; // unreachable from any anchor: floating
+        }
+        worst = worst.max(d);
+    }
+    Some(worst as f64 * pitch)
+}
+
+fn sub(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [a[0] - b[0], a[1] - b[1], a[2] - b[2]]
+}
+fn cross(a: [f64; 3], b: [f64; 3]) -> [f64; 3] {
+    [
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    ]
+}
+fn norm(a: [f64; 3]) -> f64 {
+    (a[0] * a[0] + a[1] * a[1] + a[2] * a[2]).sqrt()
+}
+pub(crate) fn round3(v: f64) -> f64 {
+    (v * 1000.0).round() / 1000.0
+}

--- a/crates/vcad-printcheck/src/lib.rs
+++ b/crates/vcad-printcheck/src/lib.rs
@@ -1,0 +1,296 @@
+//! Printability lint for an **exported** mesh in a chosen print orientation.
+//!
+//! FDM printability is a property of the shipped file, not of the model that
+//! produced it. A rana shell variant passed its author's analytic profile
+//! verification while the discretised STL carried 0.05 mm cracks across 85% of
+//! its circumference; only raycasts on the export caught it. So every check
+//! here reads triangles.
+//!
+//! What it reports:
+//!
+//! 1. floating regions / mid-air islands (per-column support raycasts)
+//! 2. interior cracks — material gaps below a threshold (default 0.15 mm)
+//! 3. overhang census against a max angle, with the staircase-vs-support verdict
+//! 4. bridge spans, with lengths
+//! 5. min wall / min feature against the nozzle width
+//! 6. manifold + closed-sections summary
+//!
+//! The verdict is a clean/dirty boolean so it can gate CI.
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use vcad_printcheck::{check_file, Options};
+//!
+//! let report = check_file(Path::new("part.stl"), &Options::default()).unwrap();
+//! assert!(report.ok);
+//! ```
+
+pub mod checks;
+pub mod mesh;
+
+use std::path::Path;
+
+pub use mesh::{Mesh, MeshError, Orientation};
+
+/// Knobs. Defaults are the rana field conventions: 0.4 mm nozzle, 4 mm bridge
+/// ceiling, 0.15 mm crack threshold, 45° self-support limit.
+#[derive(Debug, Clone)]
+pub struct Options {
+    pub orientation: Orientation,
+    /// Nozzle width; anything thinner than this cannot be extruded.
+    pub nozzle: f64,
+    /// Longest unsupported span accepted without support material.
+    pub max_bridge: f64,
+    /// Material gaps below this are cracks, not channels. Never whitelistable.
+    pub crack_threshold: f64,
+    /// Self-support limit, degrees from vertical.
+    pub max_overhang: f64,
+    /// Downward faces within this many degrees of horizontal are roofs /
+    /// bridges and are judged by the bridge span rule, not the overhang rule.
+    pub roof_deg: f64,
+    /// Turn the overhang census into a failure rather than a warning.
+    pub strict_overhangs: bool,
+    /// Distance between raycast columns, mm. Defaults to the nozzle width:
+    /// the checks look for nozzle-scale defects, so they have to sample at
+    /// nozzle scale. Finer costs time; coarser starts missing walls.
+    pub pitch: f64,
+    /// Hard cap on columns across the longer axis, so a large part cannot
+    /// blow up the grid however fine the pitch.
+    pub max_columns: usize,
+    /// Minimum |cos| between a ray and the faces it enters and leaves through
+    /// before its span counts as a wall thickness. 0.5 = within 60° of
+    /// head-on. Below this the ray is grazing a curved surface and its chord
+    /// measures the silhouette, not the wall.
+    pub wall_align: f64,
+    /// Section sampling pitch, mm.
+    pub section_step: f64,
+    /// Height above the lowest point of the mesh that still counts as sitting
+    /// on the build plate — the first layer. A chamfered or filleted rim
+    /// contacts the plate along a ring narrower than any sampling pitch, so
+    /// without this every such part reports its own bottom edge as floating.
+    pub bed_tol: f64,
+    /// Height ranges where an unsupported span is a known, accepted bridge.
+    /// Cracks are never exempted.
+    pub allow_bridges: Vec<(f64, f64)>,
+    /// Interior thin samples needed before a min-wall failure is raised.
+    pub min_thin_columns: usize,
+    /// Cap on findings of one kind printed before they are summarised.
+    pub max_reported: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Options {
+            orientation: Orientation::ZUp,
+            nozzle: 0.4,
+            max_bridge: 4.0,
+            crack_threshold: 0.15,
+            max_overhang: 45.0,
+            roof_deg: 10.0,
+            strict_overhangs: false,
+            pitch: 0.4,
+            max_columns: 512,
+            wall_align: 0.5,
+            section_step: 0.4,
+            bed_tol: 0.4,
+            allow_bridges: Vec::new(),
+            min_thin_columns: 3,
+            max_reported: 12,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Warn,
+    Fail,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingKind {
+    NonManifold,
+    EmptyLayer,
+    OpenSection,
+    Crack,
+    FloatingRegion,
+    OverlongBridge,
+    Overhang,
+    ThinWall,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Finding {
+    pub kind: FindingKind,
+    pub severity: Severity,
+    pub message: String,
+    /// A representative point, in the print frame.
+    pub location: Option<[f64; 3]>,
+    pub value_mm: Option<f64>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct Report {
+    pub file: String,
+    pub orientation: String,
+    pub manifold: checks::ManifoldSummary,
+    pub sections: checks::SectionSummary,
+    pub columns: checks::ColumnSummary,
+    pub overhangs: checks::OverhangSummary,
+    pub walls: checks::WallSummary,
+    pub findings: Vec<Finding>,
+    /// True when nothing failed. Warnings do not dirty the verdict.
+    pub ok: bool,
+}
+
+impl Report {
+    pub fn failures(&self) -> impl Iterator<Item = &Finding> {
+        self.findings
+            .iter()
+            .filter(|f| f.severity == Severity::Fail)
+    }
+
+    pub fn has(&self, kind: FindingKind) -> bool {
+        self.findings
+            .iter()
+            .any(|f| f.kind == kind && f.severity == Severity::Fail)
+    }
+}
+
+/// Load an STL and run every check.
+pub fn check_file(path: &Path, opts: &Options) -> Result<Report, MeshError> {
+    let mesh = Mesh::load_stl(path, opts.orientation)?;
+    Ok(check_mesh(&mesh, path.display().to_string(), opts))
+}
+
+/// Run every check on an already-loaded mesh (already in the print frame).
+pub fn check_mesh(mesh: &Mesh, name: String, opts: &Options) -> Report {
+    let mut findings = Vec::new();
+    let (manifold, f) = checks::check_manifold(mesh);
+    findings.extend(f);
+    let (sections, f) = checks::check_sections(mesh, opts);
+    findings.extend(f);
+    let (columns, f) = checks::check_columns(mesh, opts);
+    findings.extend(f);
+    let (overhangs, f) = checks::check_overhangs(mesh, opts);
+    findings.extend(f);
+    let (walls, f) = checks::check_walls(mesh, opts);
+    findings.extend(f);
+
+    let ok = !findings.iter().any(|f| f.severity == Severity::Fail);
+    Report {
+        file: name,
+        orientation: format!("{:?}", opts.orientation),
+        manifold,
+        sections,
+        columns,
+        overhangs,
+        walls,
+        findings,
+        ok,
+    }
+}
+
+/// Human-readable report, the shape `vcad check` prints.
+pub fn render_text(r: &Report) -> String {
+    use std::fmt::Write;
+    let mut s = String::new();
+    let _ = writeln!(s, "printability: {}  [{}]", r.file, r.orientation);
+    let _ = writeln!(
+        s,
+        "  mesh       {} triangles, {} edges, {}",
+        r.manifold.triangles,
+        r.manifold.edges,
+        if r.manifold.bad_edges == 0 {
+            "manifold".to_string()
+        } else {
+            format!("{} BAD EDGES", r.manifold.bad_edges)
+        }
+    );
+    let _ = writeln!(
+        s,
+        "  sections   {} sampled over z {:.2}..{:.2}, {} empty, {} open",
+        r.sections.sections,
+        r.sections.z_min,
+        r.sections.z_max,
+        r.sections.empty_layers.len(),
+        r.sections.open_sections.len()
+    );
+    let _ = writeln!(
+        s,
+        "  columns    {}/{} carry material; {} crack(s), thinnest gap {}",
+        r.columns.columns_with_material,
+        r.columns.columns_sampled,
+        r.columns.cracks,
+        r.columns
+            .thinnest_gap_mm
+            .map(|g| format!("{g:.3} mm"))
+            .unwrap_or_else(|| "n/a".into())
+    );
+    let _ = writeln!(
+        s,
+        "  floating   {} region(s) with nothing beneath or beside them",
+        r.columns.floating_regions
+    );
+    if r.columns.bridges.is_empty() {
+        let _ = writeln!(s, "  bridges    none");
+    } else {
+        let _ = writeln!(s, "  bridges    {} span(s), longest first:", r.columns.bridges.len());
+        for b in &r.columns.bridges {
+            let _ = writeln!(
+                s,
+                "               {:.2} mm at z={:.3} ({} columns){}",
+                b.span_mm,
+                b.z,
+                b.columns,
+                if b.whitelisted { "  [allowed]" } else { "" }
+            );
+        }
+    }
+    let _ = writeln!(s, "  overhangs  {}", r.overhangs.verdict);
+    let _ = writeln!(
+        s,
+        "             roofs {:.1} mm², self-supporting {:.1} mm², downward {:.1} of {:.1} mm² total",
+        r.overhangs.roof_area_mm2,
+        r.overhangs.self_supporting_area_mm2,
+        r.overhangs.downward_area_mm2,
+        r.overhangs.total_area_mm2
+    );
+    let _ = writeln!(
+        s,
+        "  min wall   {} vs {:.2} mm nozzle ({} interior samples below)",
+        r.walls
+            .min_feature_mm
+            .map(|t| format!("{t:.3} mm"))
+            .unwrap_or_else(|| "n/a".into()),
+        r.walls.nozzle_mm,
+        r.walls.thin_columns
+    );
+    if r.findings.is_empty() {
+        let _ = writeln!(s, "\nPRINTABILITY PASS");
+    } else {
+        s.push('\n');
+        for f in &r.findings {
+            let tag = match f.severity {
+                Severity::Fail => "FAIL",
+                Severity::Warn => "warn",
+            };
+            let loc = f
+                .location
+                .map(|p| format!("  @ ({:.2}, {:.2}, {:.2})", p[0], p[1], p[2]))
+                .unwrap_or_default();
+            let _ = writeln!(s, "  {tag}  {}{loc}", f.message);
+        }
+        let _ = writeln!(
+            s,
+            "\n{}",
+            if r.ok {
+                "PRINTABILITY PASS (warnings only)"
+            } else {
+                "PRINTABILITY FAIL"
+            }
+        );
+    }
+    s
+}

--- a/crates/vcad-printcheck/src/mesh.rs
+++ b/crates/vcad-printcheck/src/mesh.rs
@@ -1,0 +1,339 @@
+//! Triangle soup + the ray machinery every check is built on.
+//!
+//! The checks here deliberately run on the *exported* triangle soup rather
+//! than on a BRep or on the generator's own parameters. The rana `60c` shell
+//! passed its author's analytic profile verification while the shipped STL
+//! had 0.05 mm cracks around 85% of its circumference: only rays cast at the
+//! file caught it. See `crates/vcad-printcheck/README.md`.
+
+use std::path::Path;
+
+/// A loaded triangle soup, in millimetres, already rotated so that the print
+/// direction is `+Z`.
+#[derive(Clone, Debug, Default)]
+pub struct Mesh {
+    pub tris: Vec<[[f64; 3]; 3]>,
+}
+
+/// Which model axis points up on the build plate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Orientation {
+    ZUp,
+    ZDown,
+    XUp,
+    XDown,
+    YUp,
+    YDown,
+}
+
+impl Orientation {
+    /// Parse the CLI spelling (`z`, `-z`, `x`, `-x`, `y`, `-y`).
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "z" | "+z" | "z+" | "zup" => Some(Orientation::ZUp),
+            "-z" | "z-" | "zdown" => Some(Orientation::ZDown),
+            "x" | "+x" | "x+" | "xup" => Some(Orientation::XUp),
+            "-x" | "x-" | "xdown" => Some(Orientation::XDown),
+            "y" | "+y" | "y+" | "yup" => Some(Orientation::YUp),
+            "-y" | "y-" | "ydown" => Some(Orientation::YDown),
+            _ => None,
+        }
+    }
+
+    /// Rotate a point so the chosen axis becomes `+Z`. These are proper
+    /// rotations (determinant +1), so triangle winding — and therefore the
+    /// facet normals the overhang census reads — survives the change.
+    fn apply(self, p: [f64; 3]) -> [f64; 3] {
+        let [x, y, z] = p;
+        match self {
+            Orientation::ZUp => [x, y, z],
+            Orientation::ZDown => [x, -y, -z],
+            Orientation::XUp => [y, z, x],
+            Orientation::XDown => [-y, z, -x],
+            Orientation::YUp => [z, x, y],
+            Orientation::YDown => [z, -x, -y],
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MeshError {
+    #[error("read {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("mesh has no triangles: {0}")]
+    Empty(String),
+}
+
+impl Mesh {
+    /// Load a binary or ASCII STL, rotated into the print frame.
+    pub fn load_stl(path: &Path, orientation: Orientation) -> Result<Mesh, MeshError> {
+        let file = std::fs::File::open(path).map_err(|e| MeshError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+        let mut reader = std::io::BufReader::new(file);
+        let stl = stl_io::read_stl(&mut reader).map_err(|e| MeshError::Io {
+            path: path.display().to_string(),
+            source: e,
+        })?;
+
+        let mut tris = Vec::with_capacity(stl.faces.len());
+        for face in &stl.faces {
+            let mut t = [[0.0; 3]; 3];
+            for (i, vi) in face.vertices.iter().enumerate() {
+                let v = stl.vertices[*vi];
+                t[i] = orientation.apply([v[0] as f64, v[1] as f64, v[2] as f64]);
+            }
+            tris.push(t);
+        }
+        if tris.is_empty() {
+            return Err(MeshError::Empty(path.display().to_string()));
+        }
+        Ok(Mesh { tris })
+    }
+
+    /// Axis-aligned bounds as `([min], [max])`.
+    pub fn bounds(&self) -> ([f64; 3], [f64; 3]) {
+        let mut lo = [f64::INFINITY; 3];
+        let mut hi = [f64::NEG_INFINITY; 3];
+        for t in &self.tris {
+            for v in t {
+                for k in 0..3 {
+                    lo[k] = lo[k].min(v[k]);
+                    hi[k] = hi[k].max(v[k]);
+                }
+            }
+        }
+        (lo, hi)
+    }
+
+    /// A copy with coordinates cycled so that `axis` (0=X, 1=Y, 2=Z) plays the
+    /// role of the ray direction. Used by the min-wall check, which needs to
+    /// measure material thickness along all three axes — a 0.2 mm vertical
+    /// comb wall is invisible to a vertical ray and only shows up sideways.
+    pub fn permuted(&self, axis: usize) -> Mesh {
+        if axis == 2 {
+            return self.clone();
+        }
+        let tris = self
+            .tris
+            .iter()
+            .map(|t| {
+                let mut out = [[0.0; 3]; 3];
+                for (i, v) in t.iter().enumerate() {
+                    out[i] = match axis {
+                        // cyclic permutations keep the winding, so parity stays
+                        // meaningful along the permuted ray
+                        0 => [v[1], v[2], v[0]],
+                        _ => [v[2], v[0], v[1]],
+                    };
+                }
+                out
+            })
+            .collect();
+        Mesh { tris }
+    }
+}
+
+/// Uniform XY bucket grid over triangle bounding boxes, so a vertical ray only
+/// tests the triangles that can possibly contain it.
+pub struct RayIndex<'a> {
+    tris: &'a [[[f64; 3]; 3]],
+    min: [f64; 2],
+    cell: f64,
+    nx: usize,
+    ny: usize,
+    buckets: Vec<Vec<u32>>,
+}
+
+impl<'a> RayIndex<'a> {
+    pub fn build(mesh: &'a Mesh) -> RayIndex<'a> {
+        let (lo, hi) = mesh.bounds();
+        let span_x = (hi[0] - lo[0]).max(1e-6);
+        let span_y = (hi[1] - lo[1]).max(1e-6);
+        // ~128 cells across the longer axis, clamped so a huge mesh does not
+        // explode the bucket count.
+        let target = (span_x.max(span_y)) / 128.0;
+        let cell = target.max(1e-3);
+        let nx = ((span_x / cell).ceil() as usize + 1).min(4096);
+        let ny = ((span_y / cell).ceil() as usize + 1).min(4096);
+        let mut buckets = vec![Vec::new(); nx * ny];
+        for (i, t) in mesh.tris.iter().enumerate() {
+            let (mut x0, mut x1) = (f64::INFINITY, f64::NEG_INFINITY);
+            let (mut y0, mut y1) = (f64::INFINITY, f64::NEG_INFINITY);
+            for v in t {
+                x0 = x0.min(v[0]);
+                x1 = x1.max(v[0]);
+                y0 = y0.min(v[1]);
+                y1 = y1.max(v[1]);
+            }
+            let cx0 = (((x0 - lo[0]) / cell).floor().max(0.0) as usize).min(nx - 1);
+            let cx1 = (((x1 - lo[0]) / cell).floor().max(0.0) as usize).min(nx - 1);
+            let cy0 = (((y0 - lo[1]) / cell).floor().max(0.0) as usize).min(ny - 1);
+            let cy1 = (((y1 - lo[1]) / cell).floor().max(0.0) as usize).min(ny - 1);
+            for cy in cy0..=cy1 {
+                for cx in cx0..=cx1 {
+                    buckets[cy * nx + cx].push(i as u32);
+                }
+            }
+        }
+        RayIndex {
+            tris: &mesh.tris,
+            min: [lo[0], lo[1]],
+            cell,
+            nx,
+            ny,
+            buckets,
+        }
+    }
+
+    /// Sorted crossings of a vertical ray at `(x, y)` with the surface.
+    ///
+    /// Ported from `rana tools/support-check.py::crossings` — barycentric
+    /// solve in the XY plane, `u`/`v` inclusive to a 1e-9 tolerance.
+    pub fn crossings(&self, x: f64, y: f64) -> Vec<Crossing> {
+        let cx = (((x - self.min[0]) / self.cell).floor()).max(0.0) as usize;
+        let cy = (((y - self.min[1]) / self.cell).floor()).max(0.0) as usize;
+        if cx >= self.nx || cy >= self.ny {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        for &ti in &self.buckets[cy * self.nx + cx] {
+            let t = &self.tris[ti as usize];
+            let (a, b, c) = (t[0], t[1], t[2]);
+            let d1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+            let d2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+            let den = d1[0] * d2[1] - d1[1] * d2[0];
+            if den.abs() < 1e-12 {
+                continue;
+            }
+            let u = ((x - a[0]) * d2[1] - (y - a[1]) * d2[0]) / den;
+            let v = (d1[0] * (y - a[1]) - d1[1] * (x - a[0])) / den;
+            if u < -1e-9 || v < -1e-9 || u + v > 1.0 + 1e-9 {
+                continue;
+            }
+            // Unit facet normal. The min-wall check reads two things off it:
+            // how squarely the ray hits the surface (|n·ray|, near 0 means the
+            // ray skims and its chord means nothing), and whether the faces at
+            // the two ends of a span oppose each other — thickness is only
+            // defined between opposing surfaces, never across a taper.
+            let mut n = [
+                d1[1] * d2[2] - d1[2] * d2[1],
+                d1[2] * d2[0] - d1[0] * d2[2],
+                den,
+            ];
+            let nlen = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+            if nlen > 0.0 {
+                n = [n[0] / nlen, n[1] / nlen, n[2] / nlen];
+            }
+            out.push(Crossing {
+                z: a[2] + u * d1[2] + v * d2[2],
+                normal: n,
+            });
+        }
+        out.sort_by(|p, q| p.z.partial_cmp(&q.z).unwrap_or(std::cmp::Ordering::Equal));
+        out
+    }
+}
+
+/// Where a ray meets the surface, and how squarely it hits it.
+#[derive(Clone, Copy, Debug)]
+pub struct Crossing {
+    pub z: f64,
+    /// Unit normal of the facet that was hit, in the ray's frame (the ray runs
+    /// along `+Z`, so `normal[2]` is the cosine of the incidence angle).
+    pub normal: [f64; 3],
+}
+
+impl Crossing {
+    /// |cos| between ray and surface: 1 = head on, 0 = grazing.
+    pub fn align(&self) -> f64 {
+        self.normal[2].abs()
+    }
+}
+
+/// Material intervals along a ray, by STRICT PARITY (odd crossing count =
+/// inside) — exactly what a slicer's mesh analysis sees.
+///
+/// Parity is chosen over a winding-number sum on purpose. Parity reads a
+/// z-overlap between two *separate* bodies as an interior void strip, and that
+/// is a defect we want flagged: rana finding #11 was a rim chamfer ring
+/// overlapping the sector columns by 0.05 mm, which parity showed as a 0.05 mm
+/// crack ring at both rims. The first version of that checker used a winding
+/// sum with an inverted sign, saw zero material anywhere, and passed
+/// vacuously — hence the fixtures in `tests/`.
+pub fn intervals(crossings: &[Crossing]) -> Vec<(f64, f64)> {
+    solid_spans(crossings)
+        .into_iter()
+        .map(|s| (s.lo, s.hi))
+        .collect()
+}
+
+/// One run of material along a ray.
+#[derive(Clone, Copy, Debug)]
+pub struct Span {
+    pub lo: f64,
+    pub hi: f64,
+    /// The weaker of the two end faces' alignments with the ray. A span whose
+    /// ends are both grazed is a silhouette chord, not a wall thickness.
+    pub align: f64,
+    /// Do the faces at the two ends point away from each other? Only then is
+    /// the span a thickness between two surfaces of one wall. A chamfer or
+    /// fillet feathering to an edge produces short spans between faces that
+    /// meet rather than oppose — real geometry, but not a thin wall, and
+    /// enough of them to bury every genuine finding.
+    pub opposing: bool,
+    /// Distance to the previous and next material along the same ray;
+    /// infinite where the span faces open air.
+    ///
+    /// A wall is only thin if what sits either side of it is a real void. The
+    /// rana shell is meshed as 0.5° sector prisms whose seams parity reads as
+    /// 0.06 mm gaps, which turns a solid 2 mm tube into a stack of 0.24 mm
+    /// "walls" for any ray that crosses the seams. Those slabs have a hairline
+    /// either side, so this pair is what tells them apart from a comb wall
+    /// standing in open air.
+    pub void_before: f64,
+    pub void_after: f64,
+}
+
+pub fn solid_spans(crossings: &[Crossing]) -> Vec<Span> {
+    let mut iv: Vec<Span> = Vec::new();
+    let mut inside = false;
+    let mut start = Crossing {
+        z: 0.0,
+        normal: [0.0; 3],
+    };
+    for &c in crossings {
+        if !inside {
+            start = c;
+        } else {
+            let dot = start.normal[0] * c.normal[0]
+                + start.normal[1] * c.normal[1]
+                + start.normal[2] * c.normal[2];
+            iv.push(Span {
+                lo: start.z,
+                hi: c.z,
+                align: start.align().min(c.align()),
+                // within 30° of exactly opposed
+                opposing: dot <= -0.866,
+                void_before: f64::INFINITY,
+                void_after: f64::INFINITY,
+            });
+        }
+        inside = !inside;
+    }
+    iv.retain(|s| s.hi - s.lo > 1e-4);
+    for k in 0..iv.len() {
+        if k > 0 {
+            iv[k].void_before = iv[k].lo - iv[k - 1].hi;
+        }
+        if k + 1 < iv.len() {
+            iv[k].void_after = iv[k + 1].lo - iv[k].hi;
+        }
+    }
+    iv
+}

--- a/crates/vcad-printcheck/tests/fixtures/mod.rs
+++ b/crates/vcad-printcheck/tests/fixtures/mod.rs
@@ -1,0 +1,261 @@
+//! Synthetic STL fixtures — known-good and known-bad.
+//!
+//! The issue this crate answers records an acceptance protocol learned the
+//! hard way: a checker whose sign was inverted passed *vacuously* for a whole
+//! revision because nothing ever proved it could fail. So every check ships a
+//! mesh it must reject, and the tests assert the specific diagnosis, not just
+//! a non-zero exit.
+
+#![allow(dead_code)]
+
+use std::io::Write;
+
+/// Axis-aligned box as 12 triangles, wound outward (CCW seen from outside).
+pub fn cuboid(min: [f64; 3], max: [f64; 3]) -> Vec<[[f64; 3]; 3]> {
+    let (x0, y0, z0) = (min[0], min[1], min[2]);
+    let (x1, y1, z1) = (max[0], max[1], max[2]);
+    let v = [
+        [x0, y0, z0],
+        [x1, y0, z0],
+        [x1, y1, z0],
+        [x0, y1, z0],
+        [x0, y0, z1],
+        [x1, y0, z1],
+        [x1, y1, z1],
+        [x0, y1, z1],
+    ];
+    let quads = [
+        [0, 3, 2, 1], // bottom (-Z)
+        [4, 5, 6, 7], // top (+Z)
+        [0, 1, 5, 4], // -Y
+        [1, 2, 6, 5], // +X
+        [2, 3, 7, 6], // +Y
+        [3, 0, 4, 7], // -X
+    ];
+    let mut tris = Vec::with_capacity(12);
+    for q in quads {
+        tris.push([v[q[0]], v[q[1]], v[q[2]]]);
+        tris.push([v[q[0]], v[q[2]], v[q[3]]]);
+    }
+    tris
+}
+
+/// Extrude a simple polygon in the XZ plane along Y into a closed,
+/// manifold solid. Fixtures that need internal features (a portal, a T) are
+/// built this way rather than by stacking boxes: two boxes sharing a face are
+/// non-manifold and the checker would — correctly — reject them for the wrong
+/// reason.
+///
+/// `profile` is counter-clockwise in (x, z).
+pub fn prism(profile: &[[f64; 2]], y0: f64, y1: f64) -> Vec<[[f64; 3]; 3]> {
+    let cap = triangulate(profile);
+    let mut tris = Vec::new();
+    // -Y cap, wound so its normal points at -Y
+    for [a, b, c] in &cap {
+        tris.push([
+            [profile[*a][0], y0, profile[*a][1]],
+            [profile[*c][0], y0, profile[*c][1]],
+            [profile[*b][0], y0, profile[*b][1]],
+        ]);
+    }
+    for [a, b, c] in &cap {
+        tris.push([
+            [profile[*a][0], y1, profile[*a][1]],
+            [profile[*b][0], y1, profile[*b][1]],
+            [profile[*c][0], y1, profile[*c][1]],
+        ]);
+    }
+    let n = profile.len();
+    for i in 0..n {
+        let p = profile[i];
+        let q = profile[(i + 1) % n];
+        let (a, b) = ([p[0], y0, p[1]], [q[0], y0, q[1]]);
+        let (c, d) = ([q[0], y1, q[1]], [p[0], y1, p[1]]);
+        tris.push([a, b, c]);
+        tris.push([a, c, d]);
+    }
+    tris
+}
+
+/// Ear clipping for a simple CCW polygon.
+fn triangulate(poly: &[[f64; 2]]) -> Vec<[usize; 3]> {
+    let mut idx: Vec<usize> = (0..poly.len()).collect();
+    let mut out = Vec::new();
+    let cross = |o: [f64; 2], a: [f64; 2], b: [f64; 2]| {
+        (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+    };
+    let mut guard = 0;
+    while idx.len() > 3 && guard < 10_000 {
+        guard += 1;
+        let n = idx.len();
+        let mut clipped = false;
+        for i in 0..n {
+            let (ia, ib, ic) = (idx[(i + n - 1) % n], idx[i], idx[(i + 1) % n]);
+            let (a, b, c) = (poly[ia], poly[ib], poly[ic]);
+            if cross(a, b, c) <= 1e-12 {
+                continue; // reflex
+            }
+            let contains = idx.iter().any(|&k| {
+                if k == ia || k == ib || k == ic {
+                    return false;
+                }
+                let p = poly[k];
+                cross(a, b, p) >= 0.0 && cross(b, c, p) >= 0.0 && cross(c, a, p) >= 0.0
+            });
+            if contains {
+                continue;
+            }
+            out.push([ia, ib, ic]);
+            idx.remove(i);
+            clipped = true;
+            break;
+        }
+        if !clipped {
+            break;
+        }
+    }
+    if idx.len() == 3 {
+        out.push([idx[0], idx[1], idx[2]]);
+    }
+    out
+}
+
+/// Write a binary STL. Facet normals are recomputed from the winding, which is
+/// what any real exporter does.
+pub fn write_stl(path: &std::path::Path, tris: &[[[f64; 3]; 3]]) {
+    let mut out: Vec<u8> = Vec::new();
+    out.extend_from_slice(&[0u8; 80]);
+    out.extend_from_slice(&(tris.len() as u32).to_le_bytes());
+    for t in tris {
+        let u = [
+            t[1][0] - t[0][0],
+            t[1][1] - t[0][1],
+            t[1][2] - t[0][2],
+        ];
+        let v = [
+            t[2][0] - t[0][0],
+            t[2][1] - t[0][1],
+            t[2][2] - t[0][2],
+        ];
+        let mut n = [
+            u[1] * v[2] - u[2] * v[1],
+            u[2] * v[0] - u[0] * v[2],
+            u[0] * v[1] - u[1] * v[0],
+        ];
+        let len = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt();
+        if len > 0.0 {
+            n = [n[0] / len, n[1] / len, n[2] / len];
+        }
+        for c in n {
+            out.extend_from_slice(&(c as f32).to_le_bytes());
+        }
+        for vert in t {
+            for c in vert {
+                out.extend_from_slice(&(*c as f32).to_le_bytes());
+            }
+        }
+        out.extend_from_slice(&[0u8; 2]);
+    }
+    // Tests run in parallel and several share a fixture; write to a private
+    // temp file and rename, so no reader ever sees a half-written STL.
+    static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp = path.with_extension(format!("{}-{seq}.part", std::process::id()));
+    {
+        let mut f = std::fs::File::create(&tmp).expect("create fixture");
+        f.write_all(&out).expect("write fixture");
+    }
+    std::fs::rename(&tmp, path).expect("publish fixture");
+}
+
+/// Unique scratch path for a fixture, cleaned up by the OS temp dir.
+pub fn scratch(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join("vcad-printcheck-fixtures");
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    dir.join(format!("{name}.stl"))
+}
+
+pub fn build(name: &str, tris: Vec<[[f64; 3]; 3]>) -> std::path::PathBuf {
+    let p = scratch(name);
+    write_stl(&p, &tris);
+    p
+}
+
+// --- known-good --------------------------------------------------------
+
+/// A plain 10 mm cube sitting on the bed. Nothing to complain about.
+pub fn good_cube() -> std::path::PathBuf {
+    build("good_cube", cuboid([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]))
+}
+
+/// Two 2 mm pillars carrying a roof with a 3 mm clear span — inside the 4 mm
+/// bridge convention, so this must PASS while reporting the bridge.
+pub fn good_bridge() -> std::path::PathBuf {
+    build("good_bridge", portal(3.0))
+}
+
+/// A portal: two 2 mm legs 6 mm tall carrying a 2 mm roof, with a clear span
+/// of `gap` mm between them. One closed solid, no coincident faces.
+fn portal(gap: f64) -> Vec<[[f64; 3]; 3]> {
+    let w = 2.0 + gap + 2.0;
+    let profile = [
+        [0.0, 0.0],
+        [2.0, 0.0],
+        [2.0, 6.0],
+        [2.0 + gap, 6.0],
+        [2.0 + gap, 0.0],
+        [w, 0.0],
+        [w, 8.0],
+        [0.0, 8.0],
+    ];
+    prism(&profile, 0.0, 6.0)
+}
+
+// --- known-bad ---------------------------------------------------------
+
+/// Two stacked slabs with a 0.05 mm horizontal gap: the exact rana finding
+/// #10 defect — a crack a slicer reads as a floating layer, far too thin to
+/// be a deliberate channel.
+pub fn crack_005() -> std::path::PathBuf {
+    let mut t = cuboid([0.0, 0.0, 0.0], [10.0, 10.0, 5.0]);
+    t.extend(cuboid([0.0, 0.0, 5.05], [10.0, 10.0, 10.0]));
+    build("crack_005", t)
+}
+
+/// A 4 mm cube hanging 3 mm above a base plate, touching nothing.
+pub fn floating_island() -> std::path::PathBuf {
+    let mut t = cuboid([0.0, 0.0, 0.0], [20.0, 20.0, 2.0]);
+    t.extend(cuboid([8.0, 8.0, 5.0], [12.0, 12.0, 9.0]));
+    build("floating_island", t)
+}
+
+/// A 0.2 mm wall — half the 0.4 mm nozzle. Invisible to any vertical
+/// analysis; this is the comb wall that shipped once and only failed on the
+/// printer.
+pub fn thin_wall_02() -> std::path::PathBuf {
+    // T profile: a 10x1 base with a 0.2 mm fin standing 9 mm off it.
+    let profile = [
+        [0.0, 0.0],
+        [10.0, 0.0],
+        [10.0, 1.0],
+        [5.1, 1.0],
+        [5.1, 10.0],
+        [4.9, 10.0],
+        [4.9, 1.0],
+        [0.0, 1.0],
+    ];
+    build("thin_wall_02", prism(&profile, 0.0, 10.0))
+}
+
+/// Two pillars 12 mm apart carrying a roof: an unsupported span three times
+/// the 4 mm bridge convention.
+pub fn overlong_bridge() -> std::path::PathBuf {
+    build("overlong_bridge", portal(12.0))
+}
+
+/// A cube with one facet deleted — watertight nowhere near the hole.
+pub fn holed_cube() -> std::path::PathBuf {
+    let mut t = cuboid([0.0, 0.0, 0.0], [10.0, 10.0, 10.0]);
+    t.remove(3);
+    build("holed_cube", t)
+}

--- a/crates/vcad-printcheck/tests/known_bad.rs
+++ b/crates/vcad-printcheck/tests/known_bad.rs
@@ -1,0 +1,181 @@
+//! The acceptance protocol: the checker must FAIL each known-defective mesh
+//! with the RIGHT diagnosis, and pass the known-good ones. A checker that
+//! cannot demonstrate failure proves nothing.
+
+mod fixtures;
+
+use vcad_printcheck::{check_file, FindingKind, Options};
+
+fn opts() -> Options {
+    Options {
+        pitch: 0.25,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn good_cube_passes() {
+    let r = check_file(&fixtures::good_cube(), &opts()).unwrap();
+    assert!(r.ok, "plain cube should be clean:\n{:#?}", r.findings);
+    assert_eq!(r.manifold.bad_edges, 0);
+    assert_eq!(r.columns.cracks, 0);
+    assert_eq!(r.columns.floating_regions, 0);
+}
+
+#[test]
+fn good_bridge_passes_and_is_reported_as_a_bridge() {
+    let r = check_file(&fixtures::good_bridge(), &opts()).unwrap();
+    assert!(r.ok, "3 mm span is inside convention:\n{:#?}", r.findings);
+    let b = r
+        .columns
+        .bridges
+        .iter()
+        .find(|b| b.z > 5.0 && b.z < 7.0)
+        .expect("the roof should be reported as a bridge span");
+    assert!(
+        b.span_mm > 2.0 && b.span_mm <= 4.0,
+        "span {} mm should measure the ~3 mm clear gap",
+        b.span_mm
+    );
+    assert!(b.anchored);
+}
+
+#[test]
+fn crack_of_005mm_fails_as_a_crack() {
+    let r = check_file(&fixtures::crack_005(), &opts()).unwrap();
+    assert!(!r.ok, "a 0.05 mm interior gap must be dirty");
+    assert!(
+        r.has(FindingKind::Crack),
+        "expected a Crack diagnosis, got {:#?}",
+        r.findings
+    );
+    let gap = r.columns.thinnest_gap_mm.unwrap();
+    assert!(
+        (gap - 0.05).abs() < 0.01,
+        "should measure the 0.05 mm gap, measured {gap}"
+    );
+}
+
+#[test]
+fn crack_is_never_whitelistable() {
+    let o = Options {
+        allow_bridges: vec![(0.0, 100.0)],
+        ..opts()
+    };
+    let r = check_file(&fixtures::crack_005(), &o).unwrap();
+    assert!(
+        !r.ok && r.has(FindingKind::Crack),
+        "a bridge whitelist must not silence a crack"
+    );
+}
+
+#[test]
+fn floating_island_fails_as_a_floating_region() {
+    let r = check_file(&fixtures::floating_island(), &opts()).unwrap();
+    assert!(!r.ok, "a cube hanging in mid-air must be dirty");
+    assert!(
+        r.has(FindingKind::FloatingRegion),
+        "expected a FloatingRegion diagnosis, got {:#?}",
+        r.findings
+    );
+    let f = r
+        .failures()
+        .find(|f| f.kind == FindingKind::FloatingRegion)
+        .unwrap();
+    let z = f.location.unwrap()[2];
+    assert!(
+        (z - 5.0).abs() < 0.5,
+        "should locate the island at its underside z=5, reported {z}"
+    );
+}
+
+#[test]
+fn thin_wall_of_02mm_fails_against_a_04_nozzle() {
+    let r = check_file(&fixtures::thin_wall_02(), &opts()).unwrap();
+    assert!(!r.ok, "a 0.2 mm wall at a 0.4 nozzle must be dirty");
+    assert!(
+        r.has(FindingKind::ThinWall),
+        "expected a ThinWall diagnosis, got {:#?}",
+        r.findings
+    );
+    let t = r.walls.min_feature_mm.unwrap();
+    assert!(
+        (t - 0.2).abs() < 0.05,
+        "should measure the 0.2 mm wall, measured {t}"
+    );
+}
+
+#[test]
+fn thin_wall_passes_with_a_02_nozzle() {
+    // The same mesh is printable on a finer nozzle — proof the check reads the
+    // nozzle rather than a hard-coded floor.
+    let o = Options {
+        nozzle: 0.15,
+        ..opts()
+    };
+    let r = check_file(&fixtures::thin_wall_02(), &o).unwrap();
+    assert!(
+        !r.has(FindingKind::ThinWall),
+        "0.2 mm clears a 0.15 mm nozzle:\n{:#?}",
+        r.findings
+    );
+}
+
+#[test]
+fn overlong_bridge_fails_with_its_span() {
+    let r = check_file(&fixtures::overlong_bridge(), &opts()).unwrap();
+    assert!(!r.ok, "a 12 mm span at a 4 mm limit must be dirty");
+    assert!(
+        r.has(FindingKind::OverlongBridge),
+        "expected an OverlongBridge diagnosis, got {:#?}",
+        r.findings
+    );
+    let f = r
+        .failures()
+        .find(|f| f.kind == FindingKind::OverlongBridge)
+        .unwrap();
+    let span = f.value_mm.unwrap();
+    assert!(
+        span > 10.0,
+        "should report the ~12 mm span, reported {span}"
+    );
+}
+
+#[test]
+fn overlong_bridge_can_be_whitelisted_by_height() {
+    let o = Options {
+        allow_bridges: vec![(5.5, 6.5)],
+        ..opts()
+    };
+    let r = check_file(&fixtures::overlong_bridge(), &o).unwrap();
+    assert!(
+        !r.has(FindingKind::OverlongBridge),
+        "a documented bridge zone should clear the span verdict:\n{:#?}",
+        r.findings
+    );
+}
+
+#[test]
+fn holed_cube_fails_manifold_and_sections() {
+    let r = check_file(&fixtures::holed_cube(), &opts()).unwrap();
+    assert!(!r.ok);
+    assert!(r.manifold.bad_edges > 0);
+    assert!(r.has(FindingKind::NonManifold));
+}
+
+#[test]
+fn orientation_changes_the_verdict() {
+    // The 0.2 mm wall stands along Z. Lay the part on its side and the wall is
+    // still 0.2 mm — the check must find it from any orientation, which is the
+    // whole reason it casts along all three axes.
+    let o = Options {
+        orientation: vcad_printcheck::Orientation::XUp,
+        ..opts()
+    };
+    let r = check_file(&fixtures::thin_wall_02(), &o).unwrap();
+    assert!(
+        r.has(FindingKind::ThinWall),
+        "the wall must be found with the part rotated:\n{:#?}",
+        r.findings
+    );
+}

--- a/crates/vcad-printcheck/tests/real_world.rs
+++ b/crates/vcad-printcheck/tests/real_world.rs
@@ -1,0 +1,96 @@
+//! Real-world acceptance: the shipped rana `60c` shell must come back clean.
+//!
+//! The synthetic fixtures prove the checker can fail. This proves it does not
+//! cry wolf on a part that was actually printed — a 25k-triangle shell with
+//! through-wall J-slots, a chamfered rim, and roofs the author documented as
+//! deliberate bridges.
+//!
+//! The STL lives in the sibling `rana` repo rather than in this one (1.2 MB of
+//! binary, and it is that project's artifact, not vcad's), so the test locates
+//! it and skips when it is not there. Point `VCAD_PRINTCHECK_SHELL` at a copy
+//! to run it elsewhere.
+
+use std::path::PathBuf;
+
+use vcad_printcheck::{check_file, FindingKind, Options};
+
+fn shell() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("VCAD_PRINTCHECK_SHELL") {
+        let p = PathBuf::from(p);
+        return p.exists().then_some(p);
+    }
+    let home = std::env::var("HOME").ok()?;
+    let p = PathBuf::from(home).join("Developer/rana/exports/parts-60c/rana-60c-shell.stl");
+    p.exists().then_some(p)
+}
+
+/// The two whitelisted zones are the shell's documented bridges: the bottom
+/// slot roofs (z 1.75..2.65) and the top leg roof wedges (z 25.6..26.25),
+/// exactly the ranges `rana tools/support-check.py` allows.
+fn opts() -> Options {
+    Options {
+        allow_bridges: vec![(1.75, 2.65), (25.6, 26.25)],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn rana_60c_shell_is_clean() {
+    let Some(p) = shell() else {
+        eprintln!("skipping: rana-60c-shell.stl not found (set VCAD_PRINTCHECK_SHELL)");
+        return;
+    };
+    let r = check_file(&p, &opts()).unwrap();
+
+    assert_eq!(r.manifold.bad_edges, 0, "the shipped shell is manifold");
+    assert!(r.sections.empty_layers.is_empty(), "no empty layers");
+    assert!(r.sections.open_sections.is_empty(), "every section closes");
+    assert_eq!(r.columns.cracks, 0, "no interior cracks");
+    assert_eq!(r.columns.floating_regions, 0, "nothing floats");
+    assert!(
+        r.walls.min_feature_mm.unwrap() >= 0.4,
+        "min feature {:?} should clear a 0.4 nozzle",
+        r.walls.min_feature_mm
+    );
+    assert!(
+        r.ok,
+        "the shipped shell must pass:\n{}",
+        vcad_printcheck::render_text(&r)
+    );
+}
+
+#[test]
+fn rana_60c_shell_slot_roofs_are_reported_as_bridges() {
+    let Some(p) = shell() else { return };
+    let r = check_file(&p, &opts()).unwrap();
+    let roofs: Vec<_> = r
+        .columns
+        .bridges
+        .iter()
+        .filter(|b| b.whitelisted)
+        .collect();
+    assert!(
+        !roofs.is_empty(),
+        "the documented slot roofs should show up as bridge spans"
+    );
+    assert!(
+        roofs
+            .iter()
+            .all(|b| (1.75..=2.65).contains(&b.z) || (25.6..=26.25).contains(&b.z)),
+        "only the documented heights should be waived: {roofs:#?}"
+    );
+}
+
+#[test]
+fn without_the_whitelist_the_slot_roofs_are_flagged() {
+    // The waiver has to be doing real work: with the zones removed, the same
+    // roofs must be reported as overlong spans. Otherwise the "pass" above
+    // would prove nothing about the bridge check.
+    let Some(p) = shell() else { return };
+    let r = check_file(&p, &Options::default()).unwrap();
+    assert!(
+        r.has(FindingKind::OverlongBridge),
+        "un-waived slot roofs should exceed the 4 mm bridge convention"
+    );
+    assert!(!r.ok);
+}


### PR DESCRIPTION
Closes #841

`vcad check <mesh.stl>` — printability lint that reads the **exported** mesh in a chosen orientation, not the model that produced it. New library crate `vcad-printcheck` plus the CLI subcommand.

```
vcad check part.stl
vcad check part.stl --orientation -z --nozzle 0.4 --max-bridge 4 --crack-threshold 0.15
vcad check shell.stl --allow-bridge 1.75:2.65 --allow-bridge 25.6:26.25
vcad check part.stl --json
```

Exit code `0` clean / `1` dirty, so it gates CI the way `tools/support-check.py` gates the rana shell.

## All six checks are in

| check | source semantics |
| --- | --- |
| floating regions / mid-air islands | per-column vertical raycast, `support-check.py` |
| interior cracks (< 0.15 mm gaps) | same, and never waivable |
| bridge spans with lengths | distance to nearest anchor, doubled |
| overhang census + staircase-vs-support verdict | area-weighted facet census |
| min wall / min feature vs nozzle | rays along all three axes |
| manifold + closed sections | `manifold-check.py`, `slice-check.py` |

## Test evidence

The issue's central ask: **ship known-bad fixtures.** The first version of rana's own support check had an inverted sign, saw no material anywhere, and passed vacuously for a whole revision — so every check here ships a mesh it must reject, and the tests assert the specific diagnosis, not just a non-zero exit.

`tests/known_bad.rs` — 11 tests, all green:

| fixture | asserted |
| --- | --- |
| 0.05 mm internal crack (two slabs) | FAIL `Crack`, gap measured at 0.05 mm |
| same, with a full-height bridge waiver | still FAIL — a crack is never waivable |
| 4 mm cube floating 3 mm over a plate | FAIL `FloatingRegion`, located at the island's underside |
| 0.2 mm wall, 0.4 nozzle | FAIL `ThinWall`, thickness measured at 0.2 mm |
| 0.2 mm wall, 0.15 nozzle | passes — the check reads the nozzle, not a hard-coded floor |
| 0.2 mm wall, part rotated to X-up | still FAIL — found from any orientation |
| 12 mm portal span, 4 mm limit | FAIL `OverlongBridge`, span reported > 10 mm |
| same, with `--allow-bridge 5.5:6.5` | passes — the waiver works |
| cube with a facet removed | FAIL `NonManifold` |
| plain 10 mm cube | PASS |
| 3 mm portal span | PASS, and the roof is reported as an anchored bridge |

`tests/real_world.rs` — the shipped rana `60c` shell, 25,602 triangles:

```
printability: rana-60c-shell.stl  [ZUp]
  mesh       25602 triangles, 38403 edges, manifold
  sections   69 sampled over z -0.60..27.00, 0 empty, 0 open
  columns    2709/32041 carry material; 0 crack(s), thinnest gap 1.388 mm
  floating   0 region(s) with nothing beneath or beside them
  bridges    12 span(s), longest first:
               6.40 mm at z=1.800 (20 columns)  [allowed]
               3.20 mm at z=2.000 (14 columns)  [allowed]
               2.40 mm at z=25.650 (6 columns)  [allowed]
               1.60 mm at z=11.300 (1 columns)
               ...
  min wall   0.405 mm vs 0.40 mm nozzle (0 interior samples below)

  warn  133.4 mm² of downward faces exceed 45° from vertical — support material required

PRINTABILITY PASS (warnings only)     # exit 0
```

...with `--allow-bridge 1.75:2.65 --allow-bridge 25.6:26.25`, the bottom slot roofs and top leg roof wedges — the same two zones `support-check.py` whitelists. A third test asserts that **removing** the waiver makes the shell fail on those spans, so the waiver cannot be hiding a dead check.

Sweeping the other `parts-60c` exports found the defects the findings log already records — the checker reproduces them from the shipped files alone:

- `rana-60c-halbach-jig.stl` — `min feature 0.050 mm along y (171 samples below the 0.40 nozzle)`, i.e. findings row 5, the jig comb below the printable floor
- `rana-60c-spider.stl` — 80 interior cracks of 0.050 mm

## Three decisions worth review attention

**Parity, not winding.** Material spans come from strict crossing parity — what a slicer's mesh analysis sees. Parity reads a z-overlap between two *separate* bodies as an interior void, which is a defect we want flagged (finding #11: rim chamfer rings overlapping the sector columns by 0.05 mm).

**Sampling pitch follows the nozzle**, not a fixed column count over the bounding box. My first cut used 64 columns per axis; on the 70 mm shell that is 1.1 mm between rays, which straddles the 2 mm tube wall — neighbours land in air, roofs read as unanchored, and spans got measured across the bore (34 mm "bridges"). Pitch now defaults to the nozzle width, capped at 512 columns per axis. The shell check runs in 0.6 s.

**Bridge span is distance-to-anchor, doubled**, not the region's bounding diagonal. A roof over a slot is unsupported across the slot but continuous along it; the diagonal reports the slot's length rather than the span the extruder crosses.

Three filters were needed to stop min-wall crying wolf, each documented at its site: the ray must hit within 60° of head-on (a grazing chord measures the silhouette); the two end faces must oppose each other (a chamfer feathering to an edge is not a wall); and the voids either side must exceed the crack threshold. That last one matters on real parts — the rana shell is meshed as 0.5° sector prisms whose seams parity reads as 0.06 mm gaps, which turns a solid 2 mm tube into a stack of 0.24 mm "walls" for any ray crossing them. Vertical rays never cross those seams, which is why the crack and floating checks are unaffected.

## Notes

- The real-world test locates the shell in the sibling `rana` checkout (or `VCAD_PRINTCHECK_SHELL`) and **skips** when absent, rather than committing 1.2 MB of another project's artifact. It passes locally; CI will skip it.
- Overhangs warn rather than fail by default (`--strict-overhangs` to gate on them) — the failing verdicts are floating regions, cracks, overlong bridges, thin walls, non-manifold edges and unclosed sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
