### PR TITLE
deps: dev-deps that point later in the publish order are path-only

### DIFF
--- a/crates/vcad-kernel-booleans/Cargo.toml
+++ b/crates/vcad-kernel-booleans/Cargo.toml
@@ -24,7 +24,7 @@ rayon = "1.10"
 
 [dev-dependencies]
 slotmap = { workspace = true }
-vcad-kernel-sketch = { workspace = true }
+vcad-kernel-sketch = { path = "../vcad-kernel-sketch" }
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [[bench]]

--- a/crates/vcad-kernel-em/Cargo.toml
+++ b/crates/vcad-kernel-em/Cargo.toml
@@ -16,4 +16,4 @@ vcad-receipt = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
-vcad-kernel-particle = { workspace = true }
+vcad-kernel-particle = { path = "../vcad-kernel-particle" }

--- a/crates/vcad-kernel-particle/Cargo.toml
+++ b/crates/vcad-kernel-particle/Cargo.toml
@@ -19,4 +19,4 @@ serde_json = { workspace = true }
 vcad-kernel-em = { workspace = true }
 vcad-kernel-thermal = { workspace = true }
 vcad-kernel-neutronics = { workspace = true }
-vcad-kernel-tolerance = { workspace = true }
+vcad-kernel-tolerance = { path = "../vcad-kernel-tolerance" }

--- a/crates/vcad-kernel-raytrace/Cargo.toml
+++ b/crates/vcad-kernel-raytrace/Cargo.toml
@@ -47,8 +47,8 @@ default = []
 gpu = ["dep:wgpu", "kosm-render/gpu"]
 
 [dev-dependencies]
-vcad-kernel-fillet = { workspace = true }
+vcad-kernel-fillet = { path = "../vcad-kernel-fillet" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 pollster = { workspace = true }
-vcad-kernel-gpu = { workspace = true }
+vcad-kernel-gpu = { path = "../vcad-kernel-gpu" }


### PR DESCRIPTION
Five test-only edges (booleans→sketch, raytrace→fillet and gpu, em→particle, particle→tolerance) point at crates that publish after their dependents. Path-only dev-deps are stripped from the package; versioned ones make `cargo publish` fail with "no matching package". Same fix as #873, found by walking `cargo metadata` against `scripts/publish.sh`'s order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)