### PR TITLE
dfm: hobby mill triangles come from as_chunks, which is what clippy 1.98 asks for

### DIFF
--- a/crates/vcad-kernel-dfm/src/rules/hobby_mill.rs
+++ b/crates/vcad-kernel-dfm/src/rules/hobby_mill.rs
@@ -140,7 +140,9 @@ pub fn tris_from_indexed(vertices: &[f32], indices: &[u32]) -> Vec<[[f64; 3]; 3]
         ]
     };
     indices
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|t| [v(t[0]), v(t[1]), v(t[2])])
         .collect()
 }

--- a/packages/mcp/src/__tests__/tool-surface.fixture.json
+++ b/packages/mcp/src/__tests__/tool-surface.fixture.json
@@ -6525,6 +6525,13 @@
           ],
           "description": "Manufacturing process (mechanical part) or PCB fab profile (board) to evaluate against. Mechanical: cnc_3axis, fdm, sla, injection, sheet_metal, casting_sand, casting_investment. PCB fab profiles: pcb_jlcpcb, pcb_pcbway, pcb_generic_2layer, pcb_generic_4layer — these run when the document is a PCB and check the board against that fab's published process capability (min annular ring, drill, trace/space by copper weight, copper-to-edge, soldermask dam/sliver, silk-over-pad, acid traps, via-in-pad). Each pack is bundled at lib/dfm/<process>.toml."
         },
+        "ruleset": {
+          "type": "string",
+          "enum": [
+            "hobby-3axis-mill"
+          ],
+          "description": "Optional named ruleset layered on the process, selected by name. hobby-3axis-mill (process cnc_3axis): a bench mill with a 2 mm minimum end mill, 3/4/5/6 reamers, metric tap drills, plate stock and a 300x200x80 envelope — reports pass/fail per rule (R1 internal corner radius, R2 ±Z reachability, R3 hole diameters, R4 plate stock, R5 min wall, R6 envelope, R7 threads/gear teeth) with located examples and affordances. Bundled at lib/dfm/<ruleset>.toml; ignored when rule_pack_toml is given."
+        },
         "rule_pack_toml": {
           "type": "string",
           "description": "Optional TOML rule pack to override the bundled default. Same schema as lib/dfm/<process>.toml."


### PR DESCRIPTION
main's CI has been red since #865 in two ways, both fixed here:

- stable clippy (1.98) denies `chunks_exact` with a constant size (`clippy::chunks_exact_to_as_chunks`) in `hobby_mill.rs`; one call site.
- the MCP tool-surface snapshot was not regenerated for the new `ruleset` parameter; regenerated with `UPDATE_TOOL_SURFACE=1`, the only change is that parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)