### PR TITLE
vcad-diff is 0.1.0 and unpublished; cli and wasm depend on it by path only

### DIFF
--- a/crates/vcad-cli/Cargo.toml
+++ b/crates/vcad-cli/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 # Core crates
 vcad-ir = { path = "../vcad-ir", version = "0.10.0" }
 vcad-loon = { workspace = true }
-vcad-diff = { path = "../vcad-diff", version = "0.10.0" }
+vcad-diff = { path = "../vcad-diff" }
 vcad-crdt = { path = "../vcad-crdt", version = "0.10.0" }
 vcad-kernel = { path = "../vcad-kernel", version = "0.10.0" }
 vcad-app = { path = "../vcad-app", version = "0.10.0" }

--- a/crates/vcad-kernel-wasm/Cargo.toml
+++ b/crates/vcad-kernel-wasm/Cargo.toml
@@ -21,7 +21,7 @@ vcad-kernel-tessellate = { workspace = true }
 vcad-kernel-export = { workspace = true }
 vcad-ir = { workspace = true }
 vcad-crdt = { workspace = true }
-vcad-diff = { path = "../vcad-diff", version = "0.10.0" }
+vcad-diff = { path = "../vcad-diff" }
 vcad-app = { workspace = true }
 vcad-chat = { path = "../vcad-chat", default-features = false }
 vcad-eval = { workspace = true }


### PR DESCRIPTION
#881 over-reached: vcad-diff is 0.1.0 and not published, so `version = "0.10.0"` on it broke workspace resolution for every crate published after vcad-ecad-sim. Back to a path-only dep in the two unpublished consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)