### PR TITLE
deps: kosm-render from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -124,7 +124,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1327,7 +1327,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1572,7 +1572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2282,7 +2282,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -2600,7 +2600,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2838,7 +2838,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3024,8 +3024,9 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "kosm-render"
-version = "0.1.0"
-source = "git+https://github.com/ecto/kosm?branch=claude%2Fadaptive-sampling#c1e0cd25a3a09724fc7d4e7374ebc0797260cc59"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f34e90e3f7552416125f7652e504526e79269fb7b9c1abe4db1b68396ffae87"
 dependencies = [
  "bytemuck",
  "js-sys",
@@ -5111,7 +5112,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5206,7 +5207,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6440,7 +6441,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6939,7 +6940,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8952,7 +8953,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,14 +216,11 @@ thiserror = "2"
 # unreachable from a git checkout. Bump these when the sibling repo cuts a
 # release; sync-version.mjs does NOT touch them.
 # kosm-render is the renderer: rays, hierarchies, the path tracer and the wgpu
-# tier, generic over geometry. A tag now, not a branch: `claude/adaptive-sampling`
-# moved under every build and churned the lockfile on each kosm commit, and kosm
-# carried a `[patch]` back-edge onto a local path to keep one copy of the crate
-# in the graph. `kosm-render-v0.2.0` pins both ends -- the offline render, the
-# explicit camera basis and `MAX_TRAVERSAL_DEPTH` are all in it. The `version` is
-# what a published kosm-render will satisfy, so when it lands on crates.io only
-# this line changes.
-kosm-render = { git = "https://github.com/ecto/kosm", tag = "kosm-render-v0.2.0", version = "0.2.0" }
+# tier, generic over geometry. It comes from crates.io like any other
+# dependency; kosm itself keeps one copy in its graph with a `[patch.crates-io]`
+# onto its in-repo crate, and a consumer that wants a development kosm-render
+# does the same in an untracked .cargo/config.toml.
+kosm-render = "0.2"
 tang = { version = "0.2" }
 tang-la = { version = "0.1" }
 tang-expr = { version = "0.1" }


### PR DESCRIPTION
kosm-render 0.2.0 is on crates.io (same commit as tag `kosm-render-v0.2.0`), so vcad depends on it by version. This is what lets kosm and its consumers keep one `kosm-render` in the graph via `[patch.crates-io]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)