### PR TITLE
claude/ecad pcb dev dep

### DIFF
--- a/crates/vcad-ecad-pcb/Cargo.toml
+++ b/crates/vcad-ecad-pcb/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 vcad-ecad-sim = { path = "../vcad-ecad-sim", version = "0.10.0" }
 
 [dev-dependencies]
-vcad-ecad-export = { path = "../vcad-ecad-export", version = "0.10.0" }
+vcad-ecad-export = { path = "../vcad-ecad-export" }
 vcad-ecad-symbols = { workspace = true }
 env_logger = "0.11"
 


### PR DESCRIPTION
Last of the #881 fallout: ecad-pcb dev-depends on ecad-export (publish = false; it depends on pcb, so the edge is a cycle). Path-only again so cargo strips it at package time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)