### PR TITLE
deps: tessellate's dev-dep on step is path-only

### DIFF
--- a/crates/vcad-kernel-tessellate/Cargo.toml
+++ b/crates/vcad-kernel-tessellate/Cargo.toml
@@ -21,4 +21,4 @@ vcad-kernel-geom = { workspace = true }
 vcad-kernel-primitives = { workspace = true }
 
 [dev-dependencies]
-vcad-kernel-step = { workspace = true }
+vcad-kernel-step = { path = "../vcad-kernel-step" }   # path-only: dev-dep cycle with step; cargo strips it on publish


### PR DESCRIPTION
`vcad-kernel-tessellate` and `vcad-kernel-step` test against each other. A versioned dev-dep in that cycle blocks `cargo publish -p vcad-kernel-tessellate` (step is not on the index yet); path-only dev-deps are stripped from the package, which is the documented way through a dev-dep cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)