### PR TITLE
dev-deps on unpublished crates are path-only, so cargo package strips them

### DIFF
--- a/crates/vcad-ecad-pcb/Cargo.toml
+++ b/crates/vcad-ecad-pcb/Cargo.toml
@@ -32,7 +32,7 @@ vcad-ecad-sim = { path = "../vcad-ecad-sim", version = "0.10.0" }
 
 [dev-dependencies]
 vcad-ecad-export = { path = "../vcad-ecad-export" }
-vcad-ecad-symbols = { workspace = true }
+vcad-ecad-symbols = { path = "../vcad-ecad-symbols" }
 env_logger = "0.11"
 
 [features]

--- a/crates/vcad-eval/Cargo.toml
+++ b/crates/vcad-eval/Cargo.toml
@@ -35,7 +35,7 @@ stl_io = "0.8"
 # Path-only, no version: vcad-loon is publish = false (unpublished loon-lang),
 # and a versioned dev-dep would make `cargo publish -p vcad-eval` look for it
 # on the index. Cargo strips path-only dev-deps from the uploaded manifest.
-vcad-loon = { path = "../vcad-loon", version = "0.10.0" }
+vcad-loon = { path = "../vcad-loon" }
 # Path-only, no version: vcad-kernel-step publishes after vcad-eval, so a
 # versioned dev-dep would make `cargo publish -p vcad-eval` look for a
 # version of it that does not exist yet. Cargo strips path-only dev-deps

--- a/crates/vcad-render/Cargo.toml
+++ b/crates/vcad-render/Cargo.toml
@@ -63,8 +63,8 @@ required-features = ["cli"]
 [dev-dependencies]
 # Also a (feature-gated) normal dep for the CLI's `.loon` input support; tests
 # need it unconditionally.
-vcad-loon = { workspace = true }
-vcad-ecad-symbols = { workspace = true }
+vcad-loon = { path = "../vcad-loon" }
+vcad-ecad-symbols = { path = "../vcad-ecad-symbols" }
 # Integration tests decode the PNGs the renderer emits. `image` is an
 # *optional* normal dependency (behind `raster`), which an integration test
 # cannot reach through the library, so it is named again here.


### PR DESCRIPTION
vcad-ecad-pcb and vcad-render dev-depend on vcad-ecad-symbols (publish = false). As `workspace = true` they carry a version and cargo publish tries to resolve them. Path-only dev-deps are dropped at package time, which is what we want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)